### PR TITLE
Changed installer to use PowerShell

### DIFF
--- a/Cli-CredentialHelper/Cli-CredentialHelper.csproj
+++ b/Cli-CredentialHelper/Cli-CredentialHelper.csproj
@@ -81,7 +81,7 @@ COPY /V /Y "$(SolutionDir)README.md" /A "%25src%25README.md" /A
 COPY /V /Y "$(SolutionDir)install.cmd" /A "%25src%25install.cmd" /A
 COPY /V /Y "$(SolutionDir)install.ps1" /A "%25src%25install.ps1" /A
 COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B
-COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B "%25dst /B%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B
+COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B
 COPY /V /Y "%25src%25Microsoft.Alm.Authentication.dll" /B "%25dst%25Microsoft.Alm.Authentication.dll" /B
 COPY /V /Y "%25src%25git-credential-manager.exe" /B "%25dst%25git-credential-manager.exe" /B
 COPY /V /Y "%25src%25install.cmd" /A "%25dst%25install.cmd" /A

--- a/install.cmd
+++ b/install.cmd
@@ -3,16 +3,19 @@
 @ECHO OFF
 
 :: global constants
-SET title="Microsoft Git Credential Manager for Windows"
 SET powershell=0
+
+IF "%~1" EQU "--help" (
+    GOTO :PRINT_HELP
+)
+IF "%~1" EQU "/?" (
+    GOTO :PRINT_HELP
+)
 
 :ADMIN_DETECT
 
     :: Installation requires elevated privileges to write to the `Program Files` directories
-    net session 2>&1 1>nul
-    IF %errorLevel% NEQ 0 (
-        GOTO :ADMIN_NOT_FOUND
-    )
+    (net session 2>&1 1>nul) || GOTO :ADMIN_NOT_FOUND
 
 
 :POWERSHELL_DETECT
@@ -27,45 +30,56 @@ SET powershell=0
         GOTO :POWERSHELL_NOT_FOUND
     )
 
-    (powershell -nologo -file install.ps1 "%title%" %*) || GOTO :FAILURE
+    (powershell -file install.ps1 %*) || GOTO :FAILURE
 
 
 :SUCCESS
-
-    ECHO(
-    ECHO Success! %title% was installed! ^^_^^
-    ECHO(
 
     EXIT /B 0
 
 
 :FAILURE
 
-    ECHO(
+    ECHO.
     ECHO Something went wrong and I was unable to complete the installation. U_U
-    PAUSE
 
-    EXIT /B 1
+    EXIT /B %errorlevel%
 
 
 :ADMIN_NOT_FOUND
 
     :: Script requires elevated privileges
-    ECHO(
+    ECHO.
     ECHO You need to run this script elevated for it to work. U_U
-    PAUSE
 
     EXIT /B 2
 
 
 :POWERSHELL_NOT_FOUND
 
-    ECHO(
+    ECHO.
     ECHO Failed to detect Microsoft PowerShell. Make sure it is installed. U_U
     ECHO Don't know where to get Microsoft Powershell? Try http://bit.ly/1KuWq86
-    ECHO(
-    PAUSE
 
     EXIT /B 3
+
+
+:PRINT_HELP
+
+    ECHO.
+    ECHO install [[--git-path ^<path-to-git^>] [--install-to ^<installation-path^>] [--skip-netfx]]
+    ECHO.
+    ECHO: --git-path    Specifies a location to look for git.exe when installing in
+    ECHO:               addition to any Git installation locations detected.
+    ECHO.
+    ECHO: --install-to  Specifies a path to install to. This is in addition to any Git
+    ECHO:               installation locations detected.
+    ECHO.
+    ECHO: --skip-netfx  Specifies that the installer should skip the detection of the
+    ECHO:               Microsoft .NET Framwork (aka netfx) and that the installer should
+    ECHO:               progress regardless.
+    ECHO.
+
+    EXIT /B 0
 
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,31 +1,48 @@
 ﻿<#
 .SYNOPSIS
-Installs the Git Credential Manager for Windows.
+Installs the Microsoft Git Credential Manager for Windows.
 
-.PARAMETER gitPath
+.DESCRIPTION
+Installs the Microsoft Git Credential Manager for Windows. Attempts to locate and update any-and-all Git for Windows installations on the local system by looking in common paths.
+
+Supports:
+
+ * Custom installation paths
+ * Custom Git for Windows installation paths
+ * Skipping Microsoft .NET Framework detection
+
+Requires:
+
+ * Git for Windows 1.9.5 or later.
+ * Windows Vista or later.
+ * Microsoft .NET Framework v4.5.1 or later.
+
+.PARAMETER PathToGit
 Specifies a location to look for git.exe when installing in addition to any Git installation locations detected.
 
-.PARAMETER installTo
+.PARAMETER InstallTo
 Specifies a path to install to. This is in addition to any Git installation locations detected.
 
-.PARAMETER noNetfx
-Specifies that the installer should NOT detect if the Microsoft .NET Framwork (aka NetFX) is installed or not and that the installer should progress regardless.
+.PARAMETER SkipNetfx
+Specifies that the installer should skip the detection of the Microsoft .NET Framwork (aka netfx) and that the installer should progress regardless.
 #>
 [CmdletBinding()]
 Param(
-    [string]$GitPath,
+    [alias("--git-path")]
+    [string]$PathToGit,
+    [alias("--install-to")]
     [string]$InstallTo,
-    [switch]$NoNetfx
+    [alias("--skip-netfx")]
+    [switch]$SkipNetfx
 )
 
-## Globals.
+## Globals
 
-$gitExtensionName = "Microsoft Git Credential Manager for Windows"
+$title = "Microsoft Git Credential Manager for Windows"
 $name="manager"
-$exeName = "git-credential-$name.exe"
 
 $installPath = Split-Path $MyInvocation.MyCommand.Path
-$minimumVersion = New-Object System.Version("4.5.1")
+$netxfxMin = New-Object System.Version("4.5.1")
 
 ## Helper functions
 
@@ -38,7 +55,7 @@ function NetFxInstalled($pathPart) {
 
     if (Test-Path $netfx4Path) {
         $detectedVersion = New-Object System.Version((Get-ItemProperty $netfx4Path | Select-Object -ExpandProperty Version))
-        return ($detectedVersion.CompareTo($minimumVersion) -ge 0)
+        return ($detectedVersion.CompareTo($netxfxMin) -ge 0)
     }
 
     return $False
@@ -55,90 +72,118 @@ function PerformSetup($paths) {
     if (Test-Path $destination) {
 
         $localGitPath = $paths.Value
-        Write-Verbose "Deploying from $installPath to $destination"
+        Write-Output ""
+        Write-Output "Deploying from $installPath to $destination"
+        Write-Output ""
 
         # Copy all dlls and exes.
         $err = @()
-        Copy-Item "$installPath\*.dll" $destination -Force -ErrorAction SilentlyContinue -ErrorVariable +err
-        Copy-Item "$installPath\*.exe" $destination -Force -ErrorAction SilentlyContinue -ErrorVariable +err
+        $files = @("Microsoft.Alm.Authentication.dll", 
+                   "Microsoft.IdentityModel.Clients.ActiveDirectory.dll",
+                   "Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll"
+                   "git-credential-manager.exe")
+        
+        foreach ($file in $files) {
+            Copy-Item "$installPath\$file" $destination -Force -ErrorAction SilentlyContinue -ErrorVariable +err
+            Write-Output " $file"
+        }
 
         # Check if any copies failed. If one did, abort the entire script.
-        if ($err.Length -gt 0) {
-            Write-Warning "Errors encountered when copying files."
+        if ($err.Count -gt 0) {
+            Write-Error ""
+            Write-Error "Errors encountered when copying files."
+
             foreach ($e in $err) {
-                Write-Warning $e
+                Write-Error $e
             }
-            throw "Couldn't copy files."
+
+            # Exit with error code 4 (file copy error)
+            exit 4
         }
 
         # Update this git's config.
         & "$localGitPath\git.exe" config --global credential.helper $name
         if ($LastExitCode -eq 0) {
-            Write-Host "Updated your ~/.gitconfig [git config --global]"
+            Write-Output ""
+            Write-Output "Updated your ~/.gitconfig [git config --global]"
         }
     }
 }
 
+## Welcome message
+
+Write-Output "Hello! I'll install the $title."
+
 ## Validate parameters
 
-if ($InstallTo.Length) {
+if (-not [String]::IsNullOrWhiteSpace($InstallTo)) {
     if (-not (Test-Path $InstallTo)) {
-        Write-Warning "Cannot install to custom path. Path does not exist: $InstallTo"
-        throw "Invalid Parameter"
+        Write-Warning ""
+        Write-Warning "Cannot install to custom path. Path does not exist: '$InstallTo'"
+        $InstallTo = ""
     } else {
+        Write-Verbose ""
         Write-Verbose "Installing to custom path: $InstallTo"
     }
 }
 
-if ($GitPath.Length) {
-    $gitExePath = "$GitPath\cmd"
+if (-not [String]::IsNullOrWhiteSpace($PathToGit)) {
+    $gitExePath = "$PathToGit\Cmd"
+
     if (-not (Test-Path "$gitExePath\git.exe")) {
-        Write-Warning "Git.exe not found in custom path $GitPath"
-        throw "Invalid Parameter"
+        Write-Warning ""
+        Write-Warning "Git.exe not found in custom path '$PathToGit'"        
+        $PathToGit = ""
     } else {
-        Write-Verbose "Git.exe found in custom path: $gitExePath"
+        Write-Verbose ""
+        Write-Verbose "Git.exe found in custom path: '$gitExePath'"
     }
 }
 
 ## Validate administrator access
 
 if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    Write-Warning "The script must be run as Administrator. Start Windows PowerShell by using the Run as Administrator options, and try running again."
-    throw "Need admin permissions"
+    Write-Error ""
+    Write-Error "The script must be run as Administrator. Start Windows PowerShell by using the Run as Administrator options, and try running again."
+
+    # Exit with error code 2 (insufficient privileges)
+    exit 2
 }
 
 ## Detect NetFx 4.5.1 or greater.
 
-if (-not $NoNetfx) {
+if (-not $SkipNetfx) {
     if (-not (NetFxInstalled "Client" -or NetFxInstalled "Full")) {
-        Write-Warning "Failed to detect the Microsoft .NET Framework. Make sure it is installed. U_U"
-        Write-Warning "Don't know where to get the Microsoft .NET Framework? Try http://bit.ly/1kE08Rz"
-        throw "Failed to find prerequisite."
+        Write-Error ""
+        Write-Error "Failed to detect the Microsoft .NET Framework. Make sure it is installed. U_U"
+        Write-Error "Don't know where to get the Microsoft .NET Framework? Try http://bit.ly/1kE08Rz"
 
+        # Exit with error code 6 (minimum NetFX support not found)
+        exit 4
     }
-}
-else {
-    Write-Verbose "NetFX detection skipped."
+} else {
+    Write-Verbose "Microsoft .NET Framework detection skipped."
 }
 
 # Installation
 
-if ($InstallTo.Length) {
-    Write-Verbose "Deploying to custom location: $InstallTo"
+if (-not [String]::IsNullOrWhiteSpace($InstallTo)) {
+    Write-Output "Deploying to custom location: $InstallTo"
     PerformSetup $InstallTo
 }
 
-$customGitDestination = "$GitPath\Git\Cmd"
 $pfNativeDestination = "$Env:ProgramFiles\Git\Cmd"
 $pfWowDestination = "${Env:ProgramFiles(x86)}\Git\Cmd"
 
 $candidatePaths = @{}
 
-if ($GitPath.Length) {
-    $candidatePaths = @{
-        "$GitPath\mingw64\libexec\git-core\" = $customGitDestination; # 64-bit Git for Windows 2.x
-        "$GitPath\mingw32\libexec\git-core\" = $customGitDestination; # 32-bit Git for Windows 2.x
-        "$GitPath\libexec\git-core\" = $customGitDestination;         # 32-bit Git for Windows 1.x
+if (-not [String]::IsNullOrWhiteSpace($PathToGit)) {
+    $customGitDestination = "$PathToGit\Git\Cmd"
+
+    $candidatePaths + @{
+        "$PathToGit\mingw64\libexec\git-core\" = $customGitDestination; # 64-bit Git for Windows 2.x
+        "$PathToGit\mingw32\libexec\git-core\" = $customGitDestination; # 32-bit Git for Windows 2.x
+        "$PathToGit\libexec\git-core\" = $customGitDestination;         # 32-bit Git for Windows 1.x
         }
 }
 
@@ -150,10 +195,16 @@ $candidatePaths = $candidatePaths + @{
     "${Env:ProgramFiles(X86)}\Git\libexec\git-core" = $pfWowDestination         # 32-bit Git for Windows 1.x on 64-bit Windows
 }
 
-Write-Verbose "Looking for Git installation(s)..."
+Write-Output ""
+Write-Output "Looking for Git installation(s)..."
 
 Foreach ($paths in $candidatePaths.GetEnumerator()) {
     PerformSetup $paths
 }
 
-Write-Host "Success! $gitExtensionName was installed! ^^_^^"
+Write-Output ""
+Write-Output "Success! $title was installed! ^_^"
+Write-Output ""
+
+# Exit with error code 0 (success)
+exit 0


### PR DESCRIPTION
@jrbriggs was good enough to donate some PowerShell code to make the installer more reliable and debuggable.
- Changed `install.cmd` to detect PowerShell and invoke the `install.ps1`.
- Added `install.ps1` to the repo.
- Updated `install.ps1` to meet prior criteria.
- Added `install.ps1` to project post-build copy-to deploy folder.
