### PR TITLE
Change the VsoAad DefaultAuthortyHost to AzureAuthorty value.

### DIFF
--- a/Microsoft.Alm.Authentication/AzureAuthority.cs
+++ b/Microsoft.Alm.Authentication/AzureAuthority.cs
@@ -72,6 +72,8 @@ namespace Microsoft.Alm.Authentication
 
             try
             {
+                Trace.WriteLine(String.Format("   authority host url = '{0}'.", AuthorityHostUrl));
+
                 AuthenticationContext authCtx = new AuthenticationContext(AuthorityHostUrl, _adalTokenCache);
                 AuthenticationResult authResult = authCtx.AcquireToken(resource, clientId, redirectUri, PromptBehavior.Always, UserIdentifier.AnyUser, queryParameters);
                 tokens = new TokenPair(authResult);
@@ -111,6 +113,8 @@ namespace Microsoft.Alm.Authentication
 
             try
             {
+                Trace.WriteLine(String.Format("   authority host url = '{0}'.", AuthorityHostUrl));
+
                 UserCredential userCredential = credentials == null ? new UserCredential() : new UserCredential(credentials.Username, credentials.Password);
                 AuthenticationContext authCtx = new AuthenticationContext(AuthorityHostUrl, _adalTokenCache);
                 AuthenticationResult authResult = await authCtx.AcquireTokenAsync(resource, clientId, userCredential);
@@ -157,7 +161,11 @@ namespace Microsoft.Alm.Authentication
                 if (refreshToken.TargetIdentity != Guid.Empty)
                 {
                     authorityHostUrl = GetAuthorityUrl(refreshToken.TargetIdentity);
+
+                    Trace.WriteLine("   authority host url set by refresh token.");
                 }
+
+                Trace.WriteLine(String.Format("   authority host url = '{0}'.", authorityHostUrl));
 
                 AuthenticationContext authCtx = new AuthenticationContext(authorityHostUrl, _adalTokenCache);
                 AuthenticationResult authResult = await authCtx.AcquireTokenByRefreshTokenAsync(refreshToken.Value, clientId, resource);

--- a/Microsoft.Alm.Authentication/VsoAadAuthentication.cs
+++ b/Microsoft.Alm.Authentication/VsoAadAuthentication.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Alm.Authentication
     public sealed class VsoAadAuthentication : BaseVsoAuthentication, IVsoAadAuthentication
     {
         /// <summary>
-        /// The default authority host for all Azure Directory authentication
-        /// </summary>
-        public const string DefaultAuthorityHost = " https://management.core.windows.net";
-
-        /// <summary>
         /// 
         /// </summary>
         /// <param name="tenantId">
@@ -39,7 +34,7 @@ namespace Microsoft.Alm.Authentication
         {
             if (tenantId == Guid.Empty)
             {
-                this.VsoAuthority = new VsoAzureAuthority(DefaultAuthorityHost);
+                this.VsoAuthority = new VsoAzureAuthority(AzureAuthority.DefaultAuthorityHostUrl);
             }
             else
             {


### PR DESCRIPTION
* The original `DefaultAuthorityHost` value was causing the AzureAD authentication libraries to choke in custom URL parsing.
* Seems the new scheme for AzureAD doesn't care if `https://management.core.windows.net` vs `https://login.microsoftonline.com/common` is used and the libraries prefer the latter.
* Added additional tracing for better debugging.