### PR TITLE
Update Readme.md with info about build-in wincred

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #Git Credential Manager for Windows
-The [Git Credential Manager for Windows (GCM)](https://github.com/Microsoft/Git-Credential-Manager-for-Windows) provides secure Git credential storage for Windows. It's the successor to the [Windows Credential Store for Git  (git-credential-winstore)](https://gitcredentialstore.codeplex.com/), which is no longer maintained.
+The [Git Credential Manager for Windows (GCM)](https://github.com/Microsoft/Git-Credential-Manager-for-Windows) provides secure Git credential storage for Windows. It's the successor to the [Windows Credential Store for Git  (git-credential-winstore)](https://gitcredentialstore.codeplex.com/), which is no longer maintained. Compared to Git's build-in credential storage for Windows ([wincred](https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage)), which provides single-factor authentication support working on any HTTP enabled Git repository, it provides multi-factor authentication support for Visual Studio Online and GitHub.
 
 This project includes:
 


### PR DESCRIPTION
The readme should document the build-in credentials helper for Windows,
(wincred) to avoid users confusion about which approach should they use.

I tried to put that information in as short message as possible, hoping it will be the most readable way.