### PR TITLE
Check for .NET 4.5.1 in a scalable manner

### DIFF
--- a/Cli-CredentialHelper/Cli-CredentialHelper.csproj
+++ b/Cli-CredentialHelper/Cli-CredentialHelper.csproj
@@ -88,7 +88,7 @@ IF NOT EXIST  "%25dst%25" mkdir  "%25dst%25"
 
 COPY /V /Y "$(SolutionDir)LICENSE.TXT" /A "%25src%25LICENSE.TXT" /A
 COPY /V /Y "$(SolutionDir)README.md" /A "%25src%25README.md" /A
-COPY /V /Y "$(SolutionDir)install.cmd" /A "%25src%25install.cmd" /A
+COPY /V /Y "$(MSBuildProjectDirectory)\install.cmd" /A "%25src%25install.cmd" /A
 COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B
 COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B
 COPY /V /Y "%25src%25Microsoft.Alm.Authentication.dll" /B "%25dst%25Microsoft.Alm.Authentication.dll" /B

--- a/Cli-CredentialHelper/install.cmd
+++ b/Cli-CredentialHelper/install.cmd
@@ -1,6 +1,7 @@
 :: Wanto to update this thing and don't know how?
 :: Check http://ss64.com/nt/syntax.html
 @ECHO OFF
+SETLOCAL ENABLEEXTENSIONS
 
 :: globals
 SET netfx=0
@@ -17,23 +18,11 @@ IF "%~1" EQU "/?" (
 
     :: Detect if NETFX 4.5.1 or greater is installed
     :: https://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx
-    :: 0x5C733 - .NET Framework 4.5.1 installed with Windows 8.1 or Windows Server 2012 R2
-    :: 0x5C786 - .NET Framework 4.5.1 installed on Windows 8, Windows 7 SP1, or Windows Vista SP2
-    :: 0x5CBF5 - .NET Framework 4.5.2
-    :: 0x6004F - .NET Framework 4.6 installed with Windows 10
-    :: 0x60051 - .NET Framework 4.6 installed on all other OS version other than Windows 10
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client"| findstr "Release"| findstr /I "0x5C733" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client"| findstr "Release"| findstr /I "0x5C786" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client"| findstr "Release"| findstr /I "0x5CBF5" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client"| findstr "Release"| findstr /I "0x6004F" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client"| findstr "Release"| findstr /I "0x60051" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"| findstr "Release"| findstr /I "0x5C733" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"| findstr "Release"| findstr /I "0x5C786" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"| findstr "Release"| findstr /I "0x5CBF5" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"| findstr "Release"| findstr /I "0x6004F" 1>nul 2>&1) && SET netfx=1
-    (REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"| findstr "Release"| findstr /I "0x60051" 1>nul 2>&1) && SET netfx=1
+    FOR /F "usebackq tokens=1,3" %%i in (`REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client" /v Release`) DO IF "%%i" EQU "Release" SET /a netfx=%%j
+    FOR /F "usebackq tokens=1,3" %%i in (`REG QUERY "HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" /v Release`) DO IF "%%i" EQU "Release" SET /a netfx=%%j
 
-    IF %netfx% NEQ 1 (
+    :: 0x5C733 - .NET Framework 4.5.1 installed with Windows 8.1 or Windows Server 2012 R2
+    IF %netfx% LSS 378675 (
         GOTO :NETFX_NOT_FOUND
     )
     


### PR DESCRIPTION
Fixes issue #59 by using batch support for numeric comparisons.