### PR TITLE
Adds unique date-time value to PAT

### DIFF
--- a/Microsoft.Alm.Authentication/GithubAuthority.cs
+++ b/Microsoft.Alm.Authentication/GithubAuthority.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Alm.Authentication
                 }
 
                 const string HttpJsonContentType = "application/x-www-form-urlencoded";
-                const string JsonContentFormat = @"{{ ""scopes"": {0}, ""note"": ""git: {1} on {2}"" }}";
+                const string JsonContentFormat = @"{{ ""scopes"": {0}, ""note"": ""git: {1} on {2} at {3:dd-MMM-yyyy HH:mm}"" }}";
 
                 StringBuilder scopesBuilder = new StringBuilder();
                 scopesBuilder.Append('[');
@@ -90,7 +90,7 @@ namespace Microsoft.Alm.Authentication
 
                 scopesBuilder.Append(']');
 
-                string jsonContent = String.Format(JsonContentFormat, scopesBuilder, targetUri, Environment.MachineName);
+                string jsonContent = String.Format(JsonContentFormat, scopesBuilder, targetUri, Environment.MachineName, DateTime.Now);
 
                 using (StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType))
                 using (HttpResponseMessage response = await httpClient.PostAsync(_authorityUrl, content))


### PR DESCRIPTION
* GitHub personal access token generation failed if a user attempted to make a second token on the same machine, even if an existing token was lost of expired, due to text collision in the `note` field of the token request.
*  Adds a date-time component down to the seconds, to help uniquify the value of the `note` field and avoid collisions, and thus failures, at personal access generation time (part of the 2FA process).