### PR TITLE
Fix `install --help`

### DIFF
--- a/Cli-CredentialHelper/install.cmd
+++ b/Cli-CredentialHelper/install.cmd
@@ -53,7 +53,7 @@ IF "%~1" EQU "/?" (
 
 :PRINT_HELP
 
-    "~dp0\%git-credential-manager ?"
+    "%~dp0\git-credential-manager" ?
 
     EXIT /B 0
 


### PR DESCRIPTION
`install --help` would result in:

    '"~dp0\git-credential-manager ?"' is not recognized as an internal or external command ...