### PR TITLE
Fix Modal UI Config Read Error

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -667,7 +667,7 @@ namespace Microsoft.Alm.CredentialHelper
             {
                 Trace.WriteLine("   " + ConfigUseModalUi + " = " + entry.Value);
 
-                bool usemodel = operationArguments.WriteLog;
+                bool usemodel = operationArguments.UseModalUi;
                 if (Boolean.TryParse(entry.Value, out usemodel))
                 {
                     operationArguments.UseModalUi = usemodel;


### PR DESCRIPTION
Error cause by copy/paste mistake. Trivial fix.