### PR TITLE
ModalPrompt for Github authentication

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -582,9 +582,9 @@ namespace Microsoft.Alm.CredentialHelper
                     // return a GitHub authenitcation object
                     return authority ?? new GithubAuthentication(GithubCredentialScope,
                                                                  secrets,
-                                                                 GithubCredentialPrompt,
-                                                                 GithubAuthCodePrompt,
-                                                                 null);
+                                                                 operationArguments.UseModalUi ? (GithubAuthentication.AcquireCredentialsDelegate)GithubCredentialModalPrompt : GithubCredentialPrompt,
+                                                                  operationArguments.UseModalUi ? (GithubAuthentication.AcquireAuthenticationCodeDelegate)GithubAuthCodeModalPrompt : GithubAuthCodePrompt,
+                                                                 null );
 
                 case AuthorityType.MicrosoftAccount:
                     Trace.WriteLine("   authority is Microsoft Live");

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -104,10 +104,7 @@ namespace Microsoft.Alm.CredentialHelper
             }
         }
         private static Version _version;
-
-        // Storing OperationArguments here for the sake of Github ModalPrompts
-        private static OperationArguments operationArguments;
-
+        
         static void Main(string[] args)
         {
             try
@@ -271,7 +268,7 @@ namespace Microsoft.Alm.CredentialHelper
             // parse the operations arguments from stdin (this is how git sends commands)
             // see: https://www.kernel.org/pub/software/scm/git/docs/technical/api-credentials.html
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
-            operationArguments = new OperationArguments(Console.In);
+            OperationArguments operationArguments = new OperationArguments(Console.In);
 
             Debug.Assert(operationArguments != null, "The operationArguments is null");
             Debug.Assert(operationArguments.TargetUri != null, "The operationArgument.TargetUri is null");
@@ -314,7 +311,7 @@ namespace Microsoft.Alm.CredentialHelper
             // parse the operations arguments from stdin (this is how git sends commands)
             // see: https://www.kernel.org/pub/software/scm/git/docs/technical/api-credentials.html
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
-            operationArguments = new OperationArguments(Console.In);
+            OperationArguments operationArguments = new OperationArguments(Console.In);
 
             Debug.Assert(operationArguments != null, "The operationArguments is null");
             Debug.Assert(operationArguments.TargetUri != null, "The operationArgument.TargetUri is null");
@@ -466,7 +463,7 @@ namespace Microsoft.Alm.CredentialHelper
             // parse the operations arguments from stdin (this is how git sends commands)
             // see: https://www.kernel.org/pub/software/scm/git/docs/technical/api-credentials.html
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
-            operationArguments = new OperationArguments(Console.In);
+            OperationArguments operationArguments = new OperationArguments(Console.In);
 
             Debug.Assert(operationArguments != null, "The operationArguments is null");
             Debug.Assert(operationArguments.Username != null, "The operaionArgument.Username is null");
@@ -539,8 +536,8 @@ namespace Microsoft.Alm.CredentialHelper
                         || GithubAuthentication.GetAuthentication(operationArguments.TargetUri,
                                                                   GithubCredentialScope,
                                                                   secrets,
-                                                                  GithubCredentialPrompt,
-                                                                  GithubAuthCodePrompt,
+                                                                  operationArguments.UseModalUi ? (GithubAuthentication.AcquireCredentialsDelegate)GithubCredentialModalPrompt : GithubCredentialPrompt,
+                                                                  operationArguments.UseModalUi ? (GithubAuthentication.AcquireAuthenticationCodeDelegate)GithubAuthCodeModalPrompt : GithubAuthCodePrompt,
                                                                   null,
                                                                   out authority))
                     {
@@ -892,10 +889,6 @@ namespace Microsoft.Alm.CredentialHelper
 
         private static bool GithubCredentialPrompt(Uri targetUri, out string username, out string password)
         {
-            if ( operationArguments.UseModalUi ) {
-                return GithubCredentialModalPrompt( targetUri, out username, out password );
-            }
-
             // ReadConsole 32768 fail, 32767 ok 
             // @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
             const int BufferReadSize = 16 * 1024;
@@ -1025,10 +1018,6 @@ namespace Microsoft.Alm.CredentialHelper
 
         private static bool GithubAuthCodePrompt(Uri targetUri, GithubAuthenticationResultType resultType, out string authenticationCode)
         {
-            if ( operationArguments.UseModalUi ) {
-                return GithubAuthCodeModalPrompt( targetUri, resultType, out authenticationCode );
-            }
-
             // ReadConsole 32768 fail, 32767 ok 
             // @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
             const int BufferReadSize = 16 * 1024;

--- a/Microsoft.Alm.Authentication/GitHubAuthentication.cs
+++ b/Microsoft.Alm.Authentication/GitHubAuthentication.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Alm.Authentication
                         || result == GithubAuthenticationResultType.TwoFactorSms)
                 {
                     string authenticationCode;
-                    if (AcquireAuthenticationCodeCallback(targetUri, result, out authenticationCode))
+                    if (AcquireAuthenticationCodeCallback(targetUri, result, username, out authenticationCode))
                     {
                         if (result = GithubAuthority.AcquireToken(targetUri, username, password, authenticationCode, this.TokenScope).Result)
                         {
@@ -304,7 +304,7 @@ namespace Microsoft.Alm.Authentication
         /// </param>
         /// <param name="authenticationCode">The authentication code provided by the user.</param>
         /// <returns>True if successful; otherwise false.</returns>
-        public delegate bool AcquireAuthenticationCodeDelegate(Uri targetUri, GithubAuthenticationResultType resultType, out string authenticationCode);
+        public delegate bool AcquireAuthenticationCodeDelegate(Uri targetUri, GithubAuthenticationResultType resultType, string username, out string authenticationCode);
 
         /// <summary>
         /// Delegate for reporting the success, or not, of an authentiction attempt.


### PR DESCRIPTION
Added PromptForCredentialsBase as a base call for modal prompts with a custom message.
The function PromptForCredentials now calls PromptForCredentialsBase with the default message.

GithubCredentialPrompt and GithubAuthCodePrompt check for the UseModalUi argument and call their own modal prompt handler.