### PR TITLE
General improvements

### DIFF
--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -61,8 +61,9 @@ namespace Microsoft.Alm.CredentialHelper
             {
                 if (_userBinPath == null)
                 {
-                    string userBinPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-                    userBinPath = Path.Combine(userBinPath, "bin");
+                    // looking to install into '%ProgramData%\Git'
+                    string userBinPath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+                    userBinPath = Path.Combine(userBinPath, "Git");
                     _userBinPath = userBinPath;
                 }
                 return _userBinPath;

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Alm.CredentialHelper
             if ((type & Configuration.Type.Global) == Configuration.Type.Global)
             {
                 // the 0 entry in the installations list is the "preferred" instance of Git
-                string gitCmdPath = installations[0].Cmd;
+                string gitCmdPath = installations[0].Git;
                 string globalCmd = action == GitConfigAction.Set
                     ? "config --global credential.helper manager"
                     : "config --global --unset credential.helper";
@@ -505,7 +505,7 @@ namespace Microsoft.Alm.CredentialHelper
 
                 foreach (var installation in installations)
                 {
-                    if (ExecuteGit(installation.Cmd, systemCmd, 0, 5))
+                    if (ExecuteGit(installation.Git, systemCmd, 0, 5))
                     {
                         Trace.WriteLine("   updating /etc/gitconfig succeeded.");
 

--- a/Microsoft.Alm.Git.Test/GitInstallationTests.cs
+++ b/Microsoft.Alm.Git.Test/GitInstallationTests.cs
@@ -53,9 +53,11 @@ namespace Microsoft.Alm.Git.Test
                 KnownGitDistribution kgd = (KnownGitDistribution)v;
 
                 var a = list.Where(x => x.Version == kgd);
-                Assert.IsTrue(a.All(x => x != a.First() || string.Equals(x.Git, a.First().Git, System.StringComparison.OrdinalIgnoreCase)));
-                Assert.IsTrue(a.All(x => x != a.First() || string.Equals(x.Config, a.First().Config, System.StringComparison.OrdinalIgnoreCase)));
-                Assert.IsTrue(a.All(x => x != a.First() || string.Equals(x.Libexec, a.First().Libexec, System.StringComparison.OrdinalIgnoreCase)));
+                Assert.IsTrue(a.All(x => x != a.First() || GitInstallation.PathComparer.Equals(x.Cmd, a.First().Cmd)));
+                Assert.IsTrue(a.All(x => x != a.First() || GitInstallation.PathComparer.Equals(x.Config, a.First().Config)));
+                Assert.IsTrue(a.All(x => x != a.First() || GitInstallation.PathComparer.Equals(x.Git, a.First().Git)));
+                Assert.IsTrue(a.All(x => x != a.First() || GitInstallation.PathComparer.Equals(x.Libexec, a.First().Libexec)));
+                Assert.IsTrue(a.All(x => x != a.First() || GitInstallation.PathComparer.Equals(x.Sh, a.First().Sh)));
             }
         }
     }

--- a/Microsoft.Alm.Git.Test/GitInstallationTests.cs
+++ b/Microsoft.Alm.Git.Test/GitInstallationTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Alm.Git.Test
                 KnownGitDistribution kgd = (KnownGitDistribution)v;
 
                 var a = list.Where(x => x.Version == kgd);
-                Assert.IsTrue(a.All(x => x != a.First() || string.Equals(x.Cmd, a.First().Cmd, System.StringComparison.OrdinalIgnoreCase)));
+                Assert.IsTrue(a.All(x => x != a.First() || string.Equals(x.Git, a.First().Git, System.StringComparison.OrdinalIgnoreCase)));
                 Assert.IsTrue(a.All(x => x != a.First() || string.Equals(x.Config, a.First().Config, System.StringComparison.OrdinalIgnoreCase)));
                 Assert.IsTrue(a.All(x => x != a.First() || string.Equals(x.Libexec, a.First().Libexec, System.StringComparison.OrdinalIgnoreCase)));
             }

--- a/Microsoft.Alm.Git.Test/Microsoft.Alm.Git.Test.csproj
+++ b/Microsoft.Alm.Git.Test/Microsoft.Alm.Git.Test.csproj
@@ -50,7 +50,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -58,6 +60,7 @@
     <Compile Include="ConfigurationTests.cs" />
     <Compile Include="GitInstallationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WhereTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="sample.gitconfig" />

--- a/Microsoft.Alm.Git.Test/WhereTests.cs
+++ b/Microsoft.Alm.Git.Test/WhereTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Alm.Git.Test
+{
+    [TestClass]
+    public class WhereTests
+    {
+        static StringComparer PathComparer = StringComparer.InvariantCultureIgnoreCase;
+
+        [TestMethod]
+        public void FindApp()
+        {
+            string[] apps = new[] { "cmd", "notepad", "calc", "powershell", "git" };
+            foreach (string app in apps)
+            {
+                string path1;
+                Assert.IsTrue(CmdWhere(app, out path1));
+                string path2;
+                Assert.IsTrue(Where.FindApp(app, out path2));
+
+                Assert.IsTrue(PathComparer.Equals(path1, path2));
+            }
+        }
+
+        [TestMethod]
+        public void FindGit()
+        {
+            string gitPath;
+            if (!Where.FindApp("git", out gitPath))
+                Assert.Inconclusive();
+
+            List<GitInstallation> installations;
+            Assert.IsTrue(Where.FindGitInstallations(out installations));
+            Assert.IsTrue(installations.Count > 0);
+            Assert.IsTrue(PathComparer.Equals(installations[0].Git, gitPath));
+
+            GitInstallation installation;
+            Assert.IsTrue(Where.FindGitInstallation(installations[0].Path, installations[0].Version, out installation));
+            Assert.IsTrue(installations[0] == installation);
+        }
+
+        private static bool CmdWhere(string app, out string path)
+        {
+            path = null;
+
+            var startInfo = new ProcessStartInfo
+            {
+                Arguments = "/c where " + app,
+                CreateNoWindow = true,
+                FileName = "cmd",
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            var process = Process.Start(startInfo);
+            if (process.WaitForExit(3000))
+            {
+                path = process.StandardOutput.ReadLine();
+                path = path.Trim();
+            }
+
+            return path != null;
+        }
+    }
+}

--- a/Microsoft.Alm.Git/Where.cs
+++ b/Microsoft.Alm.Git/Where.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Alm.Git
         /// <param name="path">Path to the first match file which the operating system considers 
         /// executable.</param>
         /// <returns><see langword="True"/> if succeeds; <see langword="false"/> otherwise.</returns>
-        static public bool App(string name, out string path)
+        static public bool FindApp(string name, out string path)
         {
             Trace.WriteLine("Where::App");
 
@@ -160,7 +160,7 @@ namespace Microsoft.Alm.Git
 
             List<GitInstallation> candidates = new List<GitInstallation>();
             // add candidate locations in order of preference
-            if (Where.App(GitAppName, out shellPathValue))
+            if (Where.FindApp(GitAppName, out shellPathValue))
             {
                 // `Where.App` returns the path to the executable, truncate to the installation root
                 if (shellPathValue.EndsWith(GitInstallation.AllVersionCmdPath, StringComparison.InvariantCultureIgnoreCase))
@@ -403,7 +403,7 @@ namespace Microsoft.Alm.Git
             Trace.WriteLine("Where::GitSystemConfig");
 
             // find Git on the local disk - the system config is stored relative to it
-            if (App("git", out path))
+            if (FindApp("git", out path))
             {
                 FileInfo gitInfo = new FileInfo(path);
                 DirectoryInfo dir = gitInfo.Directory;

--- a/Microsoft.Alm.Git/Where.cs
+++ b/Microsoft.Alm.Git/Where.cs
@@ -370,6 +370,28 @@ namespace Microsoft.Alm.Git
         }
 
         /// <summary>
+        /// Gets the path to the Git portable system configuration file.
+        /// </summary>
+        /// <param name="path">Path to the Git portable system configuration</param>
+        /// <returns><see langword="True"/> if succeeds; <se
+        public static bool GitPortableConfig(out string path)
+        {
+            const string PortableConfigFolder = "Git";
+            const string PortableConfigFileName = "config";
+
+            path = null;
+
+            var portableConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), PortableConfigFolder, PortableConfigFileName);
+
+            if (File.Exists(portableConfigPath))
+            {
+                path = portableConfigPath;
+            }
+
+            return path != null;
+        }
+
+        /// <summary>
         /// Gets the path to the Git system configuration file.
         /// </summary>
         /// <param name="path">Path to the Git system configuration.</param>


### PR DESCRIPTION
- Fixed `Installer.UserBinPath` value to be "%ProgramData%\Git" to better match G4W.
- Added support for Portable Git configuration path.
- Improved test coverage.