### PR TITLE
Fix `ArgumentOutOfRange` exception when checking for installations

### DIFF
--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -465,10 +465,13 @@ namespace Microsoft.Alm.CredentialHelper
 
             updated = Configuration.Type.None;
 
-            if (installations == null || !Where.FindGitInstallations(out installations))
+            if (installations == null)
             {
-                Trace.WriteLine("   No Git installations detected to update.");
-                return false;
+                if (!Where.FindGitInstallations(out installations))
+                {
+                    Trace.WriteLine("   No Git installations detected to update.");
+                    return false;
+                }
             }
 
             if ((type & Configuration.Type.Global) == Configuration.Type.Global)

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -465,13 +465,10 @@ namespace Microsoft.Alm.CredentialHelper
 
             updated = Configuration.Type.None;
 
-            if (installations == null)
+            if ((installations == null || installations.Count == 0) && !Where.FindGitInstallations(out installations))
             {
-                if (!Where.FindGitInstallations(out installations))
-                {
-                    Trace.WriteLine("   No Git installations detected to update.");
-                    return false;
-                }
+                Trace.WriteLine("   No Git installations detected to update.");
+                return false;
             }
 
             if ((type & Configuration.Type.Global) == Configuration.Type.Global)

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Alm.CredentialHelper
 
             updated = Configuration.Type.None;
 
-            if (installations == null && !Where.FindGitInstallations(out installations))
+            if (installations == null || !Where.FindGitInstallations(out installations))
             {
                 Trace.WriteLine("   No Git installations detected to update.");
                 return false;


### PR DESCRIPTION
Fix `ArgumentOutOfRangeException`, when no installations are detected.

Ref: https://github.com/Microsoft/Git-Credential-Manager-for-Windows/issues/121