### PR TITLE
Fix for incorrect paths for installation checks

### DIFF
--- a/Microsoft.Alm.Git/GitInstallation.cs
+++ b/Microsoft.Alm.Git/GitInstallation.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Alm.Git
             path = path.TrimEnd('\\');
 
             // Make sure the GitExeName isn't included as a part of the path.
-            if (path.ToLower().EndsWith(AllVersionGitPath))
+            if (path.EndsWith(AllVersionGitPath, StringComparison.InvariantCultureIgnoreCase))
             {
                 path = path.Substring(0, path.Length - AllVersionGitPath.Length);
             }
@@ -77,12 +77,12 @@ namespace Microsoft.Alm.Git
             // Versions of git installation could have 2 binaries. One in the `bin` directory
             // and the other in the `cmd` directory. Handle both scenarios.
 
-            if (path.ToLower().EndsWith(AllVersionBinGitPath))
+            if (path.EndsWith(AllVersionBinGitPath, StringComparison.InvariantCultureIgnoreCase))
             {
                 path = path.Substring(0, path.Length - AllVersionBinGitPath.Length);
             }
 
-            if (path.ToLower().EndsWith(GitExeName))
+            if (path.EndsWith(GitExeName, StringComparison.InvariantCultureIgnoreCase))
             {
                 path = path.Substring(0, path.Length - GitExeName.Length);
             }

--- a/Microsoft.Alm.Git/GitInstallation.cs
+++ b/Microsoft.Alm.Git/GitInstallation.cs
@@ -9,9 +9,11 @@ namespace Microsoft.Alm.Git
     {
         public static readonly StringComparer PathComparer = StringComparer.InvariantCultureIgnoreCase;
 
+        internal const string GitExeName = @"git.exe";
         internal const string AllVersionCmdPath = @"cmd";
-        internal const string AllVersionGitPath = @"cmd\git.exe";
+        internal const string AllVersionGitPath = @"cmd\" + GitExeName;
         internal const string AllVersionShPath = @"bin\sh.exe";
+        internal const string AllVersionBinGitPath = @"bin\" + GitExeName;
         internal const string Version1Config32Path = @"etc\gitconfig";
         internal const string Version2Config32Path = @"mingw32\etc\gitconfig";
         internal const string Version2Config64Path = @"mingw64\etc\gitconfig";
@@ -63,6 +65,27 @@ namespace Microsoft.Alm.Git
             Debug.Assert(CommonGitPaths.ContainsKey(version), "The `version` parameter not found in `CommonGitPaths`.");
             Debug.Assert(CommonLibexecPaths.ContainsKey(version), "The `version` parameter not found in `CommonLibExecPaths`.");
             Debug.Assert(CommonShPaths.ContainsKey(version), "The `version` parameter not found in `CommonShPaths`.");
+
+            path = path.TrimEnd('\\');
+
+            // Make sure the GitExeName isn't included as a part of the path.
+            if (path.ToLower().EndsWith(AllVersionGitPath))
+            {
+                path = path.Substring(0, path.Length - AllVersionGitPath.Length);
+            }
+            
+            // Versions of git installation could have 2 binaries. One in the `bin` directory
+            // and the other in the `cmd` directory. Handle both scenarios.
+
+            if (path.ToLower().EndsWith(AllVersionBinGitPath))
+            {
+                path = path.Substring(0, path.Length - AllVersionBinGitPath.Length);
+            }
+
+            if (path.ToLower().EndsWith(GitExeName))
+            {
+                path = path.Substring(0, path.Length - GitExeName.Length);
+            }
 
             // trim off trailing '\' characters to increase compatibility
             path = path.TrimEnd('\\');


### PR DESCRIPTION
Incorrect paths are added when the installations are added through the shellPaths. 
Effectively, the name "Git.exe" is also added along as the directory path. 

Also, to note is that recent versions of Git portable versions have 2 "git.exe" files, one in the `bin` directory, and the other in the `cmd` directory.