### PR TITLE
Added UriToPathedName method to Secret.

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -545,7 +545,12 @@ namespace Microsoft.Alm.CredentialHelper
 
             Trace.WriteLine("Program::CreateAuthentication");
 
-            var secrets = new SecretStore(SecretsNamespace);
+            Secret.UriNameConversion getTargetName = Secret.UriToSimpleName;
+            if (operationArguments.UseHttpPath)
+            {
+                getTargetName = Secret.UriToPathedName;
+            }
+            var secrets = new SecretStore(SecretsNamespace, null, null, getTargetName);
             BaseAuthentication authority = null;
 
             switch (operationArguments.Authority)

--- a/Microsoft.Alm.Authentication.Test/CredentialTests.cs
+++ b/Microsoft.Alm.Authentication.Test/CredentialTests.cs
@@ -9,19 +9,22 @@ namespace Microsoft.Alm.Authentication.Test
         [TestMethod]
         public void CredentialStoreUrl()
         {
-            ICredentialStoreTest(new SecretStore("test"), "http://dummy.url/for/testing", "username", "password");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToSimpleName), "http://dummy.url/for/testing", "username", "password");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToPathedName), "http://dummy.url/for/testing", "username", "password");
         }
 
         [TestMethod]
         public void CredentialStoreUrlWithParams()
         {
-            ICredentialStoreTest(new SecretStore("test"), "http://dummy.url/for/testing?with=params", "username", "password");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToSimpleName), "http://dummy.url/for/testing?with=params", "username", "password");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToPathedName), "http://dummy.url/for/testing?with=params", "username", "password");
         }
 
         [TestMethod]
         public void CredentialStoreUnc()
         {
-            ICredentialStoreTest(new SecretStore("test"), @"\\unc\share\test", "username", "password");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToSimpleName), @"\\unc\share\test", "username", "password");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToPathedName), @"\\unc\share\test", "username", "password");
         }
 
         [TestMethod]
@@ -29,7 +32,14 @@ namespace Microsoft.Alm.Authentication.Test
         {
             try
             {
-                ICredentialStoreTest(new SecretStore("test"), "http://dummy.url/for/testing", null, "null_usernames_are_illegal");
+                ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToSimpleName), "http://dummy.url/for/testing", null, "null_usernames_are_illegal");
+                Assert.Fail("Null username was accepted");
+            }
+            catch { }
+
+            try
+            {
+                ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToPathedName), "http://dummy.url/for/testing", null, "null_usernames_are_illegal");
                 Assert.Fail("Null username was accepted");
             }
             catch { }
@@ -38,55 +48,64 @@ namespace Microsoft.Alm.Authentication.Test
         [TestMethod]
         public void CredentialStoreUsernameBlank()
         {
-            ICredentialStoreTest(new SecretStore("test"), "http://dummy.url/for/testing", "", "blank_usernames_are_legal");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToSimpleName), "http://dummy.url/for/testing", "", "blank_usernames_are_legal");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToPathedName), "http://dummy.url/for/testing", "", "blank_usernames_are_legal");
         }
 
         [TestMethod]
         public void CredentialStorePasswordNull()
         {
-            ICredentialStoreTest(new SecretStore("test"), "http://dummy.url/for/testing", "null_passwords_are_illegal", null);
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToSimpleName), "http://dummy.url/for/testing", "null_passwords_are_illegal", null);
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToPathedName), "http://dummy.url/for/testing", "null_passwords_are_illegal", null);
         }
 
         [TestMethod]
         public void CredentialStorePassswordBlank()
         {
-            ICredentialStoreTest(new SecretStore("test"), "http://dummy.url/for/testing", "blank_passwords_are_legal", "");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToSimpleName), "http://dummy.url/for/testing", "blank_passwords_are_legal", "");
+            ICredentialStoreTest(new SecretStore("test", null, null, Secret.UriToPathedName), "http://dummy.url/for/testing", "blank_passwords_are_legal", "");
         }
 
         [TestMethod]
         public void SecretCacheUrl()
         {
             ICredentialStoreTest(new SecretCache("test-cache"), "http://dummy.url/for/testing", "username", "password");
+            ICredentialStoreTest(new SecretCache("test-cache"), "http://dummy.url/for/testing", "username", "password");
         }
 
         [TestMethod]
         public void SecretCacheUrlWithParams()
         {
-            ICredentialStoreTest(new SecretCache("test-cache"), "http://dummy.url/for/testing?with=params", "username", "password");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToSimpleName), "http://dummy.url/for/testing?with=params", "username", "password");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToPathedName), "http://dummy.url/for/testing?with=params", "username", "password");
         }
 
         [TestMethod]
         public void SecretCacheUnc()
         {
-            ICredentialStoreTest(new SecretCache("test-cache"), @"\\unc\share\test", "username", "password");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToSimpleName), @"\\unc\share\test", "username", "password");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToPathedName), @"\\unc\share\test", "username", "password");
         }
 
         [TestMethod]
         public void SecretCacheUsernameNull()
         {
-            ICredentialStoreTest(new SecretCache("test-cache"), "http://dummy.url/for/testing", null, "null_usernames_are_illegal");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToSimpleName), "http://dummy.url/for/testing", null, "null_usernames_are_illegal");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToPathedName), "http://dummy.url/for/testing", null, "null_usernames_are_illegal");
         }
 
         [TestMethod]
         public void SecretCacheUsernameBlankReject()
         {
-            ICredentialStoreTest(new SecretCache("test-cache"), "http://dummy.url/for/testing", "", "blank_usernames_are_illegal");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToSimpleName), "http://dummy.url/for/testing", "", "blank_usernames_are_illegal");
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToPathedName), "http://dummy.url/for/testing", "", "blank_usernames_are_illegal");
         }
         
         [TestMethod]
         public void SecretCachePasswordNull()
         {
-            ICredentialStoreTest(new SecretCache("test-cache"), "http://dummy.url/for/testing", "null_passwords_are_illegal", null);
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToSimpleName), "http://dummy.url/for/testing", "null_passwords_are_illegal", null);
+            ICredentialStoreTest(new SecretCache("test-cache", Secret.UriToPathedName), "http://dummy.url/for/testing", "null_passwords_are_illegal", null);
         }        
 
         private void ICredentialStoreTest(ICredentialStore credentialStore, string url, string username, string password)

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Alm.Authentication
 {
     public abstract class Secret
     {
-        public static string UriToName(TargetUri targetUri, string @namespace)
+        public static string UriToSimpleName(TargetUri targetUri, string @namespace)
         {
             const string TokenNameBaseFormat = "{0}:{1}://{2}";
             const string TokenNamePortFormat = TokenNameBaseFormat + ":{3}";
@@ -28,6 +28,36 @@ namespace Microsoft.Alm.Authentication
             else
             {
                 targetName = String.Format(TokenNamePortFormat, @namespace, actualUri.Scheme, trimmedHostUrl, actualUri.Port);
+            }
+
+            Trace.WriteLine("   target name = " + targetName);
+
+            return targetName;
+        }
+
+        public static string UriToPathedName(TargetUri targetUri, string @namespace)
+        {
+            const string TokenNamePathFormat = "{0}:{1}://{2}{3}";
+            const string TokenNamePortFormat = "{0}:{1}://{2}:{3}{4}";
+
+            Debug.Assert(targetUri != null, "The targetUri parameter is null");
+
+            Trace.WriteLine("Secret::UriToPathedName");
+
+            string targetName = null;
+            // trim any trailing slashes and/or whitespace for compat with git-credential-winstore
+            string trimmedHostUrl = targetUri.Host
+                                             .TrimEnd('/', '\\')
+                                             .TrimEnd();
+            Uri actualUri = targetUri.ActualUri;
+
+            if (actualUri.IsDefaultPort)
+            {
+                targetName = String.Format(TokenNamePathFormat, @namespace, actualUri.Scheme, trimmedHostUrl, actualUri.AbsolutePath);
+            }
+            else
+            {
+                targetName = String.Format(TokenNamePortFormat, @namespace, actualUri.Scheme, trimmedHostUrl, actualUri.Port, actualUri.AbsolutePath);
             }
 
             Trace.WriteLine("   target name = " + targetName);

--- a/Microsoft.Alm.Authentication/SecretCache.cs
+++ b/Microsoft.Alm.Authentication/SecretCache.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Alm.Authentication
             Debug.Assert(!String.IsNullOrWhiteSpace(@namespace), "The namespace parameter is null or invalid");
 
             _namespace = @namespace;
-            _getTargetName = getTargetName ?? Secret.UriToName;
+            _getTargetName = getTargetName ?? Secret.UriToSimpleName;
         }
 
         private readonly string _namespace;

--- a/Microsoft.Alm.Authentication/SecretStore.cs
+++ b/Microsoft.Alm.Authentication/SecretStore.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Alm.Authentication
             if (String.IsNullOrWhiteSpace(@namespace) || @namespace.IndexOfAny(IllegalCharacters) != -1)
                 throw new ArgumentNullException("prefix", "The `prefix` parameter is null or invalid.");
 
-            _getTargetName = getTargetName ?? Secret.UriToName;
+            _getTargetName = getTargetName ?? Secret.UriToSimpleName;
 
             _namespace = @namespace;
             _credentialCache = credentialCache ?? new SecretCache(@namespace, _getTargetName);


### PR DESCRIPTION
Enables default generation of secret keys with paths as part of the target name.

Include related tests.

Changes GCM `Program` behavior to "do the right thing(tm)"