### PR TITLE
Fix typo in log output

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -1275,7 +1275,7 @@ namespace Microsoft.Alm.CredentialHelper
                     return false;
                 }
 
-                Trace.WriteLine("   successfully acquired crentials from user.");
+                Trace.WriteLine("   successfully acquired credentials from user.");
 
                 username = usernameBuffer.ToString();
                 password = passwordBuffer.ToString();


### PR DESCRIPTION
This is about as trivial as they come, but I noticed a typo in the credential manager log output when looking into an unrelated issue.