### PR TITLE
Fixing double scheme in UX string

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -895,7 +895,7 @@ namespace Microsoft.Alm.CredentialHelper
                 resultType == GithubAuthenticationResultType.TwoFactorApp
                     ? "app"
                     : "sms";
-            string message = String.Format("Enter {0} authentication code for {1}://{2}.", type, targetUri.ActualUri.Scheme, targetUri);
+            string message = String.Format("Enter {0} authentication code for {1}.", type, targetUri);
 
             Trace.WriteLine("   prompting user for authentication code.");
 


### PR DESCRIPTION
Fixes a bad url string created by assuming the `targetUri` did not correctly print the scheme when generating the url string (I guess?).