### PR TITLE
Set credentials in 'get' operation response when using Modal UI

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -371,6 +371,7 @@ namespace Microsoft.Alm.CredentialHelper
                             // no need to save the credentials explicitly, as Git will call back
                             // with a store command if the credentials are valid.
                             credentials = new Credential(username, password);
+                            operationArguments.SetCredentials(credentials);
                         }
                     }
                     break;


### PR DESCRIPTION
When retrieving the credentials with modal UI, the result is not set in the operation result