### PR TITLE
Fix wrong argument being passed to `String.Format`.

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -874,7 +874,7 @@ namespace Microsoft.Alm.CredentialHelper
                     // write a small header to help with identifying new log entries
                     listener.WriteLine(Environment.NewLine);
                     listener.WriteLine(String.Format("Log Start ({0:u})", DateTimeOffset.Now));
-                    listener.WriteLine(String.Format("Microsoft {0} version {0}", Program.Title, Version.ToString(3)));
+                    listener.WriteLine(String.Format("Microsoft {0} version {1}", Program.Title, Version.ToString(3)));
                 }
             }
         }


### PR DESCRIPTION
Since the index is zero based, the second object is `1`.

Spotted with MSVC Analyze (CA2241).