### PR TITLE
Use TargetUri.ResolvedUri when reading/writing from store

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -437,6 +437,7 @@ namespace Microsoft.Alm.CredentialHelper
                         string password;
                         if (ModalPromptForCredentials(operationArguments.TargetUri, out username, out password))
                         {
+                            Trace.WriteLine("   credentials found");
                             // set the credentials object
                             // no need to save the credentials explicitly, as Git will call back
                             // with a store command if the credentials are valid.

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -19,15 +19,15 @@ namespace Microsoft.Alm.Authentication
             string trimmedHostUrl = targetUri.Host
                                              .TrimEnd('/', '\\')
                                              .TrimEnd();
-            Uri actualUri = targetUri.ActualUri;
+            Uri resolvedUri = targetUri.ResolvedUri;
 
-            if (actualUri.IsDefaultPort)
+            if (resolvedUri.IsDefaultPort)
             {
-                targetName = String.Format(TokenNameBaseFormat, @namespace, actualUri.Scheme, trimmedHostUrl);
+                targetName = String.Format(TokenNameBaseFormat, @namespace, resolvedUri.Scheme, trimmedHostUrl);
             }
             else
             {
-                targetName = String.Format(TokenNamePortFormat, @namespace, actualUri.Scheme, trimmedHostUrl, actualUri.Port);
+                targetName = String.Format(TokenNamePortFormat, @namespace, resolvedUri.Scheme, trimmedHostUrl, resolvedUri.Port);
             }
 
             Trace.WriteLine("   target name = " + targetName);


### PR DESCRIPTION
Use `TargetUri.ResolvedUri` when reading/writing from store instead of `TargetUri.ActualUri`.

Resolves #180