### PR TITLE
Add support for environment variable secret store

### DIFF
--- a/Cli-CredentialHelper/Cli-CredentialHelper.csproj
+++ b/Cli-CredentialHelper/Cli-CredentialHelper.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Interactivity.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="OperationArguments.cs" />
+    <Compile Include="Preservation.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Cli-CredentialHelper/OperationArguments.cs
+++ b/Cli-CredentialHelper/OperationArguments.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Alm.CredentialHelper
         public AuthorityType Authority { get; set; }
         public string CredPassword { get; private set; }
         public string CredUsername { get; private set; }
+        public string EnvironmentKey { get; set; }
         public Interactivity Interactivity { get; set; }
         public bool PreserveCredentials { get; set; }
         public string ProxyHost

--- a/Cli-CredentialHelper/Preservation.cs
+++ b/Cli-CredentialHelper/Preservation.cs
@@ -1,0 +1,21 @@
+﻿namespace Microsoft.Alm.CredentialHelper
+{
+    /// <summary>
+    /// Specialized handling of DELETE and STORE requests from Git
+    /// </summary>
+    internal enum Preservation
+    {
+        /// <summary>
+        /// Normal handling of DELETE and STORE requests from Git
+        /// </summary>
+        Normal,
+        /// <summary>
+        /// Ignore DELETE requests from Git
+        /// </summary>
+        NeverDelete,
+        /// <summary>
+        /// Ignore STORE requests from Git
+        /// </summary>
+        NeverStore,
+    }
+}

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Alm.CredentialHelper
         internal const string ConfigUseModalPromptKey = "modalPrompt";
         internal const string ConfigValidateKey = "validate";
         internal const string ConfigWritelogKey = "writelog";
-
+        internal const string ConfigEnvironmentKey = "envStoreKey";
+        internal const string ConfigPreserve = "preserve";
 
         private const string ConfigPrefix = "credential";
         private const string SecretsNamespace = "git";
@@ -256,19 +257,27 @@ namespace Microsoft.Alm.CredentialHelper
             Console.Out.WriteLine();
             Console.Out.WriteLine("      `git config --global credential.visualstudio.com." + ConfigPreserveCredentialsKey + " true`");
             Console.Out.WriteLine();
-            Console.Out.WriteLine("  " + ConfigUseHttpPathKey + "     Causes the path portion of the target URI to considered meaningful.");
+            Console.Out.WriteLine("  " + ConfigUseHttpPathKey + "  Causes the path portion of the target URI to considered meaningful.");
             Console.Out.WriteLine("               By default the path portion of the target URI is ignore, if this is set to true");
             Console.Out.WriteLine("               the path is considered meaningful and credentials will be store for each path.");
             Console.Out.WriteLine("               Defaults to FALSE.");
             Console.Out.WriteLine();
             Console.Out.WriteLine("      `git config --global credential.bitbucket.com." + ConfigUseHttpPathKey + " true`");
             Console.Out.WriteLine();
-            Console.Out.WriteLine("  " + ConfigHttpProxyKey + "     Causes the proxy value to be considered when evaluating.");
+            Console.Out.WriteLine("  " + ConfigHttpProxyKey + "    Causes the proxy value to be considered when evaluating.");
             Console.Out.WriteLine("               credential target information. A proxy setting should established if use of a");
             Console.Out.WriteLine("               proxy is required to interact with Git remotes.");
             Console.Out.WriteLine("               The value should the url of the proxy server.");
             Console.Out.WriteLine();
             Console.Out.WriteLine("      `git config --global credential.github.com." + ConfigUseHttpPathKey + " https://myproxy:8080`");
+            Console.Out.WriteLine();
+            Console.Out.WriteLine("  " + ConfigEnvironmentKey + "  Specifies using the system's environmental variables as storage mechanism for ");
+            Console.Out.WriteLine("               secrets. All secret read and write operations will be done against the supplied ");
+            Console.Out.WriteLine("               process scoped environment variable key, regardless of remote URL. This is to support");
+            Console.Out.WriteLine("               transient values and should not be used for long-term or secure storage of secrets.");
+            Console.Out.WriteLine("               The value should the envionment variable name to be used.");
+            Console.Out.WriteLine();
+            Console.Out.WriteLine("      `git config --local credential." + ConfigEnvironmentKey + " LocalSecret`");
             Console.Out.WriteLine();
             Console.Out.WriteLine("  " + ConfigWritelogKey + "     Enables trace logging of all activities. Logs are written to");
             Console.Out.WriteLine("               the local .git/ folder at the root of the repository.");
@@ -621,8 +630,11 @@ namespace Microsoft.Alm.CredentialHelper
             {
                 getTargetName = Secret.UriToPathedName;
             }
-            var secrets = new SecretStore(SecretsNamespace, null, null, getTargetName);
             BaseAuthentication authority = null;
+            // is useEnvionment is set to a value, read/write credential to the environment instead
+            var secrets = (String.IsNullOrEmpty(operationArguments.EnvironmentKey))
+                ? new SecretStore(SecretsNamespace, null, null, getTargetName) as ICredentialStore
+                : new EnvironmentStore(operationArguments.EnvironmentKey) as ICredentialStore;
 
             switch (operationArguments.Authority)
             {
@@ -878,6 +890,17 @@ namespace Microsoft.Alm.CredentialHelper
                 Trace.WriteLine("   " + ConfigHttpProxyKey + " = " + entry.Value);
 
                 operationArguments.SetProxy(entry.Value);
+            }
+
+            if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigEnvironmentKey, out entry))
+            {
+                Trace.WriteLine("   " + ConfigEnvironmentKey + " = " + entry.Value);
+
+                if (!String.IsNullOrWhiteSpace(entry.Value)
+                    && !String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(entry.Value)))
+                {
+                    operationArguments.EnvironmentKey = entry.Value;
+                }
             }
         }
 

--- a/Microsoft.Alm.Authentication/EnvironmentStore.cs
+++ b/Microsoft.Alm.Authentication/EnvironmentStore.cs
@@ -1,0 +1,108 @@
+﻿using System;
+
+namespace Microsoft.Alm.Authentication
+{
+    /// <summary>
+    /// Interface to secure secrets storage which indexes values by target and utilizes
+    /// process scoped environment variables as the storage mechanism.
+    /// </summary>
+    public sealed class EnvironmentStore : ICredentialStore, ITokenStore
+    {
+        public EnvironmentStore(string credentialKey)
+        {
+            if (String.IsNullOrWhiteSpace(credentialKey))
+                throw new ArgumentNullException("credentialKey");
+
+            _environmentVariableName = credentialKey;
+        }
+
+        private readonly string _environmentVariableName;
+
+        /// <summary>
+        /// Deletes credentials for target URI from the credential store
+        /// </summary>
+        /// <param name="targetUri">(ignored) The URI of the target for which credentials are being deleted</param>
+        public void DeleteCredentials(TargetUri targetUri)
+        {
+            Environment.SetEnvironmentVariable(_environmentVariableName, null, EnvironmentVariableTarget.Process);
+        }
+
+        /// <summary>
+        /// Deletes the token for target URI from the token store
+        /// </summary>
+        /// <param name="targetUri">(ignored) The URI of the target for which the token is being deleted</param>
+        public void DeleteToken(TargetUri targetUri)
+        {
+            Environment.SetEnvironmentVariable(_environmentVariableName, null, EnvironmentVariableTarget.Process);
+        }
+
+        /// <summary>
+        /// Reads credentials for a target URI from the credential store
+        /// </summary>
+        /// <param name="targetUri">(ignored) The URI of the target for which credentials are being read</param>
+        /// <param name="credentials">The credentials from the store; <see langword="null"/> if failure</param>
+        /// <returns><see langword="true"/> if success; <see langword="false"/> if failure</returns>
+        public bool ReadCredentials(TargetUri targetUri, out Credential credentials)
+        {
+            credentials = null;
+
+            string value;
+            if ((value = Environment.GetEnvironmentVariable(_environmentVariableName, EnvironmentVariableTarget.Process)) != null)
+            {
+                int index = value.IndexOf(':');
+                if (index < 0)
+                {
+                    credentials = new Credential("username", value);
+                }
+                else
+                {
+                    string username = value.Substring(0, index - 1);
+                    string password = value.Substring(index + 1);
+
+                    credentials = new Credential(username, password);
+                }
+            }
+
+            return credentials != null;
+        }
+
+        /// <summary>
+        /// Reads a token for a target URI from the token store
+        /// </summary>
+        /// <param name="targetUri">(ignored) The URI of the target for which a token is being read</param>
+        /// <param name="token">The token from the store; <see langword="null"/> if failure</param>
+        /// <returns><see langword="true"/> if success; <see langword="false"/> if failure</returns>
+        public bool ReadToken(TargetUri targetUri, out Token token)
+        {
+            token = null;
+
+            string value;
+            if ((value = Environment.GetEnvironmentVariable(_environmentVariableName, EnvironmentVariableTarget.Process)) != null)
+            {
+                token = new Token(value, TokenType.Personal);
+            }
+
+            return token != null;
+        }
+
+        /// <summary>
+        /// Writes credentials for a target URI to the credential store
+        /// </summary>
+        /// <param name="targetUri">(ignored) The URI of the target for which credentials are being stored</param>
+        /// <param name="credentials">The credentials to be stored</param>
+        public void WriteCredentials(TargetUri targetUri, Credential credentials)
+        {
+            Environment.SetEnvironmentVariable(_environmentVariableName, String.Format("{0}:{1}", credentials.Username, credentials.Password), EnvironmentVariableTarget.Process);
+        }
+
+        /// <summary>
+        /// Writes a token for a target URI to the token store
+        /// </summary>
+        /// <param name="targetUri">(ignored) The URI of the target for which a token is being stored</param>
+        /// <param name="token">The token to be stored</param>
+        public void WriteToken(TargetUri targetUri, Token token)
+        {
+            Environment.SetEnvironmentVariable(_environmentVariableName, token.Value, EnvironmentVariableTarget.Process);
+        }
+    }
+}

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Security" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EnvironmentStore.cs" />
     <Compile Include="GitHubAuthentication.cs" />
     <Compile Include="GithubAuthenticationResult.cs" />
     <Compile Include="GithubAuthority.cs" />

--- a/Microsoft.Alm.Authentication/SecretCache.cs
+++ b/Microsoft.Alm.Authentication/SecretCache.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace Microsoft.Alm.Authentication
 {
-    internal sealed class SecretCache : ICredentialStore, ITokenStore
+    public sealed class SecretCache : ICredentialStore, ITokenStore
     {
         public static StringComparer KeyComparer = StringComparer.OrdinalIgnoreCase;
 


### PR DESCRIPTION
Added a new credential store which reads/write credentials and tokens from the system's process scoped environment variables.

Added a new configuration value which, when set, changes the behavior of the credential helper to utilize the new environment variable secret store instead of the Windows secure secret vault.

Updated help spew as well.