### PR TITLE
Security: Do not persists ADA Refesh Tokens

### DIFF
--- a/Microsoft.Alm.Authentication/NativeMethods.cs
+++ b/Microsoft.Alm.Authentication/NativeMethods.cs
@@ -74,6 +74,39 @@ namespace Microsoft.Alm.Authentication
         [DllImport(Advapi32, CharSet = CharSet.Unicode, EntryPoint = "CredFree", SetLastError = true)]
         internal static extern void CredFree(IntPtr credential);
 
+        /// <summary>
+        /// Enumerates the credentials from the user's credential set. The credential set used 
+        /// is the one associated with the logon session of the current token. The token must 
+        /// not have the user's SID disabled.
+        /// </summary>
+        /// <param name="targetNameFilter">
+        /// <para>Pointer to a null-terminated string that contains the filter for the returned 
+        /// credentials. Only credentials with a TargetName matching the filter will be returned. 
+        /// The filter specifies a name prefix followed by an asterisk. For instance, the filter 
+        /// "FRED*" will return all credentials with a TargetName beginning with the string 
+        /// "FRED".</para>
+        /// <para>If <see langword="null"/> is specified, all credentials will be returned.</para>
+        /// </param>
+        /// <param name="flags">The value of this parameter can be zero or more values combined 
+        /// with a bitwise-OR operation.</param>
+        /// <param name="count">Count of the credentials returned in the <paramref name="credenitalsArrayPtr"/>.</param>
+        /// <param name="credenitalsArrayPtr">
+        /// <para>Pointer to an array of pointers to credentials. The returned credential is a 
+        /// single allocated block. Any pointers contained within the buffer are pointers to 
+        /// locations within this single allocated block.</para>
+        /// <para>The single returned buffer must be freed by calling <see cref="CredFree"/>.</para>
+        /// </param>
+        /// <returns></returns>
+        [DllImport(Advapi32, CharSet = CharSet.Unicode, EntryPoint = "CredEnumerateW", SetLastError = true)]
+        internal static extern bool CredEnumerate(string targetNameFilter, CredentialEnumerateFlags flags, out int count, out IntPtr credenitalsArrayPtr);
+
+        [Flags]
+        internal enum CredentialEnumerateFlags : uint
+        {
+            None = 0,
+            AllCredentials = 1 << 0,
+        }
+
         [Flags]
         internal enum CredentialFlags : uint
         {

--- a/Microsoft.Alm.Authentication/SecretStore.cs
+++ b/Microsoft.Alm.Authentication/SecretStore.cs
@@ -74,6 +74,14 @@ namespace Microsoft.Alm.Authentication
         }
 
         /// <summary>
+        /// Purges all credenitals from the store.
+        /// </summary>
+        public void PurgeCredentials()
+        {
+            PurgeCredentials(_namespace);
+        }
+
+        /// <summary>
         /// Reads credentials for a target URI from the credential store
         /// </summary>
         /// <param name="targetUri">The URI of the target for which credentials are being read</param>


### PR DESCRIPTION
Azure Directory Refresh Tokens are over-privileged for any use the GCM would need them for, therefore they should be discarded as soon as they're no longer needed.

The only use of ADA refresh tokens is to use them to acquire VSTS personal access tokens - therefore they should only be persisted long enough to do so, then they should be discared.

Additionally, since the GCM has been caching them in the Windows Credential Manager historically, the GCM should make efforts to removed the ADA tokens it has cached.

resolves #200 