### PR TITLE
Switch to AnyCpu

### DIFF
--- a/Cli-CredentialHelper.Test/Cli-CredentialHelper.Test.csproj
+++ b/Cli-CredentialHelper.Test/Cli-CredentialHelper.Test.csproj
@@ -25,7 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Cli-CredentialHelper/Cli-CredentialHelper.csproj
+++ b/Cli-CredentialHelper/Cli-CredentialHelper.csproj
@@ -16,7 +16,7 @@
     <NuGetPackageImportStamp>3a83d7a9</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/Microsoft.Alm.Authentication.Test/Microsoft.Alm.Authentication.Test.csproj
+++ b/Microsoft.Alm.Authentication.Test/Microsoft.Alm.Authentication.Test.csproj
@@ -27,7 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -23,7 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -110,7 +110,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-
   <!-- Produce a nuget package of this assembly -->
   <Import Project="..\packages\MSBuildTasks.*\tools\MSBuild.Community.Tasks.Targets" />
   <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Package'">
@@ -121,10 +120,7 @@
     <PropertyGroup Condition="!Exists($(NugetPath))">
       <NugetPath>$(IntermediateOutputPath)nuget.exe</NugetPath>
     </PropertyGroup>
-    <WebDownload
-        Condition="!Exists($(NugetPath))"
-        Filename="$(NugetPath)"
-        FileUri="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" />
+    <WebDownload Condition="!Exists($(NugetPath))" Filename="$(NugetPath)" FileUri="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" />
     <Exec Command="$(NugetPath) pack $(AssemblyName).csproj -Symbols -IncludeReferencedProjects -Prop Configuration=Package -OutputDirectory $(OutputPath)" />
   </Target>
 </Project>

--- a/Microsoft.Alm.Git.Test/Microsoft.Alm.Git.Test.csproj
+++ b/Microsoft.Alm.Git.Test/Microsoft.Alm.Git.Test.csproj
@@ -25,7 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Microsoft.Alm.Git/Microsoft.Alm.Git.csproj
+++ b/Microsoft.Alm.Git/Microsoft.Alm.Git.csproj
@@ -21,7 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
There's no good reason to be targetting x86 when building the GCM, this change converts everything to AnyCpu which works best for WPF base forms (see GithubAuthentication).