### PR TITLE
Fix basic get

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -957,7 +957,7 @@ namespace Microsoft.Alm.CredentialHelper
             }
         }
 
-        private static bool GitHubCredentialPrompt(TargetUri targetUri, out string username, out string password)
+        private static bool BasicCredentialPrompt(TargetUri targetUri, string titleMessage, out string username, out string password)
         {
             // ReadConsole 32768 fail, 32767 ok
             // @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
@@ -965,7 +965,9 @@ namespace Microsoft.Alm.CredentialHelper
 
             Debug.Assert(targetUri != null);
 
-            Trace.WriteLine("Program::GitHubCredentialPrompt");
+            Trace.WriteLine("Program::BasicCredentialPrompt");
+
+            titleMessage = titleMessage ?? "Please enter your credentials for ";
 
             StringBuilder buffer = new StringBuilder(BufferReadSize);
             uint read = 0;
@@ -993,7 +995,7 @@ namespace Microsoft.Alm.CredentialHelper
                 Trace.WriteLine("   console mode = " + consoleMode);
 
                 // instruct the user as to what they are expected to do
-                buffer.Append("Please enter your GitHub credentials for ")
+                buffer.Append(titleMessage)
                       .Append(targetUri)
                       .AppendLine();
                 if (!NativeMethods.WriteConsole(stdout, buffer, (uint)buffer.Length, out written, IntPtr.Zero))
@@ -1081,6 +1083,15 @@ namespace Microsoft.Alm.CredentialHelper
 
             return username != null
                 && password != null;
+        }
+
+        private static bool GitHubCredentialPrompt(TargetUri targetUri, out string username, out string password)
+        {
+            const string TitleMessage = "Please enter your GitHub credentials for ";
+
+            Trace.WriteLine("Program::GitHubCredentialPrompt");
+
+            return BasicCredentialPrompt(targetUri, TitleMessage, out username, out password);
         }
 
         private static bool GitHubAuthCodePrompt(TargetUri targetUri, GitHubAuthenticationResultType resultType, string username, out string authenticationCode)

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Alm.CredentialHelper
 
             return;
 
-        error_parse:
+            error_parse:
             Console.Out.WriteLine("Fatal: unable to parse target URI.");
         }
 
@@ -430,12 +430,16 @@ namespace Microsoft.Alm.CredentialHelper
                         Trace.WriteLine("   credentials found");
                         operationArguments.SetCredentials(credentials);
                     }
-                    else if (operationArguments.UseModalUi)
+                    else if (operationArguments.Interactivity != Interactivity.Never)
                     {
-                        // display the modal dialog
                         string username;
                         string password;
-                        if (ModalPromptForCredentials(operationArguments.TargetUri, out username, out password))
+
+                        // either use modal UI or command line to query for credentials
+                        if ((operationArguments.UseModalUi 
+                                && ModalPromptForCredentials(operationArguments.TargetUri, out username, out password))
+                            || (!operationArguments.UseModalUi
+                                && BasicCredentialPrompt(operationArguments.TargetUri, null, out username, out password)))
                         {
                             Trace.WriteLine("   credentials found");
                             // set the credentials object

--- a/Microsoft.Alm.Authentication/BaseSecureStore.cs
+++ b/Microsoft.Alm.Authentication/BaseSecureStore.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Alm.Authentication
             else
             {
                 int error = Marshal.GetLastWin32Error();
-                if (error != NativeMethods.Win32Error.FileNotFound)
+                if (error != NativeMethods.Win32Error.FileNotFound
+                    && error != NativeMethods.Win32Error.NotFound)
                 {
                     Debug.Fail("Failed with error code " + error.ToString("X"));
                 }


### PR DESCRIPTION
Add new `BasicCredentialPrompt` method and make old `GitHubCredentialPrompt` method use it.

When configured to not use modal UX, basic authority was ignoring the negative case, it now honors it.

Additionally, basic authority wasn't considering the never interactive flag and still requesting credentials, this change fixes that.

Silence annoying and invalid assert