### PR TITLE
Fix GitHub authentication using a proxy with authentication

### DIFF
--- a/Cli-CredentialHelper/OperationArguments.cs
+++ b/Cli-CredentialHelper/OperationArguments.cs
@@ -89,53 +89,14 @@ namespace Microsoft.Alm.CredentialHelper
         public AuthorityType Authority { get; set; }
         public string CredPassword { get; private set; }
         public string CredUsername { get; private set; }
-        public string CustomNamespace { get; set; }
         public Interactivity Interactivity { get; set; }
         public bool PreserveCredentials { get; set; }
-        public string ProxyHost
-        {
-            get { return _proxyHost; }
-            set
-            {
-                _proxyHost = value;
-                CreateTargetUri();
-            }
-        }
-        public string ProxyPath
-        {
-            get { return _proxyPath; }
-            set
-            {
-                _proxyPath = value;
-                CreateTargetUri();
-            }
-        }
-        public string ProxyProtocol
-        {
-            get { return _proxyProtocol; }
-            set
-            {
-                _proxyProtocol = value;
-                CreateTargetUri();
-            }
-        }
         public Uri ProxyUri
         {
             get { return _proxyUri; }
             internal set
             {
-                if (value == null)
-                {
-                    _proxyHost = null;
-                    _proxyPath = null;
-                    _proxyProtocol = null;
-                }
-                else
-                {
-                    _proxyHost = value.DnsSafeHost;
-                    _proxyPath = value.AbsolutePath;
-                    _proxyProtocol = value.Scheme;
-                }
+                _proxyUri = value;
                 CreateTargetUri();
             }
         }
@@ -207,9 +168,6 @@ namespace Microsoft.Alm.CredentialHelper
         private string _queryPath;
         private string _queryProtocol;
         private Uri _queryUri;
-        private string _proxyHost;
-        private string _proxyPath;
-        private string _proxyProtocol;
         private Uri _proxyUri;
         private TargetUri _targetUri;
         private bool _useHttpPath;
@@ -265,12 +223,8 @@ namespace Microsoft.Alm.CredentialHelper
             string actualUrl = _useHttpPath
                 ? String.Format("{0}://{1}/{2}", this.QueryProtocol, this.QueryHost, this.QueryPath)
                 : String.Format("{0}://{1}", this.QueryProtocol, this.QueryHost);
-            string proxyUrl = _useHttpPath
-                ? String.Format("{0}://{1}/{2}", this.ProxyProtocol, this.ProxyHost, this.ProxyPath)
-                : String.Format("{0}://{1}", this.ProxyProtocol, this.ProxyHost);
 
-            if (Uri.TryCreate(actualUrl, UriKind.Absolute, out _queryUri)
-                | Uri.TryCreate(proxyUrl, UriKind.Absolute, out _proxyUri))
+            if (Uri.TryCreate(actualUrl, UriKind.Absolute, out _queryUri))
             {
                 _targetUri = new TargetUri(_queryUri, _proxyUri);
             }

--- a/Cli-CredentialHelper/OperationArguments.cs
+++ b/Cli-CredentialHelper/OperationArguments.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Alm.CredentialHelper
         public AuthorityType Authority { get; set; }
         public string CredPassword { get; private set; }
         public string CredUsername { get; private set; }
+        public string CustomNamespace { get; set; }
         public Interactivity Interactivity { get; set; }
         public bool PreserveCredentials { get; set; }
         public Uri ProxyUri

--- a/Microsoft.Alm.Authentication/GitHubAuthority.cs
+++ b/Microsoft.Alm.Authentication/GitHubAuthority.cs
@@ -69,11 +69,7 @@ namespace Microsoft.Alm.Authentication
 
             Token token = null;
 
-            using (HttpClientHandler handler = new HttpClientHandler()
-            {
-                MaxAutomaticRedirections = 2,
-                UseDefaultCredentials = true
-            })
+            using (HttpClientHandler handler = targetUri.HttpClientHandler)
             using (HttpClient httpClient = new HttpClient(handler)
             {
                 Timeout = TimeSpan.FromMilliseconds(RequestTimeout)
@@ -196,11 +192,7 @@ namespace Microsoft.Alm.Authentication
             string authEncode = Convert.ToBase64String(authBytes);
 
             // craft the request header for the GitHub v3 API w/ credentials
-            using (HttpClientHandler handler = new HttpClientHandler()
-            {
-                MaxAutomaticRedirections = 2,
-                UseDefaultCredentials = true
-            })
+            using (HttpClientHandler handler = targetUri.HttpClientHandler)
             using (HttpClient httpClient = new HttpClient(handler)
             {
                 Timeout = TimeSpan.FromMilliseconds(RequestTimeout)

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Alm.Authentication
             string trimmedHostUrl = targetUri.Host
                                              .TrimEnd('/', '\\')
                                              .TrimEnd();
-            Uri resolvedUri = targetUri.ResolvedUri;
+            Uri resolvedUri = targetUri.ActualUri;
 
             if (resolvedUri.IsDefaultPort)
             {

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Alm.Authentication
                     Proxy = WebProxy,
                     UseProxy = useProxy,
                     MaxAutomaticRedirections = 2,
-                    UseDefaultCredentials = !useProxy
+                    UseDefaultCredentials = true
                 };
             }
         }
@@ -167,9 +167,11 @@ namespace Microsoft.Alm.Authentication
                     WebProxy proxy = new WebProxy(ProxyUri);
 
                     int dividerIndex = ProxyUri.UserInfo.IndexOf(':');
+                    bool hasUserNameAndPassword = dividerIndex != -1;
+                    bool hasAuthenticationSpecified = !string.IsNullOrWhiteSpace(ProxyUri.UserInfo);
 
-                    if (!string.IsNullOrWhiteSpace(ProxyUri.UserInfo)
-                        && dividerIndex != -1)
+                    // check if the user has specified authentications (comes as UserInfo)
+                    if (hasAuthenticationSpecified && hasUserNameAndPassword)
                     {
                         string userName = ProxyUri.UserInfo.Substring(0, dividerIndex);
                         string password = ProxyUri.UserInfo.Substring(dividerIndex + 1);
@@ -181,6 +183,11 @@ namespace Microsoft.Alm.Authentication
 
                         proxy.UseDefaultCredentials = false;
                         proxy.Credentials = proxyCreds;
+                    }
+                    else
+                    {
+                        // if no explicit proxy authentication, set to use default (Credentials will be set to DefaultCredentials automatically)
+                        proxy.UseDefaultCredentials = true;
                     }
 
                     return proxy;

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -1,4 +1,4 @@
-﻿/**** Git Credential Manager for Windows ****
+/**** Git Credential Manager for Windows ****
  * 
  * Copyright (c) Microsoft Corporation
  * All rights reserved.
@@ -24,6 +24,8 @@
 **/
 
 using System;
+using System.Net;
+using System.Net.Http;
 
 namespace Microsoft.Alm.Authentication
 {
@@ -61,74 +63,67 @@ namespace Microsoft.Alm.Authentication
         { }
 
         /// <summary>
-        /// Gets the <see cref="Uri.AbsolutePath"/> of the <see cref="ResolvedUri"/>.
+        /// Gets the <see cref="Uri.AbsolutePath"/> of the <see cref="ActualUri"/>.
         /// </summary>
         public string AbsolutePath
         {
-            get { return ResolvedUri.AbsolutePath; }
+            get { return ActualUri.AbsolutePath; }
         }
         /// <summary>
         /// The actual <see cref="Uri"/> of the target.
         /// </summary>
         public readonly Uri ActualUri;
         /// <summary>
-        /// Gets the <see cref="Uri.DnsSafeHost"/> of the <see cref="ResolvedUri"/>.
+        /// Gets the <see cref="Uri.DnsSafeHost"/> of the <see cref="ActualUri"/>.
         /// </summary>
         public string DnsSafeHost
         {
-            get { return ResolvedUri.DnsSafeHost; }
+            get { return ActualUri.DnsSafeHost; }
         }
         /// <summary>
-        /// Gets the <see cref="Uri.Host"/> of the <see cref="ResolvedUri"/>.
+        /// Gets the <see cref="Uri.Host"/> of the <see cref="ActualUri"/>.
         /// </summary>
         public string Host
         {
-            get { return ResolvedUri.Host; }
+            get { return ActualUri.Host; }
         }
         /// <summary>
-        /// Gets whether the <see cref="ResolvedUri"/> is absolute.
+        /// Gets whether the <see cref="ActualUri"/> is absolute.
         /// </summary>
         public bool IsAbsoluteUri { get { return true; } }
         /// <summary>
-        /// Gets whether the port value of the <see cref="ResolvedUri"/> is the default for this scheme.
+        /// Gets whether the port value of the <see cref="ActualUri"/> is the default for this scheme.
         /// </summary>
-        public bool IsDefaultPort { get { return ResolvedUri.IsDefaultPort; } }
+        public bool IsDefaultPort { get { return ActualUri.IsDefaultPort; } }
         /// <summary>
-        /// Gets the <see cref="Uri.Port"/> of the <see cref="ResolvedUri"/>.
+        /// Gets the <see cref="Uri.Port"/> of the <see cref="ActualUri"/>.
         /// </summary>
         public int Port
         {
-            get { return ResolvedUri.Port; }
+            get { return ActualUri.Port; }
         }
         /// <summary>
         /// The proxy <see cref="Uri"/> of the target if it exists; otherwise <see langword="null"/>.
         /// </summary>
         public readonly Uri ProxyUri;
         /// <summary>
-        /// Gets <see cref="ProxyUri"/> if it exists; otherwise <see cref="ActualUri"/>.
-        /// </summary>
-        public Uri ResolvedUri
-        {
-            get { return (ProxyUri ?? ActualUri); }
-        }
-        /// <summary>
-        /// Gets the <see cref="Uri.Scheme"/> name of the <see cref="ResolvedUri"/>.
+        /// Gets the <see cref="Uri.Scheme"/> name of the <see cref="ActualUri"/>.
         /// </summary>
         public string Scheme
         {
-            get { return ResolvedUri.Scheme; }
+            get { return ActualUri.Scheme; }
         }
         /// <summary>
-        /// Determines whether the <see cref="ResolvedUri"/> is a base of the specified <see cref="Uri"/>.
+        /// Determines whether the <see cref="ActualUri"/> is a base of the specified <see cref="Uri"/>.
         /// </summary>
         /// <param name="uri">The <see cref="Uri"/> to test.</param>
         /// <returns><see langword="True"/> if is a base of <param name="uri"/>; otherwise, <see langword="false"/>.</returns>
         public bool IsBaseOf(Uri uri)
         {
-            return ResolvedUri.IsBaseOf(uri);
+            return ActualUri.IsBaseOf(uri);
         }
         /// <summary>
-        /// Determines whether the <see cref="ResolvedUri"/> is a base of the specified <see cref="TargetUri.ResolvedUri"/>.
+        /// Determines whether the <see cref="ActualUri"/> is a base of the specified <see cref="TargetUri.ActualUri"/>.
         /// </summary>
         /// <param name="targetUri">The <see cref="TargetUri"/> to test.</param>
         /// <returns><see langword="True"/> if is a base of <param name="targetUri"/>; otherwise, <see langword="false"/>.</returns>
@@ -137,22 +132,71 @@ namespace Microsoft.Alm.Authentication
             if (targetUri == null)
                 return false;
 
-            return ResolvedUri.IsBaseOf(targetUri.ResolvedUri);
+            return ActualUri.IsBaseOf(targetUri.ActualUri);
         }
         /// <summary>
-        /// Gets a canonical string representation for the <see cref="ResolvedUri"/>.
+        /// Gets a canonical string representation for the <see cref="ActualUri"/>.
         /// </summary>
         /// <returns></returns>
         public override String ToString()
         {
-            return ResolvedUri.ToString();
+            return ActualUri.ToString();
+        }
+
+        public HttpClientHandler HttpClientHandler
+        {
+            get
+            {
+                bool useProxy = ProxyUri != null;
+                return new HttpClientHandler()
+                {
+                    Proxy = WebProxy,
+                    UseProxy = useProxy,
+                    MaxAutomaticRedirections = 2,
+                    UseDefaultCredentials = !useProxy
+                };
+            }
+        }
+
+        public WebProxy WebProxy
+        {
+            get
+            {
+                if (ProxyUri != null)
+                {
+                    WebProxy proxy = new WebProxy(ProxyUri);
+
+                    int dividerIndex = ProxyUri.UserInfo.IndexOf(':');
+
+                    if (!string.IsNullOrWhiteSpace(ProxyUri.UserInfo)
+                        && dividerIndex != -1)
+                    {
+                        string userName = ProxyUri.UserInfo.Substring(0, dividerIndex);
+                        string password = ProxyUri.UserInfo.Substring(dividerIndex + 1);
+
+                        NetworkCredential proxyCreds = new NetworkCredential(
+                            userName,
+                            password
+                        );
+
+                        proxy.UseDefaultCredentials = false;
+                        proxy.Credentials = proxyCreds;
+                    }
+
+                    return proxy;
+                }
+                else
+                {
+                    return new WebProxy();
+                }
+            }
         }
 
         public static implicit operator Uri(TargetUri targetUri)
         {
             return ReferenceEquals(targetUri, null)
                 ? null
-                : targetUri.ResolvedUri;
+                : targetUri.ActualUri;
         }
 
         public static implicit operator TargetUri(Uri uri)


### PR DESCRIPTION
Used TargetUri.ActualUri instead of TargetUri.ResolvedUri.
Changed how proxy is stored in Cli-CredentialHelper.OperationArguments.
Changed how GitHubAuthority handles the requests.

Tested in an environment behind a corporate proxy that requires authentication.
Resolves #243 