### PR TITLE
Support null proxy

### DIFF
--- a/Cli-CredentialHelper/OperationArguments.cs
+++ b/Cli-CredentialHelper/OperationArguments.cs
@@ -227,7 +227,11 @@ namespace Microsoft.Alm.CredentialHelper
             Uri tmp = null;
             if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
             {
-                Trace.WriteLine("   successfully set proxy to " + tmp.AbsoluteUri);
+                Trace.WriteLine("   successfully set proxy to " + tmp.AbsoluteUri + ".");
+            }
+            else
+            {
+                Trace.WriteLine("   proxy cleared.");
             }
             this.ProxyUri = tmp;
         }

--- a/Cli-CredentialHelper/OperationArguments.cs
+++ b/Cli-CredentialHelper/OperationArguments.cs
@@ -224,11 +224,12 @@ namespace Microsoft.Alm.CredentialHelper
 
         public void SetProxy(string url)
         {
-            Uri tmp;
+            Uri tmp = null;
             if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
             {
-                this.ProxyUri = tmp;
+                Trace.WriteLine("   successfully set proxy to " + tmp.AbsoluteUri);
             }
+            this.ProxyUri = tmp;
         }
 
         public override string ToString()

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -1057,6 +1057,7 @@ namespace Microsoft.Alm.CredentialHelper
 
             Configuration.Entry entry;
 
+            // look for authority config settings
             if (Configuration.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigAuthortyKey, out entry))
             {
                 Trace.WriteLine("   " + ConfigAuthortyKey + " = " + entry.Value);
@@ -1095,6 +1096,7 @@ namespace Microsoft.Alm.CredentialHelper
                 }
             }
 
+            // look for interactivity config settings
             string interativeValue = null;
             if (EnvironmentVariables.ContainsKey(EnvironInteractiveKey)
                 && !string.IsNullOrWhiteSpace(interativeValue = EnvironmentVariables[EnvironInteractiveKey]))
@@ -1123,36 +1125,42 @@ namespace Microsoft.Alm.CredentialHelper
                 }
             }
 
+            // look for credential validation config settings
             bool? validateCredentials;
             if (TryReadBoolean(operationArguments.QueryUri, ConfigValidateKey, EnvironValidateKey, operationArguments.ValidateCredentials, out validateCredentials))
             {
                 operationArguments.ValidateCredentials = validateCredentials.Value;
             }
 
+            // look for write log config settings
             bool? writeLog;
             if (TryReadBoolean(operationArguments.QueryUri, ConfigWritelogKey, EnvironWritelogKey, operationArguments.WriteLog, out writeLog))
             {
                 operationArguments.WriteLog = writeLog.Value;
             }
 
+            // look for modal prompt config settings
             bool? useModalUi = null;
             if (TryReadBoolean(operationArguments.QueryUri, ConfigUseModalPromptKey, EnvironModalPromptKey, operationArguments.UseModalUi, out useModalUi))
             {
                 operationArguments.UseModalUi = useModalUi.Value;
             }
 
+            // look for credential preservation config settings
             bool? preserveCredentials;
             if (TryReadBoolean(operationArguments.QueryUri, ConfigPreserveCredentialsKey, EnvironPreserveCredentialsKey, operationArguments.PreserveCredentials, out preserveCredentials))
             {
                 operationArguments.PreserveCredentials = preserveCredentials.Value;
             }
 
+            // look for http path usage config settings
             bool? useHttpPath;
             if (TryReadBoolean(operationArguments.QueryUri, ConfigUseHttpPathKey, null, operationArguments.UseHttpPath, out useHttpPath))
             {
                 operationArguments.UseHttpPath = useHttpPath.Value;
             }
 
+            // look for http proxy config settings
             if (Configuration.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigHttpProxyKey, out entry)
                 || Configuration.TryGetEntry("http", operationArguments.QueryUri, "proxy", out entry))
             {
@@ -1161,6 +1169,7 @@ namespace Microsoft.Alm.CredentialHelper
                 operationArguments.SetProxy(entry.Value);
             }
 
+            // look for custom namespace config settings
             if (Configuration.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigNamespaceKey, out entry))
             {
                 Trace.WriteLine("   " + ConfigNamespaceKey + " = " + entry.Value);

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -46,18 +46,21 @@ namespace Microsoft.Alm.Authentication
             ProxyUri = proxyUri;
             ActualUri = actualUri;
         }
+
         public TargetUri(Uri target)
             : this(target, null)
         { }
+
         public TargetUri(string actualUrl, string proxyUrl)
         {
-            if (actualUrl == null)
+            if (ReferenceEquals(actualUrl, null))
                 throw new ArgumentNullException("actualUrl");
             if (!Uri.TryCreate(actualUrl, UriKind.Absolute, out ActualUri))
-                throw new ArgumentException("URL is invalid.", "actualUrl");
-            if (proxyUrl != null && !Uri.TryCreate(proxyUrl, UriKind.Absolute, out ProxyUri))
-                throw new ArgumentException("URL is invalid.", "proxyUrl");
+                throw new UriFormatException("actualUrl");
+            if (!(ReferenceEquals(proxyUrl, null) || Uri.TryCreate(proxyUrl, UriKind.Absolute, out ProxyUri)))
+                throw new UriFormatException("proxyUrl");
         }
+
         public TargetUri(string targetUrl)
             : this(targetUrl, null)
         { }
@@ -73,6 +76,7 @@ namespace Microsoft.Alm.Authentication
         /// The actual <see cref="Uri"/> of the target.
         /// </summary>
         public readonly Uri ActualUri;
+
         /// <summary>
         /// Gets the <see cref="Uri.DnsSafeHost"/> of the <see cref="ActualUri"/>.
         /// </summary>
@@ -80,6 +84,7 @@ namespace Microsoft.Alm.Authentication
         {
             get { return ActualUri.DnsSafeHost; }
         }
+
         /// <summary>
         /// Gets the <see cref="Uri.Host"/> of the <see cref="ActualUri"/>.
         /// </summary>
@@ -87,14 +92,17 @@ namespace Microsoft.Alm.Authentication
         {
             get { return ActualUri.Host; }
         }
+
         /// <summary>
         /// Gets whether the <see cref="ActualUri"/> is absolute.
         /// </summary>
         public bool IsAbsoluteUri { get { return true; } }
+
         /// <summary>
         /// Gets whether the port value of the <see cref="ActualUri"/> is the default for this scheme.
         /// </summary>
         public bool IsDefaultPort { get { return ActualUri.IsDefaultPort; } }
+
         /// <summary>
         /// Gets the <see cref="Uri.Port"/> of the <see cref="ActualUri"/>.
         /// </summary>
@@ -102,10 +110,12 @@ namespace Microsoft.Alm.Authentication
         {
             get { return ActualUri.Port; }
         }
+
         /// <summary>
         /// The proxy <see cref="Uri"/> of the target if it exists; otherwise <see langword="null"/>.
         /// </summary>
         public readonly Uri ProxyUri;
+
         /// <summary>
         /// Gets the <see cref="Uri.Scheme"/> name of the <see cref="ActualUri"/>.
         /// </summary>
@@ -113,6 +123,7 @@ namespace Microsoft.Alm.Authentication
         {
             get { return ActualUri.Scheme; }
         }
+
         /// <summary>
         /// Determines whether the <see cref="ActualUri"/> is a base of the specified <see cref="Uri"/>.
         /// </summary>
@@ -122,6 +133,7 @@ namespace Microsoft.Alm.Authentication
         {
             return ActualUri.IsBaseOf(uri);
         }
+
         /// <summary>
         /// Determines whether the <see cref="ActualUri"/> is a base of the specified <see cref="TargetUri.ActualUri"/>.
         /// </summary>
@@ -134,15 +146,19 @@ namespace Microsoft.Alm.Authentication
 
             return ActualUri.IsBaseOf(targetUri.ActualUri);
         }
+
         /// <summary>
         /// Gets a canonical string representation for the <see cref="ActualUri"/>.
         /// </summary>
         /// <returns></returns>
-        public override String ToString()
+        public override string ToString()
         {
             return ActualUri.ToString();
         }
 
+        /// <summary>
+        /// Gets the client header enabled to work with proxies as necissary.
+        /// </summary>
         public HttpClientHandler HttpClientHandler
         {
             get
@@ -158,6 +174,9 @@ namespace Microsoft.Alm.Authentication
             }
         }
 
+        /// <summary>
+        /// Gets the web proxy abstraction for working with proxies as necissary.
+        /// </summary>
         public WebProxy WebProxy
         {
             get
@@ -166,15 +185,15 @@ namespace Microsoft.Alm.Authentication
                 {
                     WebProxy proxy = new WebProxy(ProxyUri);
 
-                    int dividerIndex = ProxyUri.UserInfo.IndexOf(':');
-                    bool hasUserNameAndPassword = dividerIndex != -1;
+                    int tokenIndex = ProxyUri.UserInfo.IndexOf(':');
+                    bool hasUserNameAndPassword = tokenIndex != -1;
                     bool hasAuthenticationSpecified = !string.IsNullOrWhiteSpace(ProxyUri.UserInfo);
 
                     // check if the user has specified authentications (comes as UserInfo)
                     if (hasAuthenticationSpecified && hasUserNameAndPassword)
                     {
-                        string userName = ProxyUri.UserInfo.Substring(0, dividerIndex);
-                        string password = ProxyUri.UserInfo.Substring(dividerIndex + 1);
+                        string userName = ProxyUri.UserInfo.Substring(0, tokenIndex);
+                        string password = ProxyUri.UserInfo.Substring(tokenIndex + 1);
 
                         NetworkCredential proxyCreds = new NetworkCredential(
                             userName,


### PR DESCRIPTION
Resolution for #237 
Based on #253

Basically, allows for setting a `null` proxy value as a means for clearing proxy settings.