### PR TITLE
Switch from TextReader to UTF-8 encoding.

### DIFF
--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -41,6 +41,39 @@ namespace Microsoft.Alm.CredentialHelper.Test
             CollectionAssert.AreEqual(expected, actual);
         }
 
+        [TestMethod]
+        public void SpecialCharacters()
+        {
+            const string input = "protocol=https\n"
+                               + "host=example.visualstudio.com\n"
+                               + "path=path\n"
+                               + "username=userNamể\n"
+                               + "password=ḭncorrect\n";
+
+            OperationArguments cut;
+            using (var memory = new MemoryStream())
+            using (var writer = new StreamWriter(memory))
+            {
+                writer.Write(input);
+                writer.Flush();
+
+                memory.Seek(0, SeekOrigin.Begin);
+
+                cut = new OperationArguments(memory);
+            }
+
+            Assert.AreEqual("https", cut.QueryProtocol);
+            Assert.AreEqual("example.visualstudio.com", cut.QueryHost);
+            Assert.AreEqual("https://example.visualstudio.com/", cut.TargetUri.ToString());
+            Assert.AreEqual("path", cut.QueryPath);
+            Assert.AreEqual("userNamể", cut.CredUsername);
+            Assert.AreEqual("ḭncorrect", cut.CredPassword);
+
+            var expected = ReadLines(input);
+            var actual = ReadLines(cut.ToString());
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
         private static ICollection ReadLines(string input)
         {
             var result = new List<string>();

--- a/Cli-CredentialHelper/OperationArguments.cs
+++ b/Cli-CredentialHelper/OperationArguments.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Alm.CredentialHelper
 
                     // if we've filled the buffer, make it larger
                     // this could hit an out of memory condition, but that'd require
-                    // the called to be attempting to do so, since that's not a security
+                    // the called to be attempting to do so, since that's not a secyity
                     // threat we can safely ignore that and allow NetFx to handle it
                     if (read == buffer.Length)
                     {


### PR DESCRIPTION
Instead of relying on NetFx and Windows to "do the right thing(tm)", we should be explicitly encoding and decoding UTF-8 when interacting with Git. 

Resolution for #226