### PR TITLE
Add Support for a Clear Command

### DIFF
--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -11,16 +11,22 @@ namespace Microsoft.Alm.CredentialHelper.Test
         [TestMethod]
         public void Typical()
         {
-            const string input = @"protocol=https
-host=example.visualstudio.com
-path=path
-username=userName
-password=incorrect
-";
+            const string input = "protocol=https\n"
+                               + "host=example.visualstudio.com\n"
+                               + "path=path\n"
+                               + "username=userName\n"
+                               + "password=incorrect\n";
+
             OperationArguments cut;
-            using (var sr = new StringReader(input))
+            using (var memory = new MemoryStream())
+            using (var writer = new StreamWriter(memory))
             {
-                cut = new OperationArguments(sr);
+                writer.Write(input);
+                writer.Flush();
+
+                memory.Seek(0, SeekOrigin.Begin);
+
+                cut = new OperationArguments(memory);
             }
 
             Assert.AreEqual("https", cut.QueryProtocol);

--- a/Cli-CredentialHelper/NativeMethods.cs
+++ b/Cli-CredentialHelper/NativeMethods.cs
@@ -332,6 +332,46 @@ namespace Microsoft.Alm.CredentialHelper
             Delete = 0x00000004
         }
 
+        public enum FileType
+        {
+            /// <summary>
+            /// Either the type of the specified file is unknown, or the function failed.
+            /// </summary>
+            Unknown = 0x0000,
+            /// <summary>
+            /// The specified file is a disk file.
+            /// </summary>
+            Disk = 0x0001,
+            /// <summary>
+            /// The specified file is a character file, typically an LPT device or a console.
+            /// </summary>
+            Char = 0x0002,
+            /// <summary>
+            /// The specified file is a socket, a named pipe, or an anonymous pipe.
+            /// </summary>
+            Pipe = 0x0003,
+            /// <summary>
+            /// Unused.
+            /// </summary>
+            Remote = 0x8000,
+        };
+
+        public enum StandardHandleType
+        {
+            /// <summary>
+            /// The standard input device. Initially, this is the console input buffer, CONIN$.
+            /// </summary>
+            Input = -10,
+            /// <summary>
+            /// The standard output device. Initially, this is the active console screen buffer, CONOUT$.
+            /// </summary>
+            Output = -11,
+            /// <summary>
+            /// The standard error device. Initially, this is the active console screen buffer, CONOUT$.
+            /// </summary>
+            Error = -12
+        };
+
         [Flags]
         public enum CredentialPackFlags : uint
         {
@@ -736,6 +776,22 @@ namespace Microsoft.Alm.CredentialHelper
         /// <returns>True if success; otherwise false.</returns>
         [DllImport(Kernel32, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "GetConsoleMode", SetLastError = true)]
         public static extern bool GetConsoleMode(SafeFileHandle consoleHandle, out ConsoleMode consoleMode);
+
+        /// <summary>
+        /// Retrieves the file type of the specified file.
+        /// </summary>
+        /// <param name="fileHandle">A handle to the file.</param>
+        /// <returns>A <see cref="FileType"/>.</returns>
+        [DllImport(Kernel32, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "GetFileType", SetLastError = true)]
+        public static extern FileType GetFileType(IntPtr fileHandle);
+
+        /// <summary>
+        /// Retrieves a handle to the specified standard device (standard input, standard output, or standard error).
+        /// </summary>
+        /// <param name="std"></param>
+        /// <returns>A Handle.</returns>
+        [DllImport(Kernel32, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "GetStdHandle", SetLastError = true)]
+        public static extern IntPtr GetStdHandle(StandardHandleType std);
 
         /// <summary>
         /// Reads character input from the console input buffer and removes it from the buffer.

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -717,14 +717,20 @@ namespace Microsoft.Alm.CredentialHelper
 
             Trace.WriteLine("Program::BasicCredentialPrompt");
 
+            username = null;
+            password = null;
+
+            if (!StandardErrorIsTty || !StandardInputIsTty)
+            {
+                Trace.WriteLine("  not a tty detected, abandoning prompt.");
+                return false;
+            }
+
             titleMessage = titleMessage ?? "Please enter your credentials for ";
 
             StringBuilder buffer = new StringBuilder(BufferReadSize);
             uint read = 0;
             uint written = 0;
-
-            username = null;
-            password = null;
 
             NativeMethods.FileAccess fileAccessFlags = NativeMethods.FileAccess.GenericRead | NativeMethods.FileAccess.GenericWrite;
             NativeMethods.FileAttributes fileAttributes = NativeMethods.FileAttributes.Normal;

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -1415,6 +1415,13 @@ namespace Microsoft.Alm.CredentialHelper
             }
         }
 
+        private static bool StandardHandleIsTty(NativeMethods.StandardHandleType handleType)
+        {
+            var standardHandle = NativeMethods.GetStdHandle(NativeMethods.StandardHandleType.Output);
+            var handleFileType = NativeMethods.GetFileType(standardHandle);
+            return handleFileType == NativeMethods.FileType.Char;
+        }
+
         private static bool TryReadBoolean(Uri queryUri, string configKey, string environKey, bool defaultValue, out bool? value)
         {
             if (ReferenceEquals(queryUri, null))


### PR DESCRIPTION
* Add support for detecting if standard pipes are TTY or not.
* Add "clear" command with associated method.
* Refactor `Erase` into `Erase` and `DeleteCredentials` so that new `Clear` method can be DRYer.
* Leverage new ability to detect TTY to avoid deadlocks involving asking for input when pipes are redirected.

Resolves #99 