### PR TITLE
Settable useragent

### DIFF
--- a/Cli-CredentialHelper/OperationArguments.cs
+++ b/Cli-CredentialHelper/OperationArguments.cs
@@ -63,6 +63,16 @@ namespace Microsoft.Alm.CredentialHelper
                     {
                         Array.Resize(ref buffer, buffer.Length * 2);
                     }
+
+                    // the input ends with LFLF, check for that and break the read loop
+                    // unless input is coming from CLRF system, in which case it'll be CLRFCLRF
+                    if ((buffer[read - 2] == '\n'
+                            && buffer[read - 1] == '\n')
+                        || (buffer[read - 4] == '\r'
+                            && buffer[read - 3] == '\n'
+                            && buffer[read - 2] == '\r'
+                            && buffer[read - 1] == '\n'))
+                        break;
                 }
 
                 // Git uses UTF-8 for string, don't let the OS decide how to decode it

--- a/Microsoft.Alm.Authentication/BaseVstsAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BaseVstsAuthentication.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Alm.Authentication
                     {
                         // build a request that we expect to fail, do not allow redirect to sign in url
                         var request = WebRequest.CreateHttp(targetUri);
-                        request.UserAgent = Global.GetUserAgent();
+                        request.UserAgent = Global.UserAgent;
                         request.Method = "HEAD";
                         request.AllowAutoRedirect = false;
                         // get the response from the server

--- a/Microsoft.Alm.Authentication/GitHubAuthority.cs
+++ b/Microsoft.Alm.Authentication/GitHubAuthority.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Alm.Authentication
                 Timeout = TimeSpan.FromMilliseconds(RequestTimeout)
             })
             {
-                httpClient.DefaultRequestHeaders.Add("User-Agent", Global.GetUserAgent());
+                httpClient.DefaultRequestHeaders.Add("User-Agent", Global.UserAgent);
                 httpClient.DefaultRequestHeaders.Add("Accept", GitHubApiAcceptsHeaderValue);
 
                 string basicAuthValue = String.Format("{0}:{1}", username, password);
@@ -198,7 +198,7 @@ namespace Microsoft.Alm.Authentication
                 Timeout = TimeSpan.FromMilliseconds(RequestTimeout)
             })
             {
-                httpClient.DefaultRequestHeaders.Add("User-Agent", Global.GetUserAgent());
+                httpClient.DefaultRequestHeaders.Add("User-Agent", Global.UserAgent);
                 httpClient.DefaultRequestHeaders.Add("Accept", GitHubApiAcceptsHeaderValue);
                 httpClient.DefaultRequestHeaders.Add("Authorization", "Basic " + authEncode);
 

--- a/Microsoft.Alm.Authentication/Global.cs
+++ b/Microsoft.Alm.Authentication/Global.cs
@@ -27,27 +27,55 @@ using System;
 
 namespace Microsoft.Alm.Authentication
 {
-    internal static class Global
+    public static class Global
     {
+        /// <summary>
+        /// <para>Gets or sets the user-agent string sent as part of the header in any HTTP operations.</para>
+        /// <para>Defaults to a value contrived based on the executing assembly.</para>
+        /// </summary>
+        public static string UserAgent
+        {
+            get
+            {
+                lock (_syncpoint)
+                {
+                    if (_useragent == null)
+                    {
+                        _useragent = DefaultUserAgent;
+                    }
+                    return _useragent;
+                }
+            }
+            set
+            {
+                lock (_syncpoint) _useragent = value;
+            }
+        }
         private static string _useragent = null;
+
+        private static readonly object _syncpoint = new object();
 
         /// <summary>
         /// Creates the correct user-agent string for HTTP calls.
         /// </summary>
         /// <returns>The `user-agent` string for "git-tools".</returns>
-        public static string GetUserAgent()
+        private static string DefaultUserAgent
         {
-            if (_useragent == null)
+            get
             {
-                Version version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-                _useragent = String.Format("git-credential-manager ({0}; {1}; {2}) CLR/{3} git-tools/{4}",
-                                           Environment.OSVersion.VersionString,
-                                           Environment.OSVersion.Platform,
-                                           Environment.Is64BitOperatingSystem ? "x64" : "x86",
-                                           Environment.Version.ToString(3),
-                                           version.ToString(3));
+                var assemblyName = System.Reflection.Assembly.GetEntryAssembly().GetName();
+                var name = assemblyName.Name;
+                var version = assemblyName.Version;
+                var useragent = string.Format("{0} ({1}; {2}; {3}) CLR/{4} git-tools/{5}",
+                                              name,
+                                              Environment.OSVersion.VersionString,
+                                              Environment.OSVersion.Platform,
+                                              Environment.Is64BitOperatingSystem ? "x64" : "x86",
+                                              Environment.Version.ToString(3),
+                                              version.ToString(3));
+
+                return useragent;
             }
-            return _useragent;
         }
     }
 }

--- a/Microsoft.Alm.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Alm.Authentication/VstsAzureAuthority.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Alm.Authentication
                     Timeout = TimeSpan.FromMilliseconds(RequestTimeout)
                 })
                 {
-                    httpClient.DefaultRequestHeaders.Add("User-Agent", Global.GetUserAgent());
+                    httpClient.DefaultRequestHeaders.Add("User-Agent", Global.UserAgent);
 
                     switch (accessToken.Type)
                     {


### PR DESCRIPTION
To better support various consumers of Microsoft.Alm.Authentication, the `Global.UserAgent` value should be adjustable.

Now, it is.