### PR TITLE
Make `PasswordBoxHintAdorner` not COM visible.

### DIFF
--- a/Cli-Askpass/PasswordBoxHintAdorner.cs
+++ b/Cli-Askpass/PasswordBoxHintAdorner.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 
 namespace Microsoft.Alm.Gui
 {
+    [System.Runtime.InteropServices.ComVisible(false)]
     public class PasswordBoxHintAdorner : Adorner
     {
         public PasswordBoxHintAdorner(UIElement adornedElement, string hintText, Style hintStyle, VisibilityDelegate visibilityCallback)


### PR DESCRIPTION
Make `PasswordBoxHintAdorner` not COM visible.

Resolves #272 