### PR TITLE
Suppress analysis warnings in tests.

### DIFF
--- a/Cli-CredentialHelper.Test/GlobalSuppressions.cs
+++ b/Cli-CredentialHelper.Test/GlobalSuppressions.cs
@@ -1,5 +1,6 @@
 ﻿[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Scope = "member", Target = "Microsoft.Alm.Cli.Test.OperationArgumentsTests.#Typical()")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Scope = "member", Target = "Microsoft.Alm.Cli.Test.OperationArgumentsTests.#SpecialCharacters()")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Scope = "member", Target = "Microsoft.Alm.Cli.Test.OperationArgumentsTests.#CreateTargetUriTest(Microsoft.Alm.Cli.Test.OperationArgumentsTests+InputArg)")]
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given


### PR DESCRIPTION
We *really* do not care about analysis warnings in tests.

Resolves #272 