### PR TITLE
Fixup and improve config support.

### DIFF
--- a/Microsoft.Alm.Git.Test/ConfigurationTests.cs
+++ b/Microsoft.Alm.Git.Test/ConfigurationTests.cs
@@ -99,9 +99,9 @@ namespace Microsoft.Alm.Git.Test
                     "";
             Configuration cut;
 
-            using (var sr = new StringReader(input))
+            using (var reader = new StringReader(input))
             {
-                cut = new Configuration(sr);
+                cut = new Configuration(reader);
             }
 
             Assert.AreEqual(true, cut.ContainsKey("CoRe.AuToCrLf"));

--- a/Microsoft.Alm.Git/ConfigurationLevel.cs
+++ b/Microsoft.Alm.Git/ConfigurationLevel.cs
@@ -1,0 +1,46 @@
+﻿/**** Git Credential Manager for Windows ****
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the """"Software""""), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+**/
+
+using System;
+
+namespace Microsoft.Alm.Git
+{
+    [Flags]
+    public enum ConfigurationLevel
+    {
+        Unknown = 0,
+
+        Portable = 1 << 0,
+        System = 1 << 1,
+        Xdg = 1 << 2,
+        Global = 1 << 3,
+        Local = 1 << 4,
+
+        All = Portable | System | Xdg | Global | Local,
+        NoLocal = All & ~Local,
+        NoSystem = All & ~(Portable | System),
+        UserOnly = All & ~(Portable | System | Local)
+    }
+}

--- a/Microsoft.Alm.Git/Microsoft.Alm.Git.csproj
+++ b/Microsoft.Alm.Git/Microsoft.Alm.Git.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configuration.cs" />
+    <Compile Include="ConfigurationLevel.cs" />
     <Compile Include="GitInstallation.cs" />
     <Compile Include="KnownGitDistribution.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fix Where to use '%HOME%' and FindInstallations to find Git configuration files.

Add better support for multiple configuration levels.

Sneaks in support for `credential.writelog` during clone.

Resolves #256
Resolves #285 