### PR TITLE
Git trace like

### DIFF
--- a/Cli-Askpass/Cli-Askpass.csproj
+++ b/Cli-Askpass/Cli-Askpass.csproj
@@ -91,6 +91,7 @@
     </Page>
   </ItemGroup>
   <Import Project="..\Cli-Shared\Cli-Shared.projitems" Label="Shared" />
+  <Import Project="..\CommonShared\CommonShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Alm.Cli
             Match match;
             if ((match = AskCredentialRegex.Match(Environment.CommandLine)).Success)
             {
-                Trace.WriteLine("querying for HTTPS credentials.");
+                Git.Trace.WriteLine("querying for HTTPS credentials.");
 
                 if (match.Groups.Count < 3)
                     throw new ArgumentException("Unable to understand command.");
@@ -35,7 +35,7 @@ namespace Microsoft.Alm.Cli
                 int tokenIndex = targetUrl.IndexOf('@');
                 if (tokenIndex > 0)
                 {
-                    Trace.WriteLine("'@' symbol found in URL, assuming credential prefix.");
+                    Git.Trace.WriteLine("'@' symbol found in URL, assuming credential prefix.");
 
                     string prefix = targetUrl.Substring(0, tokenIndex);
                     targetUrl = targetUrl.Substring(tokenIndex + 1, targetUrl.Length - tokenIndex - 1);
@@ -46,7 +46,7 @@ namespace Microsoft.Alm.Cli
                     tokenIndex = prefix.IndexOf(':');
                     if (tokenIndex > 0)
                     {
-                        Trace.WriteLine("':' token found in credential prefix, parsing username & password.");
+                        Git.Trace.WriteLine("':' token found in credential prefix, parsing username & password.");
 
                         username = prefix.Substring(0, tokenIndex);
                         password = prefix.Substring(tokenIndex + 1, prefix.Length - tokenIndex - 1);
@@ -57,7 +57,7 @@ namespace Microsoft.Alm.Cli
 
                 if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                 {
-                    Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
+                    Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
                     OperationArguments operationArguments = new OperationArguments(targetUri);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Alm.Cli
                     {
                         if (string.IsNullOrEmpty(credential?.Username))
                         {
-                            Trace.WriteLine("username not supplied in config, need to query for value.");
+                            Git.Trace.WriteLine("username not supplied in config, need to query for value.");
 
                             QueryCredentials(operationArguments);
                             credential = new Credential(operationArguments.CredUsername, operationArguments.CredPassword);
@@ -76,7 +76,7 @@ namespace Microsoft.Alm.Cli
 
                         if (!string.IsNullOrEmpty(credential?.Username))
                         {
-                            Trace.WriteLine($"username for '{targetUrl}' asked for and found.");
+                            Git.Trace.WriteLine($"username for '{targetUrl}' asked for and found.");
 
                             Console.Out.Write(credential.Username + "\n");
                             return;
@@ -87,7 +87,7 @@ namespace Microsoft.Alm.Cli
                     {
                         if (string.IsNullOrEmpty(credential?.Password))
                         {
-                            Trace.WriteLine("password not supplied in config, need to query for value.");
+                            Git.Trace.WriteLine("password not supplied in config, need to query for value.");
 
                             QueryCredentials(operationArguments);
 
@@ -101,7 +101,7 @@ namespace Microsoft.Alm.Cli
 
                         if (!string.IsNullOrEmpty(credential?.Password))
                         {
-                            Trace.WriteLine($"password for '{targetUrl}' asked for and found.");
+                            Git.Trace.WriteLine($"password for '{targetUrl}' asked for and found.");
 
                             Console.Out.Write(credential.Password + "\n");
                             return;
@@ -110,12 +110,12 @@ namespace Microsoft.Alm.Cli
                 }
                 else
                 {
-                    Trace.WriteLine("unable to parse URL.");
+                    Git.Trace.WriteLine("unable to parse URL.");
                 }
             }
             else if ((match = AskPassphraseRegex.Match(Environment.CommandLine)).Success)
             {
-                Trace.WriteLine("querying for passphrase key.");
+                Git.Trace.WriteLine("querying for passphrase key.");
 
                 if (match.Groups.Count < 2)
                     throw new ArgumentException("Unable to understand command.");
@@ -123,7 +123,7 @@ namespace Microsoft.Alm.Cli
                 string request = match.Groups[0].Value;
                 string resource = match.Groups[1].Value;
 
-                Trace.WriteLine($"open dialog for '{resource}'.");
+                Git.Trace.WriteLine($"open dialog for '{resource}'.");
 
                 System.Windows.Application application = new System.Windows.Application();
                 Gui.PassphraseWindow prompt = new Gui.PassphraseWindow(resource);
@@ -133,14 +133,14 @@ namespace Microsoft.Alm.Cli
                 {
                     string passphase = prompt.Passphrase;
 
-                    Trace.WriteLine("passphase acquired.");
+                    Git.Trace.WriteLine("passphase acquired.");
 
                     Console.Out.Write(passphase + "\n");
                     return;
                 }
             }
 
-            Trace.WriteLine("credentials not found.");
+            Git.Trace.WriteLine("failed to acquire credentials.");
         }
 
         [STAThread]
@@ -173,7 +173,7 @@ namespace Microsoft.Alm.Cli
                                         ?? exception.InnerException;
 
                 Console.Error.WriteLine("Fatal: " + innerException.GetType().Name + " encountered.");
-                Trace.WriteLine("Fatal: " + exception.ToString());
+                Git.Trace.WriteLine("Fatal: " + exception.ToString());
                 LogEvent(exception.ToString(), EventLogEntryType.Error);
 
                 Environment.ExitCode = -1;
@@ -181,7 +181,7 @@ namespace Microsoft.Alm.Cli
             catch (Exception exception)
             {
                 Console.Error.WriteLine("Fatal: " + exception.GetType().Name + " encountered.");
-                Trace.WriteLine("Fatal: " + exception.ToString());
+                Git.Trace.WriteLine("Fatal: " + exception.ToString());
                 LogEvent(exception.ToString(), EventLogEntryType.Error);
 
                 Environment.ExitCode = -1;

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Alm.Cli
 
         private static void Askpass()
         {
-            Trace.WriteLine("Program::Askpass");
-
             Match match;
             if ((match = AskCredentialRegex.Match(Environment.CommandLine)).Success)
             {
@@ -59,7 +57,7 @@ namespace Microsoft.Alm.Cli
 
                 if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                 {
-                    Trace.WriteLine("success parsing URL, targetUri = " + targetUri);
+                    Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
                     OperationArguments operationArguments = new OperationArguments(targetUri);
 
@@ -78,7 +76,7 @@ namespace Microsoft.Alm.Cli
 
                         if (!string.IsNullOrEmpty(credential?.Username))
                         {
-                            Trace.WriteLine("username for '" + targetUrl + "' asked for and found.");
+                            Trace.WriteLine($"username for '{targetUrl}' asked for and found.");
 
                             Console.Out.Write(credential.Username + "\n");
                             return;
@@ -103,7 +101,7 @@ namespace Microsoft.Alm.Cli
 
                         if (!string.IsNullOrEmpty(credential?.Password))
                         {
-                            Trace.WriteLine("password for '{0}' asked for and found.", targetUrl);
+                            Trace.WriteLine($"password for '{targetUrl}' asked for and found.");
 
                             Console.Out.Write(credential.Password + "\n");
                             return;
@@ -125,7 +123,7 @@ namespace Microsoft.Alm.Cli
                 string request = match.Groups[0].Value;
                 string resource = match.Groups[1].Value;
 
-                Trace.WriteLine("  open dialog for " + resource);
+                Trace.WriteLine($"open dialog for '{resource}'.");
 
                 System.Windows.Application application = new System.Windows.Application();
                 Gui.PassphraseWindow prompt = new Gui.PassphraseWindow(resource);
@@ -135,7 +133,7 @@ namespace Microsoft.Alm.Cli
                 {
                     string passphase = prompt.Passphrase;
 
-                    Trace.WriteLine("passphase acquired");
+                    Trace.WriteLine("passphase acquired.");
 
                     Console.Out.Write(passphase + "\n");
                     return;
@@ -158,6 +156,8 @@ namespace Microsoft.Alm.Cli
                 PrintHelpMessage();
                 return;
             }
+
+            PrintArgs(args);
 
             try
             {

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Alm.Cli
             Match match;
             if ((match = AskCredentialRegex.Match(Environment.CommandLine)).Success)
             {
-                Trace.WriteLine("   querying for HTTPS credentials.");
+                Trace.WriteLine("querying for HTTPS credentials.");
 
                 if (match.Groups.Count < 3)
                     throw new ArgumentException("Unable to understand command.");
@@ -37,7 +37,7 @@ namespace Microsoft.Alm.Cli
                 int tokenIndex = targetUrl.IndexOf('@');
                 if (tokenIndex > 0)
                 {
-                    Trace.WriteLine("   '@' symbol found in URL, assuming credential prefix.");
+                    Trace.WriteLine("'@' symbol found in URL, assuming credential prefix.");
 
                     string prefix = targetUrl.Substring(0, tokenIndex);
                     targetUrl = targetUrl.Substring(tokenIndex + 1, targetUrl.Length - tokenIndex - 1);
@@ -48,7 +48,7 @@ namespace Microsoft.Alm.Cli
                     tokenIndex = prefix.IndexOf(':');
                     if (tokenIndex > 0)
                     {
-                        Trace.WriteLine("   ':' token found in credential prefix, parsing username & password.");
+                        Trace.WriteLine("':' token found in credential prefix, parsing username & password.");
 
                         username = prefix.Substring(0, tokenIndex);
                         password = prefix.Substring(tokenIndex + 1, prefix.Length - tokenIndex - 1);
@@ -59,7 +59,7 @@ namespace Microsoft.Alm.Cli
 
                 if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                 {
-                    Trace.WriteLine("   success parsing URL, targetUri = " + targetUri);
+                    Trace.WriteLine("success parsing URL, targetUri = " + targetUri);
 
                     OperationArguments operationArguments = new OperationArguments(targetUri);
 
@@ -70,7 +70,7 @@ namespace Microsoft.Alm.Cli
                     {
                         if (string.IsNullOrEmpty(credential?.Username))
                         {
-                            Trace.WriteLine("   username not supplied in config, need to query for value.");
+                            Trace.WriteLine("username not supplied in config, need to query for value.");
 
                             QueryCredentials(operationArguments);
                             credential = new Credential(operationArguments.CredUsername, operationArguments.CredPassword);
@@ -78,7 +78,7 @@ namespace Microsoft.Alm.Cli
 
                         if (!string.IsNullOrEmpty(credential?.Username))
                         {
-                            Trace.WriteLine("   username for '" + targetUrl + "' asked for and found.");
+                            Trace.WriteLine("username for '" + targetUrl + "' asked for and found.");
 
                             Console.Out.Write(credential.Username + "\n");
                             return;
@@ -89,7 +89,7 @@ namespace Microsoft.Alm.Cli
                     {
                         if (string.IsNullOrEmpty(credential?.Password))
                         {
-                            Trace.WriteLine("   password not supplied in config, need to query for value.");
+                            Trace.WriteLine("password not supplied in config, need to query for value.");
 
                             QueryCredentials(operationArguments);
 
@@ -103,7 +103,7 @@ namespace Microsoft.Alm.Cli
 
                         if (!string.IsNullOrEmpty(credential?.Password))
                         {
-                            Trace.WriteLine("   password for '{0}' asked for and found.", targetUrl);
+                            Trace.WriteLine("password for '{0}' asked for and found.", targetUrl);
 
                             Console.Out.Write(credential.Password + "\n");
                             return;
@@ -112,12 +112,12 @@ namespace Microsoft.Alm.Cli
                 }
                 else
                 {
-                    Trace.WriteLine("   unable to parse URL.");
+                    Trace.WriteLine("unable to parse URL.");
                 }
             }
             else if ((match = AskPassphraseRegex.Match(Environment.CommandLine)).Success)
             {
-                Trace.WriteLine("   querying for passphrase key.");
+                Trace.WriteLine("querying for passphrase key.");
 
                 if (match.Groups.Count < 2)
                     throw new ArgumentException("Unable to understand command.");
@@ -135,14 +135,14 @@ namespace Microsoft.Alm.Cli
                 {
                     string passphase = prompt.Passphrase;
 
-                    Trace.WriteLine("   passphase acquired");
+                    Trace.WriteLine("passphase acquired");
 
                     Console.Out.Write(passphase + "\n");
                     return;
                 }
             }
 
-            Trace.WriteLine("   credentials not found.");
+            Trace.WriteLine("credentials not found.");
         }
 
         [STAThread]

--- a/Cli-CredentialHelper/Cli-CredentialHelper.csproj
+++ b/Cli-CredentialHelper/Cli-CredentialHelper.csproj
@@ -72,6 +72,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\Cli-Shared\Cli-Shared.projitems" Label="Shared" />
+  <Import Project="..\CommonShared\CommonShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -171,8 +171,6 @@ namespace Microsoft.Alm.Cli
 
         public void DeployConsole()
         {
-            Trace.WriteLine("Installer::DeployConsole");
-
             SetOutput(_isPassive, _isPassive && _isForced);
             try
             {
@@ -209,7 +207,7 @@ namespace Microsoft.Alm.Cli
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v2, out installation)
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v1, out installation))
                     {
-                        Trace.Write($"   Git found: '{installation.Path}'");
+                        Trace.WriteLine($"   Git found: '{installation.Path}'.");
 
                         // track known Git installations
                         installations = new List<GitInstallation>();
@@ -258,7 +256,7 @@ namespace Microsoft.Alm.Cli
                         }
 
                         Program.LogEvent($"Deployment to '{installation.Path}' succeeded.", EventLogEntryType.Information);
-                        Console.Out.WriteLine($"        {copiedFiles.Count} file(s) copied");
+                        Console.Out.WriteLine($"     {copiedFiles.Count} file(s) copied");
                     }
                     else if (_isForced)
                     {
@@ -292,7 +290,7 @@ namespace Microsoft.Alm.Cli
                     }
 
                     Program.LogEvent($"Deployment to '{UserBinPath}' succeeded.", EventLogEntryType.Information);
-                    Console.Out.WriteLine($"        {copiedFiles.Count} file(s) copied");
+                    Console.Out.WriteLine($"     {copiedFiles.Count} file(s) copied");
                 }
                 else if (_isForced)
                 {
@@ -319,7 +317,7 @@ namespace Microsoft.Alm.Cli
                         }
 
                         Program.LogEvent($"Deployment to '{CygwinPath}' succeeded.", EventLogEntryType.Information);
-                        Console.Out.WriteLine($"        {copiedFiles.Count} file(s) copied");
+                        Console.Out.WriteLine($"     {copiedFiles.Count} file(s) copied");
                     }
                     else if (_isForced)
                     {
@@ -378,8 +376,6 @@ namespace Microsoft.Alm.Cli
             const string ValueName = "Version";
             const string DefaultValue = "0.0.0";
 
-            Trace.WriteLine("Installer::DetectNetFx");
-
             // default to not found state
             version = null;
 
@@ -393,7 +389,7 @@ namespace Microsoft.Alm.Cli
                     && Version.TryParse(netfxString, out netfxVerson))
             {
                 Program.LogEvent($"NetFx version {netfxVerson.ToString(3)} detected.", EventLogEntryType.Information);
-                Trace.WriteLine($"   NetFx version {netfxVerson.ToString(3)} detected.");
+                Trace.WriteLine($"NetFx version {netfxVerson.ToString(3)} detected.");
 
                 version = netfxVerson;
             }
@@ -403,8 +399,6 @@ namespace Microsoft.Alm.Cli
 
         public void RemoveConsole()
         {
-            Trace.WriteLine("Installer::RemoveConsole");
-
             SetOutput(_isPassive, _isPassive && _isForced);
             try
             {
@@ -440,7 +434,7 @@ namespace Microsoft.Alm.Cli
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v2, out installation)
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v1, out installation))
                     {
-                        Trace.Write($"   Git found: {installation.Path}");
+                        Trace.WriteLine($"   Git found: '{installation.Path}'.");
 
                         // track known Git installations
                         installations = new List<GitInstallation>();
@@ -527,7 +521,7 @@ namespace Microsoft.Alm.Cli
                             Console.Out.WriteLine($"  {file}");
                         }
 
-                        Console.Out.WriteLine($"        {cleanedFiles.Count} file(s) cleaned");
+                        Console.Out.WriteLine($"     {cleanedFiles.Count} file(s) cleaned");
                     }
                     else if (_isForced)
                     {
@@ -555,7 +549,7 @@ namespace Microsoft.Alm.Cli
                             Console.Out.WriteLine($"  {file}");
                         }
 
-                        Console.Out.WriteLine($"        {cleanedFiles.Count} file(s) cleaned");
+                        Console.Out.WriteLine($"     {cleanedFiles.Count} file(s) cleaned");
                     }
                     else if (_isForced)
                     {
@@ -580,7 +574,7 @@ namespace Microsoft.Alm.Cli
                             Console.Out.WriteLine($"  {file}");
                         }
 
-                        Console.Out.WriteLine($"        {cleanedFiles.Count} file(s) cleaned");
+                        Console.Out.WriteLine($"     {cleanedFiles.Count} file(s) cleaned");
                     }
                 }
 
@@ -601,8 +595,7 @@ namespace Microsoft.Alm.Cli
 
         public bool SetGitConfig(List<GitInstallation> installations, GitConfigAction action, Configuration.Type type, out Configuration.Type updated)
         {
-            Trace.WriteLine("Installer::SetGitConfig");
-            Trace.WriteLine($"   action = {action}.");
+            Trace.WriteLine($"action = '{action}'.");
 
             updated = Configuration.Type.None;
 
@@ -674,13 +667,11 @@ namespace Microsoft.Alm.Cli
 
         private bool CleanFiles(string path, out List<string> cleanedFiles)
         {
-            Trace.WriteLine("Installer::CleanFiles");
-
             cleanedFiles = new List<string>();
 
             if (!Directory.Exists(path))
             {
-                Trace.WriteLine($"   path '{path}' does not exist.");
+                Trace.WriteLine($"path '{path}' does not exist.");
                 return false;
             }
 
@@ -690,7 +681,7 @@ namespace Microsoft.Alm.Cli
                 {
                     string target = Path.Combine(path, file);
 
-                    Trace.WriteLine($"   clean '{target}'.");
+                    Trace.WriteLine($"clean '{target}'.");
 
                     File.Delete(target);
 
@@ -708,13 +699,11 @@ namespace Microsoft.Alm.Cli
 
         private bool CopyFiles(string srcPath, string dstPath, out List<string> copiedFiles)
         {
-            Trace.WriteLine("Installer::CopyFiles");
-
             copiedFiles = new List<string>();
 
             if (!Directory.Exists(srcPath))
             {
-                Trace.WriteLine($"   source '{srcPath}' does not exist.");
+                Trace.WriteLine($"source '{srcPath}' does not exist.");
                 return false;
             }
 
@@ -724,7 +713,7 @@ namespace Microsoft.Alm.Cli
                 {
                     foreach (string file in Files)
                     {
-                        Trace.WriteLine($"   copy '{srcPath}' to '{dstPath}'.");
+                        Trace.WriteLine($"copy '{srcPath}' to '{dstPath}'.");
 
                         string src = Path.Combine(srcPath, file);
                         string dst = Path.Combine(dstPath, file);
@@ -744,7 +733,7 @@ namespace Microsoft.Alm.Cli
             }
             else
             {
-                Trace.WriteLine($"   destination '{dstPath}' does not exist.");
+                Trace.WriteLine($"destination '{dstPath}' does not exist.");
             }
 
             Trace.WriteLine("copy failed.");
@@ -753,8 +742,6 @@ namespace Microsoft.Alm.Cli
 
         private void DeployElevated()
         {
-            Trace.WriteLine("Installer::DeployElevated");
-
             if (_isPassive)
             {
                 this.Result = ResultValue.Unprivileged;
@@ -795,7 +782,7 @@ namespace Microsoft.Alm.Cli
                     WorkingDirectory = Program.Location,
                 };
 
-                Trace.WriteLine($"   cmd {options.Verb} {options.FileName} {options.Arguments}");
+                Trace.WriteLine($"create process: cmd '{options.Verb}' '{options.FileName}' '{options.Arguments}' .");
 
                 try
                 {
@@ -805,14 +792,14 @@ namespace Microsoft.Alm.Cli
                     // wait for the process to complete
                     elevated.WaitForExit();
 
-                    Trace.WriteLine($"   process exited with {elevated.ExitCode}.");
+                    Trace.WriteLine($"process exited with {elevated.ExitCode}.");
 
                     // exit with the elevated process' exit code
                     this.ExitCode = elevated.ExitCode;
                 }
                 catch (Exception exception)
                 {
-                    Trace.WriteLine($"   process failed with {exception.Message}");
+                    Trace.WriteLine($"process failed with '{exception.Message}'");
                     this.Result = ResultValue.Unprivileged;
                 }
             }
@@ -834,13 +821,13 @@ namespace Microsoft.Alm.Cli
                 UseShellExecute = false,
             };
 
-            Trace.WriteLine($"   cmd {options.FileName} {options.Arguments}.");
+            Trace.WriteLine($"create process: cmd '{options.FileName}' '{options.Arguments}' .");
 
             var gitProcess = Process.Start(options);
 
             gitProcess.WaitForExit();
 
-            Trace.WriteLine($"   Git exited with {gitProcess.ExitCode}.");
+            Trace.WriteLine($"Git exited with {gitProcess.ExitCode}.");
 
             if (allowedExitCodes != null && allowedExitCodes.Length > 0)
                 return allowedExitCodes.Contains(gitProcess.ExitCode);
@@ -860,8 +847,6 @@ namespace Microsoft.Alm.Cli
 
         private void RemoveElevated()
         {
-            Trace.WriteLine("Installer::RemoveElevated");
-
             if (_isPassive)
             {
                 this.Result = ResultValue.Unprivileged;
@@ -902,7 +887,7 @@ namespace Microsoft.Alm.Cli
                     WorkingDirectory = Program.Location,
                 };
 
-                Trace.WriteLine("cmd " + options.Verb + " " + options.FileName + " " + options.Arguments);
+                Trace.WriteLine($"create process: cmd '{options.Verb}' '{options.FileName}' '{options.Arguments}' .");
 
                 try
                 {
@@ -912,14 +897,14 @@ namespace Microsoft.Alm.Cli
                     // wait for the process to complete
                     elevated.WaitForExit();
 
-                    Trace.WriteLine($"   process exited with {elevated.ExitCode}.");
+                    Trace.WriteLine($"process exited with {elevated.ExitCode}.");
 
                     // exit with the elevated process' exit code
                     this.ExitCode = elevated.ExitCode;
                 }
                 catch (Exception exception)
                 {
-                    Trace.WriteLine($"   process failed with {exception.Message}");
+                    Trace.WriteLine($"process failed with '{exception.Message}'");
                     this.Result = ResultValue.Unprivileged;
                 }
             }

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Alm.Cli
         internal const string ParamPathKey = "--path";
         internal const string ParamPassiveKey = "--passive";
         internal const string ParamForceKey = "--force";
+        internal const string FailFace = "U_U";
+        internal const string TadaFace = "^_^";
         //private static readonly Version NetFxMinVersion = new Version(4, 5, 1);
         private static readonly IReadOnlyList<string> Files = new List<string>
         {
@@ -64,20 +66,20 @@ namespace Microsoft.Alm.Cli
                         i += 1;
                         _customPath = args[i];
 
-                        Trace.WriteLine($"  {ParamPathKey} = '{_customPath}'.");
+                        Git.Trace.WriteLine($"{ParamPathKey} = '{_customPath}'.");
                     }
                 }
                 else if (String.Equals(args[i], ParamPassiveKey, StringComparison.OrdinalIgnoreCase))
                 {
                     _isPassive = true;
 
-                    Trace.WriteLine($"  {ParamPassiveKey} = true.");
+                    Git.Trace.WriteLine($"{ParamPassiveKey} = true.");
                 }
                 else if (String.Equals(args[i], ParamForceKey, StringComparison.OrdinalIgnoreCase))
                 {
                     _isForced = true;
 
-                    Trace.WriteLine($"  {ParamForceKey} = true.");
+                    Git.Trace.WriteLine($"{ParamForceKey} = true.");
                 }
             }
         }
@@ -97,6 +99,8 @@ namespace Microsoft.Alm.Cli
 
                         if (Directory.Exists(path))
                         {
+                            Git.Trace.WriteLine($"cygwin directory found at '{path}'.");
+
                             _cygwinPath = path;
                             break;
                         }
@@ -105,6 +109,8 @@ namespace Microsoft.Alm.Cli
 
                         if (Directory.Exists(path))
                         {
+                            Git.Trace.WriteLine($"cygwin directory found at '{path}'.");
+
                             _cygwinPath = path;
                             break;
                         }
@@ -149,6 +155,8 @@ namespace Microsoft.Alm.Cli
                     {
                         // Git for Windows adds %HOME%\bin to %PATH%
                         _userBinPath = Path.Combine(_userBinPath, "bin");
+
+                        Git.Trace.WriteLine($"user bin found at '{_userBinPath}'.");
                     }
                 }
                 return _userBinPath;
@@ -189,9 +197,9 @@ namespace Microsoft.Alm.Cli
                 {
                     if (!Directory.Exists(_customPath))
                     {
-                        Program.LogEvent($"No Git installation found, unable to continue deployment.", EventLogEntryType.Error);
+                        Program.LogEvent("No Git installation found, unable to continue deployment.", EventLogEntryType.Error);
                         Console.Out.WriteLine();
-                        Console.Error.WriteLine($"Fatal: custom path does not exist: '{_customPath}'. U_U");
+                        Console.Error.WriteLine($"Fatal: custom path does not exist: '{_customPath}'. {FailFace}");
                         Pause();
 
                         Result = ResultValue.InvalidCustomPath;
@@ -207,7 +215,7 @@ namespace Microsoft.Alm.Cli
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v2, out installation)
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v1, out installation))
                     {
-                        Trace.WriteLine($"   Git found: '{installation.Path}'.");
+                        Git.Trace.WriteLine($"   Git found: '{installation.Path}'.");
 
                         // track known Git installations
                         installations = new List<GitInstallation>();
@@ -233,9 +241,9 @@ namespace Microsoft.Alm.Cli
 
                 if (installations == null)
                 {
-                    Program.LogEvent($"No Git installation found, unable to continue.", EventLogEntryType.Error);
+                    Program.LogEvent("No Git installation found, unable to continue.", EventLogEntryType.Error);
                     Console.Out.WriteLine();
-                    Console.Error.WriteLine("Fatal: Git was not detected, unable to continue. U_U");
+                    Console.Error.WriteLine("Fatal: Git was not detected, unable to continue. {FailFace}");
                     Pause();
 
                     Result = ResultValue.GitNotFound;
@@ -261,12 +269,12 @@ namespace Microsoft.Alm.Cli
                     else if (_isForced)
                     {
                         Program.LogEvent($"Deployment to '{installation.Path}' failed.", EventLogEntryType.Warning);
-                        Console.Error.WriteLine("  deployment failed. U_U");
+                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
                     }
                     else
                     {
                         Program.LogEvent($"Deployment to '{installation.Path}' failed.", EventLogEntryType.Error);
-                        Console.Error.WriteLine("  deployment failed. U_U");
+                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
                         Pause();
 
                         Result = ResultValue.DeploymentFailed;
@@ -295,12 +303,12 @@ namespace Microsoft.Alm.Cli
                 else if (_isForced)
                 {
                     Program.LogEvent($"Deployment to '{UserBinPath}' failed.", EventLogEntryType.Warning);
-                    Console.Error.WriteLine("  deployment failed. U_U");
+                    Console.Error.WriteLine($"  deployment failed. {FailFace}");
                 }
                 else
                 {
                     Program.LogEvent($"Deployment to '{UserBinPath}' failed.", EventLogEntryType.Error);
-                    Console.Error.WriteLine("  deployment failed. U_U");
+                    Console.Error.WriteLine($"  deployment failed. {FailFace}");
                     Pause();
 
                     Result = ResultValue.DeploymentFailed;
@@ -322,12 +330,12 @@ namespace Microsoft.Alm.Cli
                     else if (_isForced)
                     {
                         Program.LogEvent($"Deployment to '{CygwinPath}' failed.", EventLogEntryType.Warning);
-                        Console.Error.WriteLine("  deployment failed. U_U");
+                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
                     }
                     else
                     {
                         Program.LogEvent($"Deployment to '{CygwinPath}' failed.", EventLogEntryType.Error);
-                        Console.Error.WriteLine("  deployment failed. U_U");
+                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
                         Pause();
 
                         Result = ResultValue.DeploymentFailed;
@@ -359,7 +367,7 @@ namespace Microsoft.Alm.Cli
 
                 Program.LogEvent($"{Program.Title} v{Program.Version.ToString(3)} successfully deployed.", EventLogEntryType.Information);
                 Console.Out.WriteLine();
-                Console.Out.WriteLine($"Success! {Program.Title} was deployed! ^_^");
+                Console.Out.WriteLine($"Success! {Program.Title} was deployed! {TadaFace}");
                 Pause();
             }
             finally
@@ -389,7 +397,7 @@ namespace Microsoft.Alm.Cli
                     && Version.TryParse(netfxString, out netfxVerson))
             {
                 Program.LogEvent($"NetFx version {netfxVerson.ToString(3)} detected.", EventLogEntryType.Information);
-                Trace.WriteLine($"NetFx version {netfxVerson.ToString(3)} detected.");
+                Git.Trace.WriteLine($"NetFx version {netfxVerson.ToString(3)} detected.");
 
                 version = netfxVerson;
             }
@@ -434,7 +442,7 @@ namespace Microsoft.Alm.Cli
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v2, out installation)
                         || Where.FindGitInstallation(_customPath, KnownGitDistribution.GitForWindows32v1, out installation))
                     {
-                        Trace.WriteLine($"   Git found: '{installation.Path}'.");
+                        Git.Trace.WriteLine($"Git found: '{installation.Path}'.");
 
                         // track known Git installations
                         installations = new List<GitInstallation>();
@@ -525,11 +533,11 @@ namespace Microsoft.Alm.Cli
                     }
                     else if (_isForced)
                     {
-                        Console.Error.WriteLine("  removal failed. U_U");
+                        Console.Error.WriteLine($"  removal failed. {FailFace}");
                     }
                     else
                     {
-                        Console.Error.WriteLine("  removal failed. U_U");
+                        Console.Error.WriteLine($"  removal failed. {FailFace}");
                         Pause();
 
                         Result = ResultValue.RemovalFailed;
@@ -553,11 +561,11 @@ namespace Microsoft.Alm.Cli
                     }
                     else if (_isForced)
                     {
-                        Console.Error.WriteLine("  removal failed. U_U");
+                        Console.Error.WriteLine($"  removal failed. {FailFace}");
                     }
                     else
                     {
-                        Console.Error.WriteLine("  removal failed. U_U");
+                        Console.Error.WriteLine($"  removal failed. {FailFace}");
                         Pause();
 
                         Result = ResultValue.RemovalFailed;
@@ -584,7 +592,7 @@ namespace Microsoft.Alm.Cli
                 Program.LogEvent($"{Program.Title} successfully removed.", EventLogEntryType.Information);
 
                 Console.Out.WriteLine();
-                Console.Out.WriteLine($"Success! {Program.Title} was removed! ^_^");
+                Console.Out.WriteLine($"Success! {Program.Title} was removed! {TadaFace}");
                 Pause();
             }
             finally
@@ -595,13 +603,13 @@ namespace Microsoft.Alm.Cli
 
         public bool SetGitConfig(List<GitInstallation> installations, GitConfigAction action, Configuration.Type type, out Configuration.Type updated)
         {
-            Trace.WriteLine($"action = '{action}'.");
+            Git.Trace.WriteLine($"action = '{action}'.");
 
             updated = Configuration.Type.None;
 
             if ((installations == null || installations.Count == 0) && !Where.FindGitInstallations(out installations))
             {
-                Trace.WriteLine("No Git installations detected to update.");
+                Git.Trace.WriteLine("No Git installations detected to update.");
                 return false;
             }
 
@@ -615,13 +623,13 @@ namespace Microsoft.Alm.Cli
 
                 if (ExecuteGit(gitCmdPath, globalCmd, 0, 5))
                 {
-                    Trace.WriteLine("updating ~/.gitconfig succeeded.");
+                    Git.Trace.WriteLine("updating ~/.gitconfig succeeded.");
 
                     updated |= Configuration.Type.Global;
                 }
                 else
                 {
-                    Trace.WriteLine("updating ~/.gitconfig failed.");
+                    Git.Trace.WriteLine("updating ~/.gitconfig failed.");
 
                     Console.Out.WriteLine();
                     Console.Error.WriteLine("Fatal: Unable to update ~/.gitconfig.");
@@ -642,13 +650,13 @@ namespace Microsoft.Alm.Cli
                 {
                     if (ExecuteGit(installation.Git, systemCmd, 0, 5))
                     {
-                        Trace.WriteLine("updating /etc/gitconfig succeeded.");
+                        Git.Trace.WriteLine("updating /etc/gitconfig succeeded.");
 
                         successCount++;
                     }
                     else
                     {
-                        Trace.WriteLine("updating ~/.gitconfig failed.");
+                        Git.Trace.WriteLine("updating ~/.gitconfig failed.");
                     }
                 }
 
@@ -671,7 +679,7 @@ namespace Microsoft.Alm.Cli
 
             if (!Directory.Exists(path))
             {
-                Trace.WriteLine($"path '{path}' does not exist.");
+                Git.Trace.WriteLine($"path '{path}' does not exist.");
                 return false;
             }
 
@@ -681,7 +689,7 @@ namespace Microsoft.Alm.Cli
                 {
                     string target = Path.Combine(path, file);
 
-                    Trace.WriteLine($"clean '{target}'.");
+                    Git.Trace.WriteLine($"clean '{target}'.");
 
                     File.Delete(target);
 
@@ -692,7 +700,7 @@ namespace Microsoft.Alm.Cli
             }
             catch
             {
-                Trace.WriteLine("clean failed.");
+                Git.Trace.WriteLine($"clean of '{path}' failed.");
                 return false;
             }
         }
@@ -703,7 +711,7 @@ namespace Microsoft.Alm.Cli
 
             if (!Directory.Exists(srcPath))
             {
-                Trace.WriteLine($"source '{srcPath}' does not exist.");
+                Git.Trace.WriteLine($"source '{srcPath}' does not exist.");
                 return false;
             }
 
@@ -713,7 +721,7 @@ namespace Microsoft.Alm.Cli
                 {
                     foreach (string file in Files)
                     {
-                        Trace.WriteLine($"copy '{srcPath}' to '{dstPath}'.");
+                        Git.Trace.WriteLine($"copy '{file}' from '{srcPath}' to '{dstPath}'.");
 
                         string src = Path.Combine(srcPath, file);
                         string dst = Path.Combine(dstPath, file);
@@ -727,16 +735,16 @@ namespace Microsoft.Alm.Cli
                 }
                 catch
                 {
-                    Trace.WriteLine("copy failed.");
+                    Git.Trace.WriteLine("copy failed.");
                     return false;
                 }
             }
             else
             {
-                Trace.WriteLine($"destination '{dstPath}' does not exist.");
+                Git.Trace.WriteLine($"destination '{dstPath}' does not exist.");
             }
 
-            Trace.WriteLine("copy failed.");
+            Git.Trace.WriteLine("copy failed.");
             return false;
         }
 
@@ -782,7 +790,7 @@ namespace Microsoft.Alm.Cli
                     WorkingDirectory = Program.Location,
                 };
 
-                Trace.WriteLine($"create process: cmd '{options.Verb}' '{options.FileName}' '{options.Arguments}' .");
+                Git.Trace.WriteLine($"create process: cmd '{options.Verb}' '{options.FileName}' '{options.Arguments}' .");
 
                 try
                 {
@@ -792,14 +800,14 @@ namespace Microsoft.Alm.Cli
                     // wait for the process to complete
                     elevated.WaitForExit();
 
-                    Trace.WriteLine($"process exited with {elevated.ExitCode}.");
+                    Git.Trace.WriteLine($"process exited with {elevated.ExitCode}.");
 
                     // exit with the elevated process' exit code
                     this.ExitCode = elevated.ExitCode;
                 }
                 catch (Exception exception)
                 {
-                    Trace.WriteLine($"process failed with '{exception.Message}'");
+                    Git.Trace.WriteLine($"process failed with '{exception.Message}'");
                     this.Result = ResultValue.Unprivileged;
                 }
             }
@@ -821,13 +829,13 @@ namespace Microsoft.Alm.Cli
                 UseShellExecute = false,
             };
 
-            Trace.WriteLine($"create process: cmd '{options.FileName}' '{options.Arguments}' .");
+            Git.Trace.WriteLine($"create process: cmd '{options.FileName}' '{options.Arguments}' .");
 
             var gitProcess = Process.Start(options);
 
             gitProcess.WaitForExit();
 
-            Trace.WriteLine($"Git exited with {gitProcess.ExitCode}.");
+            Git.Trace.WriteLine($"Git exited with {gitProcess.ExitCode}.");
 
             if (allowedExitCodes != null && allowedExitCodes.Length > 0)
                 return allowedExitCodes.Contains(gitProcess.ExitCode);
@@ -887,7 +895,7 @@ namespace Microsoft.Alm.Cli
                     WorkingDirectory = Program.Location,
                 };
 
-                Trace.WriteLine($"create process: cmd '{options.Verb}' '{options.FileName}' '{options.Arguments}' .");
+                Git.Trace.WriteLine($"create process: cmd '{options.Verb}' '{options.FileName}' '{options.Arguments}' .");
 
                 try
                 {
@@ -897,14 +905,14 @@ namespace Microsoft.Alm.Cli
                     // wait for the process to complete
                     elevated.WaitForExit();
 
-                    Trace.WriteLine($"process exited with {elevated.ExitCode}.");
+                    Git.Trace.WriteLine($"process exited with {elevated.ExitCode}.");
 
                     // exit with the elevated process' exit code
                     this.ExitCode = elevated.ExitCode;
                 }
                 catch (Exception exception)
                 {
-                    Trace.WriteLine($"process failed with '{exception.Message}'");
+                    Git.Trace.WriteLine($"! process failed with '{exception.Message}'.");
                     this.Result = ResultValue.Unprivileged;
                 }
             }

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -608,7 +608,7 @@ namespace Microsoft.Alm.Cli
 
             if ((installations == null || installations.Count == 0) && !Where.FindGitInstallations(out installations))
             {
-                Trace.WriteLine("   No Git installations detected to update.");
+                Trace.WriteLine("No Git installations detected to update.");
                 return false;
             }
 
@@ -622,13 +622,13 @@ namespace Microsoft.Alm.Cli
 
                 if (ExecuteGit(gitCmdPath, globalCmd, 0, 5))
                 {
-                    Trace.WriteLine("   updating ~/.gitconfig succeeded.");
+                    Trace.WriteLine("updating ~/.gitconfig succeeded.");
 
                     updated |= Configuration.Type.Global;
                 }
                 else
                 {
-                    Trace.WriteLine("   updating ~/.gitconfig failed.");
+                    Trace.WriteLine("updating ~/.gitconfig failed.");
 
                     Console.Out.WriteLine();
                     Console.Error.WriteLine("Fatal: Unable to update ~/.gitconfig.");
@@ -649,13 +649,13 @@ namespace Microsoft.Alm.Cli
                 {
                     if (ExecuteGit(installation.Git, systemCmd, 0, 5))
                     {
-                        Trace.WriteLine("   updating /etc/gitconfig succeeded.");
+                        Trace.WriteLine("updating /etc/gitconfig succeeded.");
 
                         successCount++;
                     }
                     else
                     {
-                        Trace.WriteLine("   updating ~/.gitconfig failed.");
+                        Trace.WriteLine("updating ~/.gitconfig failed.");
                     }
                 }
 
@@ -701,7 +701,7 @@ namespace Microsoft.Alm.Cli
             }
             catch
             {
-                Trace.WriteLine("   clean failed.");
+                Trace.WriteLine("clean failed.");
                 return false;
             }
         }
@@ -738,7 +738,7 @@ namespace Microsoft.Alm.Cli
                 }
                 catch
                 {
-                    Trace.WriteLine("   copy failed.");
+                    Trace.WriteLine("copy failed.");
                     return false;
                 }
             }
@@ -747,7 +747,7 @@ namespace Microsoft.Alm.Cli
                 Trace.WriteLine($"   destination '{dstPath}' does not exist.");
             }
 
-            Trace.WriteLine("   copy failed.");
+            Trace.WriteLine("copy failed.");
             return false;
         }
 
@@ -902,7 +902,7 @@ namespace Microsoft.Alm.Cli
                     WorkingDirectory = Program.Location,
                 };
 
-                Trace.WriteLine("   cmd " + options.Verb + " " + options.FileName + " " + options.Arguments);
+                Trace.WriteLine("cmd " + options.Verb + " " + options.FileName + " " + options.Arguments);
 
                 try
                 {

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -69,8 +69,6 @@ namespace Microsoft.Alm.Cli
 
         private static void Clear()
         {
-            Trace.WriteLine("Program::Clear");
-
             var args = Environment.GetCommandLineArgs();
             string url = null;
             bool forced = false;
@@ -99,12 +97,12 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Trace.WriteLine("url = " + url);
+            Trace.WriteLine($"url = '{url}'.");
 
             Uri uri;
             if (Uri.TryCreate(url, UriKind.Absolute, out uri))
             {
-                Trace.WriteLine("targetUri = " + uri.AbsoluteUri + ".");
+                Trace.WriteLine($"targetUri = '{uri.AbsoluteUri}'.");
 
                 OperationArguments operationArguments = new OperationArguments(uri);
 
@@ -113,8 +111,8 @@ namespace Microsoft.Alm.Cli
 
                 if (operationArguments.PreserveCredentials && !forced)
                 {
-                    Trace.Write("   attempting to delete preserved credentials without force.");
-                    Trace.Write("   prompting user for interactivity.");
+                    Trace.WriteLine("attempting to delete preserved credentials without force.");
+                    Trace.WriteLine("prompting user for interactivity.");
 
                     if (!StandardInputIsTty || !StandardErrorIsTty)
                     {
@@ -129,13 +127,13 @@ namespace Microsoft.Alm.Cli
                     {
                         if (key.KeyChar == 'N' || key.KeyChar == 'n')
                         {
-                            Trace.Write("   use cancelled.");
+                            Trace.WriteLine("user cancelled.");
                             return;
                         }
 
                         if (key.KeyChar == 'Y' || key.KeyChar == 'y')
                         {
-                            Trace.Write("   use continued.");
+                            Trace.WriteLine("user continued.");
                             break;
                         }
                     }
@@ -147,8 +145,6 @@ namespace Microsoft.Alm.Cli
 
         private static void Delete()
         {
-            Trace.WriteLine("Program::Erase");
-
             string[] args = Environment.GetCommandLineArgs();
 
             if (args.Length < 3)
@@ -181,13 +177,13 @@ namespace Microsoft.Alm.Cli
             {
                 default:
                 case AuthorityType.Basic:
-                    Trace.WriteLine("deleting basic credentials");
+                    Trace.WriteLine("deleting basic credentials.");
                     authentication.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
-                    Trace.WriteLine("deleting VSTS credentials");
+                    Trace.WriteLine("deleting VSTS credentials.");
                     BaseVstsAuthentication vstsAuth = authentication as BaseVstsAuthentication;
                     vstsAuth.DeleteCredentials(operationArguments.TargetUri);
                     // call delete twice to purge any stored ADA tokens
@@ -195,7 +191,7 @@ namespace Microsoft.Alm.Cli
                     break;
 
                 case AuthorityType.GitHub:
-                    Trace.WriteLine("deleting GitHub credentials");
+                    Trace.WriteLine("deleting GitHub credentials.");
                     GitHubAuthentication ghAuth = authentication as GitHubAuthentication;
                     ghAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
@@ -209,13 +205,10 @@ namespace Microsoft.Alm.Cli
 
         private static void Deploy()
         {
-            Trace.WriteLine("Program::Deploy");
-
             var installer = new Installer();
             installer.DeployConsole();
 
-            Trace.WriteLine(String.Format("   Installer result = {0}.", installer.Result));
-            Trace.WriteLine(String.Format("   Installer exit code = {0}.", installer.ExitCode));
+            Trace.WriteLine($"Installer result = '{installer.Result}', exit code = {installer.ExitCode}.");
 
             Environment.Exit(installer.ExitCode);
         }
@@ -234,13 +227,9 @@ namespace Microsoft.Alm.Cli
             LoadOperationArguments(operationArguments);
             EnableTraceLogging(operationArguments);
 
-            Trace.WriteLine("Program::Erase");
-            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
-
             if (operationArguments.PreserveCredentials)
             {
-                Trace.WriteLine("" + ConfigPreserveCredentialsKey + " = true");
-                Trace.WriteLine("canceling erase request.");
+                Trace.WriteLine($"{ConfigPreserveCredentialsKey} = true, canceling erase request.");
                 return;
             }
 
@@ -259,9 +248,6 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentNullException("operationArguments");
             if (ReferenceEquals(operationArguments.TargetUri, null))
                 throw new ArgumentNullException("operationArguments.TargetUri");
-
-            Trace.WriteLine("Program::Get");
-            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
 
             LoadOperationArguments(operationArguments);
             EnableTraceLogging(operationArguments);
@@ -295,6 +281,8 @@ namespace Microsoft.Alm.Cli
                     PrintHelpMessage();
                     return;
                 }
+
+                PrintArgs(args);
 
                 // list of arg => method associations (case-insensitive)
                 Dictionary<string, Action> actions = new Dictionary<string, Action>(StringComparer.OrdinalIgnoreCase)
@@ -359,8 +347,6 @@ namespace Microsoft.Alm.Cli
 
         private static void PrintHelpMessage()
         {
-            Trace.WriteLine("Program::PrintHelpMessage");
-
             Console.Out.WriteLine("usage: git credential-manager [" + String.Join("|", CommandList) + "] [<args>]");
             Console.Out.WriteLine();
             Console.Out.WriteLine("Command Line Options:");
@@ -414,13 +400,10 @@ namespace Microsoft.Alm.Cli
 
         private static void Remove()
         {
-            Trace.WriteLine("Program::Remove");
-
             var installer = new Installer();
             installer.RemoveConsole();
 
-            Trace.WriteLine(String.Format("   Installer result = {0}.", installer.Result));
-            Trace.WriteLine(String.Format("   Installer exit code = {0}.", installer.ExitCode));
+            Trace.WriteLine($"Installer result = {installer.Result}, exit code = {installer.ExitCode}.");
 
             Environment.Exit(installer.ExitCode);
         }
@@ -439,9 +422,6 @@ namespace Microsoft.Alm.Cli
 
             LoadOperationArguments(operationArguments);
             EnableTraceLogging(operationArguments);
-
-            Trace.WriteLine("Program::Store");
-            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
 
             BaseAuthentication authentication = CreateAuthentication(operationArguments);
             Credential credentials = new Credential(operationArguments.CredUsername, operationArguments.CredPassword);

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Alm.Cli
             {
                 if (!StandardInputIsTty)
                 {
-                    Trace.WriteLine("   standard input is not TTY, abandoning prompt.");
+                    Trace.WriteLine("standard input is not TTY, abandoning prompt.");
 
                     return;
                 }
 
-                Trace.WriteLine("   prompting user for url.");
+                Trace.WriteLine("prompting user for url.");
 
                 Console.Out.WriteLine(" Target Url:");
                 url = Console.In.ReadLine();
@@ -99,12 +99,12 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Trace.WriteLine("   url = " + url);
+            Trace.WriteLine("url = " + url);
 
             Uri uri;
             if (Uri.TryCreate(url, UriKind.Absolute, out uri))
             {
-                Trace.WriteLine("   targetUri = " + uri.AbsoluteUri + ".");
+                Trace.WriteLine("targetUri = " + uri.AbsoluteUri + ".");
 
                 OperationArguments operationArguments = new OperationArguments(uri);
 
@@ -118,7 +118,7 @@ namespace Microsoft.Alm.Cli
 
                     if (!StandardInputIsTty || !StandardErrorIsTty)
                     {
-                        Trace.WriteLine("   standard input is not TTY, abandoning prompt.");
+                        Trace.WriteLine("standard input is not TTY, abandoning prompt.");
                         return;
                     }
 
@@ -181,13 +181,13 @@ namespace Microsoft.Alm.Cli
             {
                 default:
                 case AuthorityType.Basic:
-                    Trace.WriteLine("   deleting basic credentials");
+                    Trace.WriteLine("deleting basic credentials");
                     authentication.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
-                    Trace.WriteLine("   deleting VSTS credentials");
+                    Trace.WriteLine("deleting VSTS credentials");
                     BaseVstsAuthentication vstsAuth = authentication as BaseVstsAuthentication;
                     vstsAuth.DeleteCredentials(operationArguments.TargetUri);
                     // call delete twice to purge any stored ADA tokens
@@ -195,7 +195,7 @@ namespace Microsoft.Alm.Cli
                     break;
 
                 case AuthorityType.GitHub:
-                    Trace.WriteLine("   deleting GitHub credentials");
+                    Trace.WriteLine("deleting GitHub credentials");
                     GitHubAuthentication ghAuth = authentication as GitHubAuthentication;
                     ghAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
@@ -235,12 +235,12 @@ namespace Microsoft.Alm.Cli
             EnableTraceLogging(operationArguments);
 
             Trace.WriteLine("Program::Erase");
-            Trace.WriteLine("   targetUri = " + operationArguments.TargetUri);
+            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
 
             if (operationArguments.PreserveCredentials)
             {
-                Trace.WriteLine("   " + ConfigPreserveCredentialsKey + " = true");
-                Trace.WriteLine("   canceling erase request.");
+                Trace.WriteLine("" + ConfigPreserveCredentialsKey + " = true");
+                Trace.WriteLine("canceling erase request.");
                 return;
             }
 
@@ -261,7 +261,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentNullException("operationArguments.TargetUri");
 
             Trace.WriteLine("Program::Get");
-            Trace.WriteLine("   targetUri = " + operationArguments.TargetUri);
+            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
 
             LoadOperationArguments(operationArguments);
             EnableTraceLogging(operationArguments);
@@ -441,7 +441,7 @@ namespace Microsoft.Alm.Cli
             EnableTraceLogging(operationArguments);
 
             Trace.WriteLine("Program::Store");
-            Trace.WriteLine("   targetUri = " + operationArguments.TargetUri);
+            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
 
             BaseAuthentication authentication = CreateAuthentication(operationArguments);
             Credential credentials = new Credential(operationArguments.CredUsername, operationArguments.CredPassword);

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -77,12 +77,12 @@ namespace Microsoft.Alm.Cli
             {
                 if (!StandardInputIsTty)
                 {
-                    Trace.WriteLine("standard input is not TTY, abandoning prompt.");
+                    Git.Trace.WriteLine("standard input is not TTY, abandoning prompt.");
 
                     return;
                 }
 
-                Trace.WriteLine("prompting user for url.");
+                Git.Trace.WriteLine("prompting user for url.");
 
                 Console.Out.WriteLine(" Target Url:");
                 url = Console.In.ReadLine();
@@ -97,12 +97,10 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Trace.WriteLine($"url = '{url}'.");
-
             Uri uri;
             if (Uri.TryCreate(url, UriKind.Absolute, out uri))
             {
-                Trace.WriteLine($"targetUri = '{uri.AbsoluteUri}'.");
+                Git.Trace.WriteLine($"converted '{url}' to '{uri.AbsoluteUri}'.");
 
                 OperationArguments operationArguments = new OperationArguments(uri);
 
@@ -111,12 +109,11 @@ namespace Microsoft.Alm.Cli
 
                 if (operationArguments.PreserveCredentials && !forced)
                 {
-                    Trace.WriteLine("attempting to delete preserved credentials without force.");
-                    Trace.WriteLine("prompting user for interactivity.");
+                    Git.Trace.WriteLine("attempting to delete preserved credentials without force, prompting user for interactivity.");
 
                     if (!StandardInputIsTty || !StandardErrorIsTty)
                     {
-                        Trace.WriteLine("standard input is not TTY, abandoning prompt.");
+                        Git.Trace.WriteLine("standard input is not TTY, abandoning prompt.");
                         return;
                     }
 
@@ -126,20 +123,18 @@ namespace Microsoft.Alm.Cli
                     while ((key = Console.ReadKey(true)).Key != ConsoleKey.Escape)
                     {
                         if (key.KeyChar == 'N' || key.KeyChar == 'n')
-                        {
-                            Trace.WriteLine("user cancelled.");
                             return;
-                        }
 
                         if (key.KeyChar == 'Y' || key.KeyChar == 'y')
-                        {
-                            Trace.WriteLine("user continued.");
                             break;
-                        }
                     }
                 }
 
                 DeleteCredentials(operationArguments);
+            }
+            else
+            {
+                Git.Trace.WriteLine($"unable to parse input '{url}'.");
             }
         }
 
@@ -177,13 +172,13 @@ namespace Microsoft.Alm.Cli
             {
                 default:
                 case AuthorityType.Basic:
-                    Trace.WriteLine("deleting basic credentials.");
+                    Git.Trace.WriteLine($"deleting basic credentials for '{operationArguments.TargetUri}'.");
                     authentication.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
-                    Trace.WriteLine("deleting VSTS credentials.");
+                    Git.Trace.WriteLine("deleting VSTS credentials for '{operationArguments.TargetUri}'.");
                     BaseVstsAuthentication vstsAuth = authentication as BaseVstsAuthentication;
                     vstsAuth.DeleteCredentials(operationArguments.TargetUri);
                     // call delete twice to purge any stored ADA tokens
@@ -191,7 +186,7 @@ namespace Microsoft.Alm.Cli
                     break;
 
                 case AuthorityType.GitHub:
-                    Trace.WriteLine("deleting GitHub credentials.");
+                    Git.Trace.WriteLine("deleting GitHub credentials for '{operationArguments.TargetUri}'.");
                     GitHubAuthentication ghAuth = authentication as GitHubAuthentication;
                     ghAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
@@ -200,6 +195,7 @@ namespace Microsoft.Alm.Cli
             return;
 
             error_parse:
+            Git.Trace.WriteLine($"Fatal: unable to parse target URI.");
             Console.Error.WriteLine("Fatal: unable to parse target URI.");
         }
 
@@ -208,7 +204,7 @@ namespace Microsoft.Alm.Cli
             var installer = new Installer();
             installer.DeployConsole();
 
-            Trace.WriteLine($"Installer result = '{installer.Result}', exit code = {installer.ExitCode}.");
+            Git.Trace.WriteLine($"Installer result = '{installer.Result}', exit code = {installer.ExitCode}.");
 
             Environment.Exit(installer.ExitCode);
         }
@@ -229,7 +225,7 @@ namespace Microsoft.Alm.Cli
 
             if (operationArguments.PreserveCredentials)
             {
-                Trace.WriteLine($"{ConfigPreserveCredentialsKey} = true, canceling erase request.");
+                Git.Trace.WriteLine($"{ConfigPreserveCredentialsKey} = true, canceling erase request.");
                 return;
             }
 
@@ -323,7 +319,7 @@ namespace Microsoft.Alm.Cli
                     Console.Error.WriteLine("   " + innerException.Message);
                 }
 
-                Trace.WriteLine("Fatal: " + exception.ToString());
+                Git.Trace.WriteLine("Fatal: " + exception.ToString());
                 LogEvent(exception.ToString(), EventLogEntryType.Error);
 
                 Environment.ExitCode = -1;
@@ -336,7 +332,7 @@ namespace Microsoft.Alm.Cli
                     Console.Error.WriteLine("   " + exception.Message);
                 }
 
-                Trace.WriteLine("Fatal: " + exception.ToString());
+                Git.Trace.WriteLine("Fatal: " + exception.ToString());
                 LogEvent(exception.ToString(), EventLogEntryType.Error);
 
                 Environment.ExitCode = -1;
@@ -403,7 +399,7 @@ namespace Microsoft.Alm.Cli
             var installer = new Installer();
             installer.RemoveConsole();
 
-            Trace.WriteLine($"Installer result = {installer.Result}, exit code = {installer.ExitCode}.");
+            Git.Trace.WriteLine($"Installer result = {installer.Result}, exit code = {installer.ExitCode}.");
 
             Environment.Exit(installer.ExitCode);
         }

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -302,11 +302,11 @@ namespace Microsoft.Alm.Cli
             Uri tmp = null;
             if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
             {
-                Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
+                Git.Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
             }
             else
             {
-                Trace.WriteLine("proxy cleared.");
+                Git.Trace.WriteLine("proxy cleared.");
             }
             this.ProxyUri = tmp;
         }

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -307,11 +307,11 @@ namespace Microsoft.Alm.Cli
             Uri tmp = null;
             if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
             {
-                Trace.WriteLine("   successfully set proxy to " + tmp.AbsoluteUri + ".");
+                Trace.WriteLine("successfully set proxy to " + tmp.AbsoluteUri + ".");
             }
             else
             {
-                Trace.WriteLine("   proxy cleared.");
+                Trace.WriteLine("proxy cleared.");
             }
             this.ProxyUri = tmp;
         }
@@ -448,7 +448,7 @@ namespace Microsoft.Alm.Cli
 
             _queryUri = new Uri(queryUrl);
 
-            Trace.WriteLine($"   created {_queryUri}");
+            Trace.WriteLine("created " + _queryUri);
 
             _targetUri = new TargetUri(_queryUri, _proxyUri);
         }

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -23,12 +23,11 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using Microsoft.Alm.Authentication;
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Microsoft.Alm.Authentication;
-using System.Collections.Generic;
 
 namespace Microsoft.Alm.Cli
 {
@@ -294,20 +293,16 @@ namespace Microsoft.Alm.Cli
 
         public void SetCredentials(Credential credentials)
         {
-            Trace.WriteLine("OperationArguments::SetCredentials");
-
             _username = credentials.Username;
             _password = credentials.Password;
         }
 
         public void SetProxy(string url)
         {
-            Trace.WriteLine("OperationArguments::SetProxy");
-
             Uri tmp = null;
             if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
             {
-                Trace.WriteLine("successfully set proxy to " + tmp.AbsoluteUri + ".");
+                Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
             }
             else
             {
@@ -354,9 +349,9 @@ namespace Microsoft.Alm.Cli
         public void WriteToStream(Stream writableStream)
         {
             if (ReferenceEquals(writableStream, null))
-                throw new ArgumentNullException("writableStream");
+                throw new ArgumentNullException(nameof(writableStream));
             if (!writableStream.CanWrite)
-                throw new ArgumentException("writableStream");
+                throw new ArgumentException(nameof(writableStream));
 
             // Git reads/writes UTF-8, we'll explicitly encode to Utf-8 to
             // avoid NetFx or the operating system making the wrong encoding
@@ -370,8 +365,6 @@ namespace Microsoft.Alm.Cli
 
         internal void CreateTargetUri()
         {
-            Trace.WriteLine("OperationArguments::CreateTargetUri");
-
             string queryUrl = null;
 
             // when the target requests a path...
@@ -447,8 +440,6 @@ namespace Microsoft.Alm.Cli
             }
 
             _queryUri = new Uri(queryUrl);
-
-            Trace.WriteLine("created " + _queryUri);
 
             _targetUri = new TargetUri(_queryUri, _proxyUri);
         }

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -146,18 +146,16 @@ namespace Microsoft.Alm.Cli
 
             try
             {
-                Trace.WriteLine("Program::LogEvent");
-
                 if (!EventLog.SourceExists(EventSource))
                 {
                     EventLog.CreateEventSource(EventSource, "Application");
 
-                    Trace.WriteLine("event source created");
+                    Trace.WriteLine("event source created.");
                 }
 
                 EventLog.WriteEntry(EventSource, message, eventType);
 
-                Trace.WriteLine("" + eventType + "event written");
+                Trace.WriteLine($"'{eventType}' event written.");
             }
             catch
             {
@@ -173,14 +171,12 @@ namespace Microsoft.Alm.Cli
 
             Debug.Assert(targetUri != null);
 
-            Trace.WriteLine("Program::BasicCredentialPrompt");
-
             username = null;
             password = null;
 
             if (!StandardErrorIsTty || !StandardInputIsTty)
             {
-                Trace.WriteLine("  not a tty detected, abandoning prompt.");
+                Trace.WriteLine("not a tty detected, abandoning prompt.");
                 return false;
             }
 
@@ -206,7 +202,7 @@ namespace Microsoft.Alm.Cli
                     throw new Win32Exception(error, "Unable to determine console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                 }
 
-                Trace.WriteLine("console mode = " + consoleMode);
+                Trace.WriteLine($"console mode = '{consoleMode}'.");
 
                 // instruct the user as to what they are expected to do
                 buffer.Append(titleMessage)
@@ -257,7 +253,7 @@ namespace Microsoft.Alm.Cli
                         throw new Win32Exception(error, "Unable to set console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                     }
 
-                    Trace.WriteLine("console mode = " + consoleMode2);
+                    Trace.WriteLine($"console mode = '{consoleMode2}'.");
 
                     // prompt the user for password
                     buffer.Append("password: ");
@@ -291,7 +287,7 @@ namespace Microsoft.Alm.Cli
                         throw new Win32Exception(error, "Unable to set console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                     }
 
-                    Trace.WriteLine("console mode = " + consoleMode);
+                    Trace.WriteLine($"console mode = '{consoleMode}'.");
                 }
             }
 
@@ -304,8 +300,6 @@ namespace Microsoft.Alm.Cli
             Debug.Assert(operationArguments != null, "The operationArguments is null");
             Debug.Assert(operationArguments.TargetUri != null, "The operationArgument.TargetUri is null");
 
-            Trace.WriteLine("Program::CreateAuthentication");
-
             var secretsNamespace = operationArguments.CustomNamespace ?? SecretsNamespace;
             var secrets = new SecretStore(secretsNamespace, null, null, Secret.UriToName);
             BaseAuthentication authority = null;
@@ -313,7 +307,7 @@ namespace Microsoft.Alm.Cli
             switch (operationArguments.Authority)
             {
                 case AuthorityType.Auto:
-                    Trace.WriteLine("detecting authority type");
+                    Trace.WriteLine("detecting authority type.");
 
                     // detect the authority
                     authority = BaseVstsAuthentication.GetAuthentication(operationArguments.TargetUri,
@@ -354,7 +348,7 @@ namespace Microsoft.Alm.Cli
                     goto case AuthorityType.Basic;
 
                 case AuthorityType.AzureDirectory:
-                    Trace.WriteLine("authority is Azure Directory");
+                    Trace.WriteLine("authority is Azure Directory.");
 
                     Guid tenantId = Guid.Empty;
                     // return the allocated authority or a generic AAD backed VSTS authentication object
@@ -362,13 +356,13 @@ namespace Microsoft.Alm.Cli
 
                 case AuthorityType.Basic:
                 default:
-                    Trace.WriteLine("authority is basic");
+                    Trace.WriteLine("authority is basic.");
 
                     // return a generic username + password authentication object
                     return authority ?? new BasicAuthentication(secrets);
 
                 case AuthorityType.GitHub:
-                    Trace.WriteLine("authority it GitHub");
+                    Trace.WriteLine("authority it GitHub.");
 
                     // return a GitHub authentication object
                     return authority ?? new GitHubAuthentication(GitHubCredentialScope,
@@ -382,7 +376,7 @@ namespace Microsoft.Alm.Cli
                                                                  null);
 
                 case AuthorityType.MicrosoftAccount:
-                    Trace.WriteLine("authority is Microsoft Live");
+                    Trace.WriteLine("authority is Microsoft Live.");
 
                     // return the allocated authority or a generic MSA backed VSTS authentication object
                     return authority ?? new VstsMsaAuthentication(VstsCredentialScope, secrets);
@@ -394,28 +388,25 @@ namespace Microsoft.Alm.Cli
             if (ReferenceEquals(operationArguments, null))
                 throw new ArgumentNullException("operationArguments");
 
-            Trace.WriteLine("Program::DeleteCredentials");
-            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
-
             BaseAuthentication authentication = CreateAuthentication(operationArguments);
 
             switch (operationArguments.Authority)
             {
                 default:
                 case AuthorityType.Basic:
-                    Trace.WriteLine("deleting basic credentials");
+                    Trace.WriteLine("deleting basic credentials.");
                     authentication.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
-                    Trace.WriteLine("deleting VSTS credentials");
+                    Trace.WriteLine("deleting VSTS credentials.");
                     BaseVstsAuthentication vstsAuth = authentication as BaseVstsAuthentication;
                     vstsAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.GitHub:
-                    Trace.WriteLine("deleting GitHub credentials");
+                    Trace.WriteLine("deleting GitHub credentials.");
                     GitHubAuthentication ghAuth = authentication as GitHubAuthentication;
                     ghAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
@@ -424,10 +415,6 @@ namespace Microsoft.Alm.Cli
 
         private static void LoadOperationArguments(OperationArguments operationArguments)
         {
-            Debug.Assert(operationArguments != null, "The operationsArguments parameter is null.");
-
-            Trace.WriteLine("Program::LoadOperationArguments");
-
             if (operationArguments.TargetUri == null)
             {
                 Console.Error.WriteLine("fatal: no host information, unable to continue.");
@@ -458,7 +445,7 @@ namespace Microsoft.Alm.Cli
             // look for authority config settings
             if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigAuthortyKey, out entry))
             {
-                Trace.WriteLine("" + ConfigAuthortyKey + " = " + entry.Value);
+                Trace.WriteLine($"{ConfigAuthortyKey} = '{entry.Value}'.");
 
                 if (ConfigKeyComparer.Equals(entry.Value, "MSA")
                     || ConfigKeyComparer.Equals(entry.Value, "Microsoft")
@@ -499,11 +486,11 @@ namespace Microsoft.Alm.Cli
             if (envars.TryGetValue(EnvironInteractiveKey, out interativeValue)
                 && !string.IsNullOrWhiteSpace(interativeValue))
             {
-                Trace.WriteLine("" + EnvironInteractiveKey + " = " + interativeValue);
+                Trace.WriteLine($"{EnvironInteractiveKey} = '{interativeValue}'.");
             }
             else if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigInteractiveKey, out entry))
             {
-                Trace.WriteLine("" + ConfigInteractiveKey + " = " + entry.Value);
+                Trace.WriteLine($"{ConfigInteractiveKey} = '{entry.Value}'.");
 
                 interativeValue = entry.Value;
             }
@@ -562,7 +549,7 @@ namespace Microsoft.Alm.Cli
             if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigHttpProxyKey, out entry)
                 || config.TryGetEntry("http", operationArguments.QueryUri, "proxy", out entry))
             {
-                Trace.WriteLine("" + ConfigHttpProxyKey + " = " + entry.Value);
+                Trace.WriteLine($"{ConfigHttpProxyKey} = '{entry.Value}'.");
 
                 operationArguments.SetProxy(entry.Value);
             }
@@ -570,10 +557,33 @@ namespace Microsoft.Alm.Cli
             // look for custom namespace config settings
             if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigNamespaceKey, out entry))
             {
-                Trace.WriteLine("" + ConfigNamespaceKey + " = " + entry.Value);
+                Trace.WriteLine($"{ConfigNamespaceKey} = '{entry.Value}'.");
 
                 operationArguments.CustomNamespace = entry.Value;
             }
+        }
+
+        private static void PrintArgs(string[] args)
+        {
+            Debug.Assert(args != null, $"The `{nameof(args)}` parameter is null.");
+
+            StringBuilder builder = new StringBuilder();
+            builder.Append(Program.Name);
+
+            for (int i = 0; i < args.Length; i += 1)
+            {
+                builder.Append(" '")
+                       .Append(args[i])
+                       .Append("'");
+
+                if (i + 1 < args.Length)
+                {
+                    builder.Append(",");
+                }
+            }
+
+            Trace.WriteLine(builder.ToString());
+            builder = null;
         }
 
         [Conditional("DEBUG")]
@@ -585,16 +595,14 @@ namespace Microsoft.Alm.Cli
 
         private static void EnableTraceLogging(OperationArguments operationArguments)
         {
-            Trace.WriteLine("Program::EnableTraceLogging");
-
             if (operationArguments.WriteLog)
             {
-                Trace.WriteLine("trace logging enabled");
+                Trace.WriteLine("trace logging enabled.");
 
                 string gitConfigPath;
                 if (Where.GitLocalConfig(out gitConfigPath))
                 {
-                    Trace.WriteLine("git local config found at " + gitConfigPath);
+                    Trace.WriteLine($"git local config found at '{gitConfigPath}'.");
 
                     string gitDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -605,7 +613,7 @@ namespace Microsoft.Alm.Cli
                 }
                 else if (Where.GitGlobalConfig(out gitConfigPath))
                 {
-                    Trace.WriteLine("git global config found at " + gitConfigPath);
+                    Trace.WriteLine($"git global config found at '{gitConfigPath}'.");
 
                     string homeDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -639,7 +647,7 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Trace.WriteLine("trace log destination is " + logFilePath);
+            Trace.WriteLine($"trace log destination is '{logFilePath}'.");
 
             var fileStream = File.Open(logFileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
             var listener = new StreamWriter(fileStream, Encoding.UTF8);
@@ -647,8 +655,8 @@ namespace Microsoft.Alm.Cli
 
             // write a small header to help with identifying new log entries
             listener.WriteLine(Environment.NewLine);
-            listener.WriteLine(String.Format("Log Start ({0:u})", DateTimeOffset.Now));
-            listener.WriteLine(String.Format("Microsoft {0} version {1}", Program.Title, Version.ToString(3)));
+            listener.WriteLine($"Log Start ({DateTimeOffset.Now:u})");
+            listener.WriteLine($"Microsoft {Program.Title} version {Version.ToString(3)}");
         }
 
         private static bool GitHubAuthCodePrompt(TargetUri targetUri, GitHubAuthenticationResultType resultType, string username, out string authenticationCode)
@@ -658,8 +666,6 @@ namespace Microsoft.Alm.Cli
             const int BufferReadSize = 16 * 1024;
 
             Debug.Assert(targetUri != null);
-
-            Trace.WriteLine("Program::GitHubAuthCodePrompt");
 
             StringBuilder buffer = new StringBuilder(BufferReadSize);
             uint read = 0;
@@ -679,7 +685,7 @@ namespace Microsoft.Alm.Cli
                     ? "app"
                     : "sms";
 
-                Trace.WriteLine("2fa type = " + type);
+                Trace.WriteLine($"2fa type = '{type}'.");
 
                 buffer.AppendLine()
                       .Append("authcode (")
@@ -711,8 +717,6 @@ namespace Microsoft.Alm.Cli
         {
             const string TitleMessage = "Please enter your GitHub credentials for ";
 
-            Trace.WriteLine("Program::GitHubCredentialPrompt");
-
             return BasicCredentialPrompt(targetUri, TitleMessage, out username, out password);
         }
 
@@ -731,8 +735,6 @@ namespace Microsoft.Alm.Cli
         {
             Debug.Assert(targetUri != null);
             Debug.Assert(message != null);
-
-            Trace.WriteLine("Program::ModalPromptForCredemtials");
 
             NativeMethods.CredentialUiInfo credUiInfo = new NativeMethods.CredentialUiInfo
             {
@@ -764,8 +766,6 @@ namespace Microsoft.Alm.Cli
 
         private static bool ModalPromptForCredentials(TargetUri targetUri, out string username, out string password)
         {
-            Trace.WriteLine("Program::ModalPromptForCredemtials");
-
             string message = String.Format("Enter your credentials for {0}.", targetUri);
             return ModalPromptForCredentials(targetUri, message, out username, out password);
         }
@@ -775,8 +775,6 @@ namespace Microsoft.Alm.Cli
             Debug.Assert(targetUri != null);
             Debug.Assert(message != null);
             Debug.Assert(username != null);
-
-            Trace.WriteLine("Program::ModalPromptForPassword");
 
             NativeMethods.CredentialUiInfo credUiInfo = new NativeMethods.CredentialUiInfo
             {
@@ -808,7 +806,7 @@ namespace Microsoft.Alm.Cli
                 if (inBufferSize <= 0)
                 {
                     error = Marshal.GetLastWin32Error();
-                    Trace.WriteLine("unable to determine credential buffer size (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine($"unable to determine credential buffer size ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     username = null;
                     password = null;
@@ -825,7 +823,7 @@ namespace Microsoft.Alm.Cli
                                                                 packedCredentialsSize: ref inBufferSize))
                 {
                     error = Marshal.GetLastWin32Error();
-                    Trace.WriteLine("unable to write to credential buffer (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine($"unable to write to credential buffer ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     username = null;
                     password = null;
@@ -930,8 +928,6 @@ namespace Microsoft.Alm.Cli
 
         private static void PrintVersion()
         {
-            Trace.WriteLine("Program::PrintVersion");
-
             Console.Out.WriteLine("{0} version {1}", Title, Version.ToString(3));
         }
 
@@ -945,9 +941,6 @@ namespace Microsoft.Alm.Cli
             if (ReferenceEquals(operationArguments.TargetUri, null))
                 throw new ArgumentNullException("operationArguments.TargetUri");
 
-            Trace.WriteLine("Program::QueryCredentials");
-            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
-
             BaseAuthentication authentication = CreateAuthentication(operationArguments);
             Credential credentials = null;
 
@@ -957,7 +950,7 @@ namespace Microsoft.Alm.Cli
                 case AuthorityType.Basic:
                     if ((credentials = authentication.GetCredentials(operationArguments.TargetUri)) != null)
                     {
-                        Trace.WriteLine("credentials found");
+                        Trace.WriteLine("credentials found.");
                         operationArguments.SetCredentials(credentials);
                     }
                     else if (operationArguments.Interactivity != Interactivity.Never)
@@ -971,7 +964,7 @@ namespace Microsoft.Alm.Cli
                             || (!operationArguments.UseModalUi
                                 && BasicCredentialPrompt(operationArguments.TargetUri, null, out username, out password)))
                         {
-                            Trace.WriteLine("credentials found");
+                            Trace.WriteLine("credentials found.");
                             // set the credentials object
                             // no need to save the credentials explicitly, as Git will call back
                             // with a store command if the credentials are valid.
@@ -1001,7 +994,7 @@ namespace Microsoft.Alm.Cli
                             && (!operationArguments.ValidateCredentials
                                 || await aadAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Trace.WriteLine("credentials found");
+                            Trace.WriteLine("credentials found.");
                             operationArguments.SetCredentials(credentials);
                             LogEvent("Azure Directory credentials for " + operationArguments.TargetUri + " successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
@@ -1029,7 +1022,7 @@ namespace Microsoft.Alm.Cli
                             && (!operationArguments.ValidateCredentials
                                 || await msaAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Trace.WriteLine("credentials found");
+                            Trace.WriteLine("credentials found.");
                             operationArguments.SetCredentials(credentials);
                             LogEvent("Microsoft Live credentials for " + operationArguments.TargetUri + " successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
@@ -1055,7 +1048,7 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await ghAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Trace.WriteLine("credentials found");
+                            Trace.WriteLine("credentials found.");
                             operationArguments.SetCredentials(credentials);
                             LogEvent("GitHub credentials for " + operationArguments.TargetUri + " successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
@@ -1088,8 +1081,6 @@ namespace Microsoft.Alm.Cli
             if (ReferenceEquals(configKey, null))
                 throw new ArgumentNullException(nameof(configKey));
 
-            Trace.WriteLine("Program::TryReadBoolean");
-
             var config = operationArguments.GitConfiguration;
             var envars = operationArguments.EnvironmentVariables;
 
@@ -1100,13 +1091,13 @@ namespace Microsoft.Alm.Cli
             if (!string.IsNullOrWhiteSpace(environKey)
                 && envars.TryGetValue(environKey, out valueString))
             {
-                Trace.WriteLine("" + environKey + " = " + valueString);
+                Trace.WriteLine($"{environKey} = '{valueString}'.");
             }
 
             if (!string.IsNullOrWhiteSpace(valueString)
                 || config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, configKey, out entry))
             {
-                Trace.WriteLine("" + configKey + " = " + entry.Value);
+                Trace.WriteLine($"{configKey} = '{entry.Value}'.");
                 valueString = entry.Value;
             }
 
@@ -1145,8 +1136,6 @@ namespace Microsoft.Alm.Cli
             out string username,
             out string password)
         {
-            Trace.WriteLine("Program::ModalPromptDisplayDialog");
-
             int error;
 
             try
@@ -1162,7 +1151,7 @@ namespace Microsoft.Alm.Cli
                                                                              saveCredentials: ref saveCredentials,
                                                                              flags: flags)) != NativeMethods.Win32Error.Success)
                 {
-                    Trace.WriteLine("credential prompt failed (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine($"credential prompt failed ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     username = null;
                     password = null;
@@ -1193,7 +1182,7 @@ namespace Microsoft.Alm.Cli
                     password = null;
 
                     error = Marshal.GetLastWin32Error();
-                    Trace.WriteLine("failed to unpack buffer (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine($"failed to unpack buffer ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     return false;
                 }

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Alm.Cli
         internal const string EnvironWritelogKey = "GCM_WRITELOG";
         internal const string EnvironConfigNoLocalKey = "GCM_CONFIG_NOLOCAL";
         internal const string EnvironConfigNoSystemKey = "GCM_CONFIG_NOSYSTEM";
+        internal const string EnvironConfigTraceKey = Git.Trace.EnvironmentVariableKey;
 
         internal static readonly StringComparer EnvironKeyComparer = StringComparer.OrdinalIgnoreCase;
 
@@ -151,16 +152,16 @@ namespace Microsoft.Alm.Cli
                 {
                     EventLog.CreateEventSource(EventSource, "Application");
 
-                    Trace.WriteLine("   event source created");
+                    Trace.WriteLine("event source created");
                 }
 
                 EventLog.WriteEntry(EventSource, message, eventType);
 
-                Trace.WriteLine("   " + eventType + "event written");
+                Trace.WriteLine("" + eventType + "event written");
             }
             catch
             {
-                Trace.WriteLine("   failed ot log event.");
+                Trace.WriteLine("failed ot log event.");
             }
         }
 
@@ -205,7 +206,7 @@ namespace Microsoft.Alm.Cli
                     throw new Win32Exception(error, "Unable to determine console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                 }
 
-                Trace.WriteLine("   console mode = " + consoleMode);
+                Trace.WriteLine("console mode = " + consoleMode);
 
                 // instruct the user as to what they are expected to do
                 buffer.Append(titleMessage)
@@ -256,7 +257,7 @@ namespace Microsoft.Alm.Cli
                         throw new Win32Exception(error, "Unable to set console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                     }
 
-                    Trace.WriteLine("   console mode = " + consoleMode2);
+                    Trace.WriteLine("console mode = " + consoleMode2);
 
                     // prompt the user for password
                     buffer.Append("password: ");
@@ -290,7 +291,7 @@ namespace Microsoft.Alm.Cli
                         throw new Win32Exception(error, "Unable to set console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                     }
 
-                    Trace.WriteLine("   console mode = " + consoleMode);
+                    Trace.WriteLine("console mode = " + consoleMode);
                 }
             }
 
@@ -312,7 +313,7 @@ namespace Microsoft.Alm.Cli
             switch (operationArguments.Authority)
             {
                 case AuthorityType.Auto:
-                    Trace.WriteLine("   detecting authority type");
+                    Trace.WriteLine("detecting authority type");
 
                     // detect the authority
                     authority = BaseVstsAuthentication.GetAuthentication(operationArguments.TargetUri,
@@ -353,7 +354,7 @@ namespace Microsoft.Alm.Cli
                     goto case AuthorityType.Basic;
 
                 case AuthorityType.AzureDirectory:
-                    Trace.WriteLine("   authority is Azure Directory");
+                    Trace.WriteLine("authority is Azure Directory");
 
                     Guid tenantId = Guid.Empty;
                     // return the allocated authority or a generic AAD backed VSTS authentication object
@@ -361,13 +362,13 @@ namespace Microsoft.Alm.Cli
 
                 case AuthorityType.Basic:
                 default:
-                    Trace.WriteLine("   authority is basic");
+                    Trace.WriteLine("authority is basic");
 
                     // return a generic username + password authentication object
                     return authority ?? new BasicAuthentication(secrets);
 
                 case AuthorityType.GitHub:
-                    Trace.WriteLine("   authority it GitHub");
+                    Trace.WriteLine("authority it GitHub");
 
                     // return a GitHub authentication object
                     return authority ?? new GitHubAuthentication(GitHubCredentialScope,
@@ -381,7 +382,7 @@ namespace Microsoft.Alm.Cli
                                                                  null);
 
                 case AuthorityType.MicrosoftAccount:
-                    Trace.WriteLine("   authority is Microsoft Live");
+                    Trace.WriteLine("authority is Microsoft Live");
 
                     // return the allocated authority or a generic MSA backed VSTS authentication object
                     return authority ?? new VstsMsaAuthentication(VstsCredentialScope, secrets);
@@ -394,7 +395,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentNullException("operationArguments");
 
             Trace.WriteLine("Program::DeleteCredentials");
-            Trace.WriteLine("   targetUri = " + operationArguments.TargetUri);
+            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
 
             BaseAuthentication authentication = CreateAuthentication(operationArguments);
 
@@ -402,19 +403,19 @@ namespace Microsoft.Alm.Cli
             {
                 default:
                 case AuthorityType.Basic:
-                    Trace.WriteLine("   deleting basic credentials");
+                    Trace.WriteLine("deleting basic credentials");
                     authentication.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
-                    Trace.WriteLine("   deleting VSTS credentials");
+                    Trace.WriteLine("deleting VSTS credentials");
                     BaseVstsAuthentication vstsAuth = authentication as BaseVstsAuthentication;
                     vstsAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.GitHub:
-                    Trace.WriteLine("   deleting GitHub credentials");
+                    Trace.WriteLine("deleting GitHub credentials");
                     GitHubAuthentication ghAuth = authentication as GitHubAuthentication;
                     ghAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
@@ -457,7 +458,7 @@ namespace Microsoft.Alm.Cli
             // look for authority config settings
             if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigAuthortyKey, out entry))
             {
-                Trace.WriteLine("   " + ConfigAuthortyKey + " = " + entry.Value);
+                Trace.WriteLine("" + ConfigAuthortyKey + " = " + entry.Value);
 
                 if (ConfigKeyComparer.Equals(entry.Value, "MSA")
                     || ConfigKeyComparer.Equals(entry.Value, "Microsoft")
@@ -498,11 +499,11 @@ namespace Microsoft.Alm.Cli
             if (envars.TryGetValue(EnvironInteractiveKey, out interativeValue)
                 && !string.IsNullOrWhiteSpace(interativeValue))
             {
-                Trace.WriteLine("   " + EnvironInteractiveKey + " = " + interativeValue);
+                Trace.WriteLine("" + EnvironInteractiveKey + " = " + interativeValue);
             }
             else if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigInteractiveKey, out entry))
             {
-                Trace.WriteLine("   " + ConfigInteractiveKey + " = " + entry.Value);
+                Trace.WriteLine("" + ConfigInteractiveKey + " = " + entry.Value);
 
                 interativeValue = entry.Value;
             }
@@ -561,7 +562,7 @@ namespace Microsoft.Alm.Cli
             if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigHttpProxyKey, out entry)
                 || config.TryGetEntry("http", operationArguments.QueryUri, "proxy", out entry))
             {
-                Trace.WriteLine("   " + ConfigHttpProxyKey + " = " + entry.Value);
+                Trace.WriteLine("" + ConfigHttpProxyKey + " = " + entry.Value);
 
                 operationArguments.SetProxy(entry.Value);
             }
@@ -569,7 +570,7 @@ namespace Microsoft.Alm.Cli
             // look for custom namespace config settings
             if (config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, ConfigNamespaceKey, out entry))
             {
-                Trace.WriteLine("   " + ConfigNamespaceKey + " = " + entry.Value);
+                Trace.WriteLine("" + ConfigNamespaceKey + " = " + entry.Value);
 
                 operationArguments.CustomNamespace = entry.Value;
             }
@@ -579,7 +580,7 @@ namespace Microsoft.Alm.Cli
         private static void EnableDebugTrace()
         {
             // use the stderr stream for the trace as stdout is used in the cross-process communications protocol
-            Trace.Listeners.Add(new ConsoleTraceListener(useErrorStream: true));
+            Trace.AddListener(Console.Error);
         }
 
         private static void EnableTraceLogging(OperationArguments operationArguments)
@@ -588,12 +589,12 @@ namespace Microsoft.Alm.Cli
 
             if (operationArguments.WriteLog)
             {
-                Trace.WriteLine("   trace logging enabled");
+                Trace.WriteLine("trace logging enabled");
 
                 string gitConfigPath;
                 if (Where.GitLocalConfig(out gitConfigPath))
                 {
-                    Trace.WriteLine("   git local config found at " + gitConfigPath);
+                    Trace.WriteLine("git local config found at " + gitConfigPath);
 
                     string gitDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -604,7 +605,7 @@ namespace Microsoft.Alm.Cli
                 }
                 else if (Where.GitGlobalConfig(out gitConfigPath))
                 {
-                    Trace.WriteLine("   git global config found at " + gitConfigPath);
+                    Trace.WriteLine("git global config found at " + gitConfigPath);
 
                     string homeDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -638,10 +639,11 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Trace.WriteLine("   trace log destination is " + logFilePath);
+            Trace.WriteLine("trace log destination is " + logFilePath);
 
-            var listener = new TextWriterTraceListener(logFilePath, logFileName);
-            Trace.Listeners.Add(listener);
+            var fileStream = File.Open(logFileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
+            var listener = new StreamWriter(fileStream, Encoding.UTF8);
+            Trace.AddListener(listener);
 
             // write a small header to help with identifying new log entries
             listener.WriteLine(Environment.NewLine);
@@ -677,7 +679,7 @@ namespace Microsoft.Alm.Cli
                     ? "app"
                     : "sms";
 
-                Trace.WriteLine("   2fa type = " + type);
+                Trace.WriteLine("2fa type = " + type);
 
                 buffer.AppendLine()
                       .Append("authcode (")
@@ -806,7 +808,7 @@ namespace Microsoft.Alm.Cli
                 if (inBufferSize <= 0)
                 {
                     error = Marshal.GetLastWin32Error();
-                    Trace.WriteLine("   unable to determine credential buffer size (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine("unable to determine credential buffer size (" + NativeMethods.Win32Error.GetText(error) + ").");
 
                     username = null;
                     password = null;
@@ -823,7 +825,7 @@ namespace Microsoft.Alm.Cli
                                                                 packedCredentialsSize: ref inBufferSize))
                 {
                     error = Marshal.GetLastWin32Error();
-                    Trace.WriteLine("   unable to write to credential buffer (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine("unable to write to credential buffer (" + NativeMethods.Win32Error.GetText(error) + ").");
 
                     username = null;
                     password = null;
@@ -944,7 +946,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentNullException("operationArguments.TargetUri");
 
             Trace.WriteLine("Program::QueryCredentials");
-            Trace.WriteLine("   targetUri = " + operationArguments.TargetUri);
+            Trace.WriteLine("targetUri = " + operationArguments.TargetUri);
 
             BaseAuthentication authentication = CreateAuthentication(operationArguments);
             Credential credentials = null;
@@ -955,7 +957,7 @@ namespace Microsoft.Alm.Cli
                 case AuthorityType.Basic:
                     if ((credentials = authentication.GetCredentials(operationArguments.TargetUri)) != null)
                     {
-                        Trace.WriteLine("   credentials found");
+                        Trace.WriteLine("credentials found");
                         operationArguments.SetCredentials(credentials);
                     }
                     else if (operationArguments.Interactivity != Interactivity.Never)
@@ -969,7 +971,7 @@ namespace Microsoft.Alm.Cli
                             || (!operationArguments.UseModalUi
                                 && BasicCredentialPrompt(operationArguments.TargetUri, null, out username, out password)))
                         {
-                            Trace.WriteLine("   credentials found");
+                            Trace.WriteLine("credentials found");
                             // set the credentials object
                             // no need to save the credentials explicitly, as Git will call back
                             // with a store command if the credentials are valid.
@@ -999,7 +1001,7 @@ namespace Microsoft.Alm.Cli
                             && (!operationArguments.ValidateCredentials
                                 || await aadAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Trace.WriteLine("   credentials found");
+                            Trace.WriteLine("credentials found");
                             operationArguments.SetCredentials(credentials);
                             LogEvent("Azure Directory credentials for " + operationArguments.TargetUri + " successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
@@ -1027,7 +1029,7 @@ namespace Microsoft.Alm.Cli
                             && (!operationArguments.ValidateCredentials
                                 || await msaAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Trace.WriteLine("   credentials found");
+                            Trace.WriteLine("credentials found");
                             operationArguments.SetCredentials(credentials);
                             LogEvent("Microsoft Live credentials for " + operationArguments.TargetUri + " successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
@@ -1053,7 +1055,7 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await ghAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Trace.WriteLine("   credentials found");
+                            Trace.WriteLine("credentials found");
                             operationArguments.SetCredentials(credentials);
                             LogEvent("GitHub credentials for " + operationArguments.TargetUri + " successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
@@ -1098,13 +1100,13 @@ namespace Microsoft.Alm.Cli
             if (!string.IsNullOrWhiteSpace(environKey)
                 && envars.TryGetValue(environKey, out valueString))
             {
-                Trace.WriteLine("   " + environKey + " = " + valueString);
+                Trace.WriteLine("" + environKey + " = " + valueString);
             }
 
             if (!string.IsNullOrWhiteSpace(valueString)
                 || config.TryGetEntry(ConfigPrefix, operationArguments.QueryUri, configKey, out entry))
             {
-                Trace.WriteLine("   " + configKey + " = " + entry.Value);
+                Trace.WriteLine("" + configKey + " = " + entry.Value);
                 valueString = entry.Value;
             }
 
@@ -1160,7 +1162,7 @@ namespace Microsoft.Alm.Cli
                                                                              saveCredentials: ref saveCredentials,
                                                                              flags: flags)) != NativeMethods.Win32Error.Success)
                 {
-                    Trace.WriteLine("   credential prompt failed (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine("credential prompt failed (" + NativeMethods.Win32Error.GetText(error) + ").");
 
                     username = null;
                     password = null;
@@ -1191,12 +1193,12 @@ namespace Microsoft.Alm.Cli
                     password = null;
 
                     error = Marshal.GetLastWin32Error();
-                    Trace.WriteLine("   failed to unpack buffer (" + NativeMethods.Win32Error.GetText(error) + ").");
+                    Trace.WriteLine("failed to unpack buffer (" + NativeMethods.Win32Error.GetText(error) + ").");
 
                     return false;
                 }
 
-                Trace.WriteLine("   successfully acquired credentials from user.");
+                Trace.WriteLine("successfully acquired credentials from user.");
 
                 username = usernameBuffer.ToString();
                 password = passwordBuffer.ToString();

--- a/CommonShared/CommonShared.projitems
+++ b/CommonShared/CommonShared.projitems
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>0e1864bd-c462-4600-9c29-06bf8562a9b2</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>CommonShared</Import_RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/CommonShared/CommonShared.shproj
+++ b/CommonShared/CommonShared.shproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>0e1864bd-c462-4600-9c29-06bf8562a9b2</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="CommonShared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/GitHub.Authentication/AuthenticationPrompts.cs
+++ b/GitHub.Authentication/AuthenticationPrompts.cs
@@ -18,7 +18,7 @@ namespace GitHub.Authentication
 
             var credentialViewModel = new CredentialsViewModel();
 
-            Trace.WriteLine("   prompting user for credentials.");
+            Trace.WriteLine("prompting user for credentials.");
 
             bool credentialValid = ShowViewModel(credentialViewModel, () => new CredentialsWindow());
 
@@ -34,7 +34,7 @@ namespace GitHub.Authentication
 
             var twoFactorViewModel = new TwoFactorViewModel(resultType == GitHubAuthenticationResultType.TwoFactorSms);
 
-            Trace.WriteLine("   prompting user for authentication code.");
+            Trace.WriteLine("prompting user for authentication code.");
 
             bool authenticationCodeValid = ShowViewModel(twoFactorViewModel, () => new TwoFactorWindow());
 

--- a/GitHub.Authentication/AuthenticationPrompts.cs
+++ b/GitHub.Authentication/AuthenticationPrompts.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using GitHub.Authentication.ViewModels;
 using GitHub.UI;
 using Microsoft.Alm.Authentication;
+using Git = Microsoft.Alm.Git;
 
 namespace GitHub.Authentication
 {
@@ -14,11 +15,9 @@ namespace GitHub.Authentication
     {
         public static bool CredentialModalPrompt(TargetUri targetUri, out string username, out string password)
         {
-            Trace.WriteLine("Program::GitHubCredentialModalPrompt");
-
             var credentialViewModel = new CredentialsViewModel();
 
-            Trace.WriteLine("prompting user for credentials.");
+            Git.Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
 
             bool credentialValid = ShowViewModel(credentialViewModel, () => new CredentialsWindow());
 
@@ -30,11 +29,9 @@ namespace GitHub.Authentication
 
         public static bool AuthenticationCodeModalPrompt(TargetUri targetUri, GitHubAuthenticationResultType resultType, string username, out string authenticationCode)
         {
-            Trace.WriteLine("Program::GitHubAuthcodeModalPrompt");
-
             var twoFactorViewModel = new TwoFactorViewModel(resultType == GitHubAuthenticationResultType.TwoFactorSms);
 
-            Trace.WriteLine("prompting user for authentication code.");
+            Git.Trace.WriteLine($"prompting user for authentication code for '{targetUri}'.");
 
             bool authenticationCodeValid = ShowViewModel(twoFactorViewModel, () => new TwoFactorWindow());
 

--- a/GitHub.Authentication/GitHub.Authentication.csproj
+++ b/GitHub.Authentication/GitHub.Authentication.csproj
@@ -214,10 +214,15 @@
       <Project>{c1daabc1-b493-459d-bb4f-04fbefb1ba13}</Project>
       <Name>Microsoft.Alm.Authentication</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Microsoft.Alm.Git\Microsoft.Alm.Git.csproj">
+      <Project>{4827c16d-5c58-406d-ab3f-3700bb0d06fe}</Project>
+      <Name>Microsoft.Alm.Git</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Assets\octocat-mark.ico" />
   </ItemGroup>
+  <Import Project="..\CommonShared\CommonShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/Microsoft.Alm.Authentication/AzureAuthority.cs
+++ b/Microsoft.Alm.Authentication/AzureAuthority.cs
@@ -98,15 +98,11 @@ namespace Microsoft.Alm.Authentication
             if (!redirectUri.IsAbsoluteUri)
                 throw new ArgumentException(nameof(redirectUri));
 
-            Trace.WriteLine("AzureAuthority::InteractiveAcquireToken");
-
             Token token = null;
             queryParameters = queryParameters ?? String.Empty;
 
             try
             {
-                Trace.WriteLine(String.Format("   authority host URL = '{0}'.", AuthorityHostUrl));
-
                 AuthenticationContext authCtx = new AuthenticationContext(AuthorityHostUrl, _adalTokenCache);
                 AuthenticationResult authResult = await authCtx.AcquireTokenAsync(resource,
                                                                                   clientId,
@@ -117,11 +113,11 @@ namespace Microsoft.Alm.Authentication
 
                 token = new Token(authResult, TokenType.Access);
 
-                Trace.WriteLine("token acquisition succeeded.");
+                Git.Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition succeeded.");
             }
             catch (AdalException)
             {
-                Trace.WriteLine("token acquisition failed.");
+                Git.Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition failed.");
             }
 
             return token;
@@ -158,15 +154,11 @@ namespace Microsoft.Alm.Authentication
             if (!redirectUri.IsAbsoluteUri)
                 throw new ArgumentException(nameof(redirectUri));
 
-            Trace.WriteLine("AzureAuthority::NoninteractiveAcquireToken");
-
             Token token = null;
             queryParameters = queryParameters ?? String.Empty;
 
             try
             {
-                Trace.WriteLine(String.Format("   authority host URL = '{0}'.", AuthorityHostUrl));
-
                 AuthenticationContext authCtx = new AuthenticationContext(AuthorityHostUrl, _adalTokenCache);
                 AuthenticationResult authResult = await authCtx.AcquireTokenAsync(resource,
                                                                                   clientId,
@@ -177,11 +169,11 @@ namespace Microsoft.Alm.Authentication
 
                 token = new Token(authResult, TokenType.Access);
 
-                Trace.WriteLine("token acquisition succeeded.");
+                Git.Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' succeeded.");
             }
             catch (AdalException)
             {
-                Trace.WriteLine("token acquisition failed.");
+                Git.Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' failed.");
             }
 
             return token;

--- a/Microsoft.Alm.Authentication/AzureAuthority.cs
+++ b/Microsoft.Alm.Authentication/AzureAuthority.cs
@@ -117,11 +117,11 @@ namespace Microsoft.Alm.Authentication
 
                 token = new Token(authResult, TokenType.Access);
 
-                Trace.WriteLine("   token acquisition succeeded.");
+                Trace.WriteLine("token acquisition succeeded.");
             }
             catch (AdalException)
             {
-                Trace.WriteLine("   token acquisition failed.");
+                Trace.WriteLine("token acquisition failed.");
             }
 
             return token;
@@ -177,11 +177,11 @@ namespace Microsoft.Alm.Authentication
 
                 token = new Token(authResult, TokenType.Access);
 
-                Trace.WriteLine("   token acquisition succeeded.");
+                Trace.WriteLine("token acquisition succeeded.");
             }
             catch (AdalException)
             {
-                Trace.WriteLine("   token acquisition failed.");
+                Trace.WriteLine("token acquisition failed.");
             }
 
             return token;

--- a/Microsoft.Alm.Authentication/BaseSecureStore.cs
+++ b/Microsoft.Alm.Authentication/BaseSecureStore.cs
@@ -37,8 +37,6 @@ namespace Microsoft.Alm.Authentication
 
         protected void Delete(string targetName)
         {
-            Trace.WriteLine("BaseSecureStore::Delete");
-
             try
             {
                 if (!NativeMethods.CredDelete(targetName, NativeMethods.CredentialType.Generic, 0))
@@ -48,12 +46,16 @@ namespace Microsoft.Alm.Authentication
                     {
                         case NativeMethods.Win32Error.NotFound:
                         case NativeMethods.Win32Error.NoSuchLogonSession:
-                            Trace.WriteLine("   credentials not found for " + targetName);
+                            Git.Trace.WriteLine($"credentials not found for '{targetName}'.");
                             break;
 
                         default:
                             throw new Win32Exception(error, "Failed to delete credentials for " + targetName);
                     }
+                }
+                else
+                {
+                    Git.Trace.WriteLine($"credentials for '{targetName}' deleted from store.");
                 }
             }
             catch (Exception exception)
@@ -89,7 +91,10 @@ namespace Microsoft.Alm.Authentication
                                 Debug.Fail("Failed with error code " + error.ToString("X"));
                             }
                         }
-
+                        else
+                        {
+                            Git.Trace.WriteLine($"credentials for '{@namespace}' purged from store.");
+                        }
                     }
                 }
 
@@ -108,8 +113,6 @@ namespace Microsoft.Alm.Authentication
 
         protected Credential ReadCredentials(string targetName)
         {
-            Trace.WriteLine("BaseSecureStore::ReadCredentials");
-
             Credential credentials = null;
             IntPtr credPtr = IntPtr.Zero;
 
@@ -126,6 +129,8 @@ namespace Microsoft.Alm.Authentication
                     string username = credStruct.UserName ?? String.Empty;
 
                     credentials = new Credential(username, password);
+
+                    Git.Trace.WriteLine($"credentials for '{targetName}' read from store.");
                 }
             }
             finally
@@ -141,8 +146,6 @@ namespace Microsoft.Alm.Authentication
 
         protected Token ReadToken(string targetName)
         {
-            Trace.WriteLine("BaseSecureStore::ReadToken");
-
             Token token = null;
             IntPtr credPtr = IntPtr.Zero;
 
@@ -162,6 +165,8 @@ namespace Microsoft.Alm.Authentication
                         {
                             Token.Deserialize(bytes, type, out token);
                         }
+
+                        Git.Trace.WriteLine($"token for '{targetName}' read from store.");
                     }
                 }
             }
@@ -178,8 +183,6 @@ namespace Microsoft.Alm.Authentication
 
         protected void WriteCredential(string targetName, Credential credentials)
         {
-            Trace.WriteLine("BaseSecureStore::WriteCredential");
-
             NativeMethods.Credential credential = new NativeMethods.Credential()
             {
                 Type = NativeMethods.CredentialType.Generic,
@@ -197,6 +200,8 @@ namespace Microsoft.Alm.Authentication
                     int errorCode = Marshal.GetLastWin32Error();
                     throw new Exception("Failed to write credentials", new Win32Exception(errorCode));
                 }
+
+                Git.Trace.WriteLine($"credentials for '{targetName}' written to store.");
             }
             finally
             {
@@ -209,8 +214,6 @@ namespace Microsoft.Alm.Authentication
 
         protected void WriteToken(string targetName, Token token)
         {
-            Trace.WriteLine("BaseSecureStore::WriteToken");
-
             byte[] bytes = null;
             if (Token.Serialize(token, out bytes))
             {
@@ -236,6 +239,8 @@ namespace Microsoft.Alm.Authentication
                             int errorCode = Marshal.GetLastWin32Error();
                             throw new Exception("Failed to write credentials", new Win32Exception(errorCode));
                         }
+
+                        Git.Trace.WriteLine($"token for '{targetName}' written to store.");
                     }
                     finally
                     {

--- a/Microsoft.Alm.Authentication/BaseVstsAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BaseVstsAuthentication.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Alm.Authentication
 
             if ((credentials = this.PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
             {
-                Trace.WriteLine("   successfully retrieved stored credentials, updating credential cache");
+                Trace.WriteLine("successfully retrieved stored credentials, updating credential cache");
             }
 
             return credentials;
@@ -197,7 +197,7 @@ namespace Microsoft.Alm.Authentication
 
             if (targetUri.ActualUri.Host.EndsWith(VstsBaseUrlHost, StringComparison.OrdinalIgnoreCase))
             {
-                Trace.WriteLine("   detected visualstudio.com, checking AAD vs MSA");
+                Trace.WriteLine("detected visualstudio.com, checking AAD vs MSA");
 
                 string tenant = null;
                 WebResponse response;
@@ -223,7 +223,7 @@ namespace Microsoft.Alm.Authentication
                     // if the response exists and we have headers, parse them
                     if (response != null && response.SupportsHeaders)
                     {
-                        Trace.WriteLine("   server has responded");
+                        Trace.WriteLine("server has responded");
 
                         // find the VSTS resource tenant entry
                         tenant = response.Headers[VstsResourceTenantHeader];
@@ -238,7 +238,7 @@ namespace Microsoft.Alm.Authentication
                 }
             }
 
-            Trace.WriteLine("   failed detection");
+            Trace.WriteLine("failed detection");
 
             // if all else fails, fallback to basic authentication
             return false;
@@ -279,12 +279,12 @@ namespace Microsoft.Alm.Authentication
                 // empty Guid is MSA, anything else is AAD
                 if (tenantId == Guid.Empty)
                 {
-                    Trace.WriteLine("   MSA authority detected");
+                    Trace.WriteLine("MSA authority detected");
                     authentication = new VstsMsaAuthentication(scope, personalAccessTokenStore);
                 }
                 else
                 {
-                    Trace.WriteLine("   AAD authority for tenant '" + tenantId + "' detected");
+                    Trace.WriteLine("AAD authority for tenant '" + tenantId + "' detected");
                     authentication = new VstsAadAuthentication(tenantId, scope, personalAccessTokenStore);
                     (authentication as VstsAadAuthentication).TenantId = tenantId;
                 }

--- a/Microsoft.Alm.Authentication/BasicAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BasicAuthentication.cs
@@ -59,8 +59,6 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("BasicAuthentication::DeleteCredentials");
-
             this.CredentialStore.DeleteCredentials(targetUri);
         }
 
@@ -75,8 +73,6 @@ namespace Microsoft.Alm.Authentication
         public override Credential GetCredentials(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("BasicAuthentication::GetCredentials");
 
             return this.CredentialStore.ReadCredentials(targetUri);
         }
@@ -93,8 +89,6 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
-
-            Trace.WriteLine("BasicAuthentication::SetCredentials");
 
             this.CredentialStore.WriteCredentials(targetUri, credentials);
         }

--- a/Microsoft.Alm.Authentication/GitHubAuthentication.cs
+++ b/Microsoft.Alm.Authentication/GitHubAuthentication.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Alm.Authentication
             if ((credentials = this.PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
             {
                 this.PersonalAccessTokenStore.DeleteCredentials(targetUri);
-                Trace.WriteLine("   credentials deleted");
+                Trace.WriteLine("credentials deleted");
             }
         }
 
@@ -128,12 +128,12 @@ namespace Microsoft.Alm.Authentication
             if (targetUri.ActualUri.DnsSafeHost.EndsWith(GitHubBaseUrlHost, StringComparison.OrdinalIgnoreCase))
             {
                 authentication = new GitHubAuthentication(tokenScope, personalAccessTokenStore, acquireCredentialsCallback, acquireAuthenticationCodeCallback, authenticationResultCallback);
-                Trace.WriteLine("   authentication for GitHub created");
+                Trace.WriteLine("authentication for GitHub created");
             }
             else
             {
                 authentication = null;
-                Trace.WriteLine("   not github.com, authentication creation aborted");
+                Trace.WriteLine("not github.com, authentication creation aborted");
             }
 
             return authentication;
@@ -157,7 +157,7 @@ namespace Microsoft.Alm.Authentication
 
             if ((credentials = this.PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
             {
-                Trace.WriteLine("   successfully retrieved stored credentials, updating credential cache");
+                Trace.WriteLine("successfully retrieved stored credentials, updating credential cache");
             }
 
             return credentials;
@@ -185,7 +185,7 @@ namespace Microsoft.Alm.Authentication
 
                 if (result = await GitHubAuthority.AcquireToken(targetUri, username, password, null, this.TokenScope))
                 {
-                    Trace.WriteLine("   token acquisition succeeded");
+                    Trace.WriteLine("token acquisition succeeded");
 
                     credentials = (Credential)result.Token;
                     this.PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
@@ -206,7 +206,7 @@ namespace Microsoft.Alm.Authentication
                     {
                         if (result = await GitHubAuthority.AcquireToken(targetUri, username, password, authenticationCode, this.TokenScope))
                         {
-                            Trace.WriteLine("   token acquisition succeeded");
+                            Trace.WriteLine("token acquisition succeeded");
 
                             credentials = (Credential)result.Token;
                             this.PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
@@ -229,7 +229,7 @@ namespace Microsoft.Alm.Authentication
                 }
             }
 
-            Trace.WriteLine("   interactive logon failed");
+            Trace.WriteLine("interactive logon failed");
             return credentials;
         }
 
@@ -259,7 +259,7 @@ namespace Microsoft.Alm.Authentication
             GitHubAuthenticationResult result;
             if (result = await GitHubAuthority.AcquireToken(targetUri, username, password, authenticationCode, this.TokenScope))
             {
-                Trace.WriteLine("   token acquisition succeeded");
+                Trace.WriteLine("token acquisition succeeded");
 
                 credentials = (Credential)result.Token;
                 PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
@@ -267,7 +267,7 @@ namespace Microsoft.Alm.Authentication
                 return credentials;
             }
 
-            Trace.WriteLine("   non-interactive logon failed");
+            Trace.WriteLine("non-interactive logon failed");
             return credentials;
         }
 

--- a/Microsoft.Alm.Authentication/GitHubAuthentication.cs
+++ b/Microsoft.Alm.Authentication/GitHubAuthentication.cs
@@ -86,14 +86,11 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("GitHubAuthentication::DeleteCredentials");
-
             Credential credentials = null;
-
             if ((credentials = this.PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
             {
                 this.PersonalAccessTokenStore.DeleteCredentials(targetUri);
-                Trace.WriteLine("credentials deleted");
+                Git.Trace.WriteLine($"credentials for '{targetUri}' deleted");
             }
         }
 
@@ -123,17 +120,15 @@ namespace Microsoft.Alm.Authentication
             if (personalAccessTokenStore == null)
                 throw new ArgumentNullException("personalAccessTokenStore", "The `personalAccessTokenStore` is null or invalid.");
 
-            Trace.WriteLine("GitHubAuthentication::GetAuthentication");
-
             if (targetUri.ActualUri.DnsSafeHost.EndsWith(GitHubBaseUrlHost, StringComparison.OrdinalIgnoreCase))
             {
                 authentication = new GitHubAuthentication(tokenScope, personalAccessTokenStore, acquireCredentialsCallback, acquireAuthenticationCodeCallback, authenticationResultCallback);
-                Trace.WriteLine("authentication for GitHub created");
+                Git.Trace.WriteLine($"created GitHub authentication for '{targetUri}'.");
             }
             else
             {
                 authentication = null;
-                Trace.WriteLine("not github.com, authentication creation aborted");
+                Git.Trace.WriteLine($"not github.com, authentication creation aborted.");
             }
 
             return authentication;
@@ -151,13 +146,11 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("GitHubAuthentication::GetCredentials");
-
             Credential credentials = null;
 
             if ((credentials = this.PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
             {
-                Trace.WriteLine("successfully retrieved stored credentials, updating credential cache");
+                Git.Trace.WriteLine($"credentials for '{targetUri}' found.");
             }
 
             return credentials;
@@ -173,8 +166,6 @@ namespace Microsoft.Alm.Authentication
         /// /// <returns>Acquired <see cref="Credential"/> if successful; otherwise <see langword="null"/>.</returns>
         public async Task<Credential> InteractiveLogon(TargetUri targetUri)
         {
-            Trace.WriteLine("GitHubAuthentication::InteractiveLogon");
-
             Credential credentials = null;
             string username;
             string password;
@@ -185,16 +176,13 @@ namespace Microsoft.Alm.Authentication
 
                 if (result = await GitHubAuthority.AcquireToken(targetUri, username, password, null, this.TokenScope))
                 {
-                    Trace.WriteLine("token acquisition succeeded");
+                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
 
                     credentials = (Credential)result.Token;
                     this.PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
 
                     // if a result callback was registered, call it
-                    if (AuthenticationResultCallback != null)
-                    {
-                        AuthenticationResultCallback(targetUri, result);
-                    }
+                    AuthenticationResultCallback?.Invoke(targetUri, result);
 
                     return credentials;
                 }
@@ -206,16 +194,13 @@ namespace Microsoft.Alm.Authentication
                     {
                         if (result = await GitHubAuthority.AcquireToken(targetUri, username, password, authenticationCode, this.TokenScope))
                         {
-                            Trace.WriteLine("token acquisition succeeded");
+                            Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                             credentials = (Credential)result.Token;
                             this.PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
 
                             // if a result callback was registered, call it
-                            if (AuthenticationResultCallback != null)
-                            {
-                                AuthenticationResultCallback(targetUri, result);
-                            }
+                            AuthenticationResultCallback?.Invoke(targetUri, result);
 
                             return credentials;
                         }
@@ -229,7 +214,7 @@ namespace Microsoft.Alm.Authentication
                 }
             }
 
-            Trace.WriteLine("interactive logon failed");
+            Git.Trace.WriteLine($"interactive logon for '{targetUri}' failed.");
             return credentials;
         }
 
@@ -252,14 +237,12 @@ namespace Microsoft.Alm.Authentication
             if (String.IsNullOrWhiteSpace(password))
                 throw new ArgumentNullException("username", "The `password` parameter is null or invalid.");
 
-            Trace.WriteLine("GitHubAuthentication::NoninteractiveLogonWithCredentials");
-
             Credential credentials = null;
 
             GitHubAuthenticationResult result;
             if (result = await GitHubAuthority.AcquireToken(targetUri, username, password, authenticationCode, this.TokenScope))
             {
-                Trace.WriteLine("token acquisition succeeded");
+                Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                 credentials = (Credential)result.Token;
                 PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
@@ -267,7 +250,7 @@ namespace Microsoft.Alm.Authentication
                 return credentials;
             }
 
-            Trace.WriteLine("non-interactive logon failed");
+            Git.Trace.WriteLine($"non-interactive logon for '{targetUri}' failed.");
             return credentials;
         }
 
@@ -283,8 +266,6 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            Trace.WriteLine("GitHubAuthentication::SetCredentials");
-
             PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
         }
 
@@ -299,8 +280,6 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
-
-            Trace.WriteLine("GitHubAuthentication::ValidateCredentials");
 
             return await GitHubAuthority.ValidateCredentials(targetUri, credentials);
         }

--- a/Microsoft.Alm.Authentication/GitHubAuthority.cs
+++ b/Microsoft.Alm.Authentication/GitHubAuthority.cs
@@ -65,8 +65,6 @@ namespace Microsoft.Alm.Authentication
         {
             const string GitHubOptHeader = "X-GitHub-OTP";
 
-            Trace.WriteLine("GitHubAuthority::AcquireToken");
-
             Token token = null;
 
             using (HttpClientHandler handler = targetUri.HttpClientHandler)
@@ -116,7 +114,7 @@ namespace Microsoft.Alm.Authentication
                 using (StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType))
                 using (HttpResponseMessage response = await httpClient.PostAsync(_authorityUrl, content))
                 {
-                    Trace.WriteLine("server responded with " + response.StatusCode);
+                    Git.Trace.WriteLine($"server responded with {response.StatusCode}.");
 
                     switch (response.StatusCode)
                     {
@@ -135,12 +133,12 @@ namespace Microsoft.Alm.Authentication
 
                                 if (token == null)
                                 {
-                                    Trace.WriteLine("authentication failure");
+                                    Git.Trace.WriteLine($"authentication for '{targetUri}' failed.");
                                     return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                                 else
                                 {
-                                    Trace.WriteLine("authentication success: new personal acces token created.");
+                                    Git.Trace.WriteLine($"authentication success: new personal acces token for '{targetUri}' created.");
                                     return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Success, token);
                                 }
                             }
@@ -154,24 +152,24 @@ namespace Microsoft.Alm.Authentication
 
                                     if (mfakvp.Value.First().Contains("app"))
                                     {
-                                        Trace.WriteLine("two-factor app authentication code required");
+                                        Git.Trace.WriteLine($"two-factor app authentication code required for '{targetUri}'.");
                                         return new GitHubAuthenticationResult(GitHubAuthenticationResultType.TwoFactorApp);
                                     }
                                     else
                                     {
-                                        Trace.WriteLine("two-factor sms authentication code required");
+                                        Git.Trace.WriteLine($"two-factor sms authentication code required for '{targetUri}'.");
                                         return new GitHubAuthenticationResult(GitHubAuthenticationResultType.TwoFactorSms);
                                     }
                                 }
                                 else
                                 {
-                                    Trace.WriteLine("authentication failed");
+                                    Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
                                     return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                             }
 
                         default:
-                            Trace.WriteLine("authentication failed");
+                            Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
                             return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Failure);
                     }
                 }
@@ -184,8 +182,6 @@ namespace Microsoft.Alm.Authentication
 
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
-
-            Trace.WriteLine("GitHubAuthority::ValidateCredentials");
 
             string authString = String.Format("{0}:{1}", credentials.Username, credentials.Password);
             byte[] authBytes = Encoding.UTF8.GetBytes(authString);
@@ -206,12 +202,12 @@ namespace Microsoft.Alm.Authentication
                 {
                     if (response.IsSuccessStatusCode)
                     {
-                        Trace.WriteLine("credential validation succeeded");
+                        Git.Trace.WriteLine($"credential validation for '{targetUri}' succeeded.");
                         return true;
                     }
                     else
                     {
-                        Trace.WriteLine("credential validation failed");
+                        Git.Trace.WriteLine($"credential validation for '{targetUri}' failed.");
                         return false;
                     }
                 }

--- a/Microsoft.Alm.Authentication/GitHubAuthority.cs
+++ b/Microsoft.Alm.Authentication/GitHubAuthority.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Alm.Authentication
                 using (StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType))
                 using (HttpResponseMessage response = await httpClient.PostAsync(_authorityUrl, content))
                 {
-                    Trace.WriteLine("   server responded with " + response.StatusCode);
+                    Trace.WriteLine("server responded with " + response.StatusCode);
 
                     switch (response.StatusCode)
                     {
@@ -135,12 +135,12 @@ namespace Microsoft.Alm.Authentication
 
                                 if (token == null)
                                 {
-                                    Trace.WriteLine("   authentication failure");
+                                    Trace.WriteLine("authentication failure");
                                     return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                                 else
                                 {
-                                    Trace.WriteLine("   authentication success: new personal acces token created.");
+                                    Trace.WriteLine("authentication success: new personal acces token created.");
                                     return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Success, token);
                                 }
                             }
@@ -154,24 +154,24 @@ namespace Microsoft.Alm.Authentication
 
                                     if (mfakvp.Value.First().Contains("app"))
                                     {
-                                        Trace.WriteLine("   two-factor app authentication code required");
+                                        Trace.WriteLine("two-factor app authentication code required");
                                         return new GitHubAuthenticationResult(GitHubAuthenticationResultType.TwoFactorApp);
                                     }
                                     else
                                     {
-                                        Trace.WriteLine("   two-factor sms authentication code required");
+                                        Trace.WriteLine("two-factor sms authentication code required");
                                         return new GitHubAuthenticationResult(GitHubAuthenticationResultType.TwoFactorSms);
                                     }
                                 }
                                 else
                                 {
-                                    Trace.WriteLine("   authentication failed");
+                                    Trace.WriteLine("authentication failed");
                                     return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                             }
 
                         default:
-                            Trace.WriteLine("   authentication failed");
+                            Trace.WriteLine("authentication failed");
                             return new GitHubAuthenticationResult(GitHubAuthenticationResultType.Failure);
                     }
                 }
@@ -185,7 +185,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            Trace.WriteLine("   GitHubAuthority::ValidateCredentials");
+            Trace.WriteLine("GitHubAuthority::ValidateCredentials");
 
             string authString = String.Format("{0}:{1}", credentials.Username, credentials.Password);
             byte[] authBytes = Encoding.UTF8.GetBytes(authString);
@@ -206,12 +206,12 @@ namespace Microsoft.Alm.Authentication
                 {
                     if (response.IsSuccessStatusCode)
                     {
-                        Trace.WriteLine("   credential validation succeeded");
+                        Trace.WriteLine("credential validation succeeded");
                         return true;
                     }
                     else
                     {
-                        Trace.WriteLine("   credential validation failed");
+                        Trace.WriteLine("credential validation failed");
                         return false;
                     }
                 }

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -98,6 +98,13 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Alm.Git\Microsoft.Alm.Git.csproj">
+      <Project>{4827c16d-5c58-406d-ab3f-3700bb0d06fe}</Project>
+      <Name>Microsoft.Alm.Git</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\CommonShared\CommonShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Produce a nuget package of this assembly -->
   <Import Project="..\packages\MSBuildTasks.*\tools\MSBuild.Community.Tasks.Targets" />

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -36,12 +36,8 @@ namespace Microsoft.Alm.Authentication
             if (String.IsNullOrWhiteSpace(@namespace))
                 throw new ArgumentNullException(@namespace);
 
-            Trace.WriteLine("Secret::UriToName");
-
             string targetName = $"{@namespace}:{targetUri}";
             targetName = targetName.TrimEnd('/', '\\');
-
-            Trace.WriteLine("target name = " + targetName);
 
             return targetName;
         }

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Alm.Authentication
             string targetName = $"{@namespace}:{targetUri}";
             targetName = targetName.TrimEnd('/', '\\');
 
-            Trace.WriteLine("   target name = " + targetName);
+            Trace.WriteLine("target name = " + targetName);
 
             return targetName;
         }

--- a/Microsoft.Alm.Authentication/SecretCache.cs
+++ b/Microsoft.Alm.Authentication/SecretCache.cs
@@ -60,8 +60,6 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("SecretCache::DeleteCredentials");
-
             string targetName = this.GetTargetName(targetUri);
 
             lock (_cache)
@@ -80,8 +78,6 @@ namespace Microsoft.Alm.Authentication
         public void DeleteToken(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("SecretCache::DeleteToken");
 
             string targetName = this.GetTargetName(targetUri);
 
@@ -102,8 +98,6 @@ namespace Microsoft.Alm.Authentication
         public Credential ReadCredentials(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("SecretCache::ReadCredentials");
 
             Credential credentials = null;
             string targetName = this.GetTargetName(targetUri);
@@ -131,8 +125,6 @@ namespace Microsoft.Alm.Authentication
         public Token ReadToken(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("SecretCache::ReadToken");
 
             Token token = null;
             string targetName = this.GetTargetName(targetUri);
@@ -162,8 +154,6 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            Trace.WriteLine("SecretCache::WriteCredentials");
-
             string targetName = this.GetTargetName(targetUri);
 
             lock (_cache)
@@ -189,8 +179,6 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             Token.Validate(token);
 
-            Trace.WriteLine("SecretCache::WriteToken");
-
             string targetName = this.GetTargetName(targetUri);
 
             lock (_cache)
@@ -214,8 +202,6 @@ namespace Microsoft.Alm.Authentication
         private string GetTargetName(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("SecretCache::GetTargetName");
 
             return _getTargetName(targetUri, _namespace);
         }

--- a/Microsoft.Alm.Authentication/SecretStore.cs
+++ b/Microsoft.Alm.Authentication/SecretStore.cs
@@ -49,8 +49,10 @@ namespace Microsoft.Alm.Authentication
         /// </param>
         public SecretStore(string @namespace, ICredentialStore credentialCache = null, ITokenStore tokenCache = null, Secret.UriNameConversion getTargetName = null)
         {
-            if (String.IsNullOrWhiteSpace(@namespace) || @namespace.IndexOfAny(IllegalCharacters) != -1)
-                throw new ArgumentNullException("prefix", "The `prefix` parameter is null or invalid.");
+            if (String.IsNullOrWhiteSpace(@namespace))
+                throw new ArgumentNullException(nameof(@namespace));
+            if (@namespace.IndexOfAny(IllegalCharacters) != -1)
+                throw new ArgumentException(nameof(@namespace));
 
             _getTargetName = getTargetName ?? Secret.UriToName;
 
@@ -73,8 +75,6 @@ namespace Microsoft.Alm.Authentication
         {
             ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("CredentialStore::DeleteCredentials");
-
             string targetName = this.GetTargetName(targetUri);
 
             this.Delete(targetName);
@@ -89,8 +89,6 @@ namespace Microsoft.Alm.Authentication
         public void DeleteToken(TargetUri targetUri)
         {
             ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("TokenStore::ReadToken");
 
             string targetName = this.GetTargetName(targetUri);
 
@@ -119,8 +117,6 @@ namespace Microsoft.Alm.Authentication
             Credential credentials = null;
             string targetName = this.GetTargetName(targetUri);
 
-            Trace.WriteLine("CredentialStore::ReadCredentials");
-
             if ((credentials = _credentialCache.ReadCredentials(targetUri)) == null)
             {
                 credentials = this.ReadCredentials(targetName);
@@ -137,8 +133,6 @@ namespace Microsoft.Alm.Authentication
         public Token ReadToken(TargetUri targetUri)
         {
             ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("TokenStore::ReadToken");
 
             Token token = null;
 
@@ -161,8 +155,6 @@ namespace Microsoft.Alm.Authentication
             ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            Trace.WriteLine("CredentialStore::WriteCredentials");
-
             string targetName = this.GetTargetName(targetUri);
 
             this.WriteCredential(targetName, credentials);
@@ -180,8 +172,6 @@ namespace Microsoft.Alm.Authentication
             ValidateTargetUri(targetUri);
             Token.Validate(token);
 
-            Trace.WriteLine("TokenStore::ReadToken");
-
             string targetName = this.GetTargetName(targetUri);
 
             _tokenCache.WriteToken(targetUri, token);
@@ -197,8 +187,6 @@ namespace Microsoft.Alm.Authentication
         protected override string GetTargetName(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
-
-            Trace.WriteLine("SecretStore::GetTargetName");
 
             return _getTargetName(targetUri, _namespace);
         }

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Trace.WriteLine("   token deserialization error");
+                Trace.WriteLine("token deserialization error");
             }
 
             return token != null;
@@ -268,7 +268,7 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Trace.WriteLine("   token serialization error");
+                Trace.WriteLine("token serialization error");
             }
 
             return bytes != null;

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Trace.WriteLine("token deserialization error");
+                Git.Trace.WriteLine("! token deserialization error.");
             }
 
             return token != null;
@@ -268,7 +268,7 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Trace.WriteLine("token serialization error");
+                Git.Trace.WriteLine("! token serialization error.");
             }
 
             return bytes != null;

--- a/Microsoft.Alm.Authentication/TokenRegistry.cs
+++ b/Microsoft.Alm.Authentication/TokenRegistry.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Alm.Authentication
                     }
                     catch
                     {
-                        Trace.WriteLine("   token read from registry was corrupt");
+                        Trace.WriteLine("token read from registry was corrupt");
                     }
                 }
             }
@@ -143,7 +143,7 @@ namespace Microsoft.Alm.Authentication
                         }
                         catch
                         {
-                            Trace.WriteLine("   failed to open subkey");
+                            Trace.WriteLine("failed to open subkey");
                         }
 
                         if (nodeKey != null)

--- a/Microsoft.Alm.Authentication/TokenRegistry.cs
+++ b/Microsoft.Alm.Authentication/TokenRegistry.cs
@@ -65,8 +65,6 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("TokenRegistry::ReadToken");
-
             Token token = null;
 
             foreach (var key in EnumerateKeys(false))
@@ -103,12 +101,14 @@ namespace Microsoft.Alm.Authentication
 
                             token = new Token(value, tokenType);
 
+                            Git.Trace.WriteLine($"token for '{targetUri}' read from registry.");
+
                             return token;
                         }
                     }
                     catch
                     {
-                        Trace.WriteLine("token read from registry was corrupt");
+                        Git.Trace.WriteLine("! token read from registry was corrupt.");
                     }
                 }
             }
@@ -128,8 +128,6 @@ namespace Microsoft.Alm.Authentication
 
         private IEnumerable<RegistryKey> EnumerateKeys(bool writeable)
         {
-            Trace.WriteLine("TokenRegistry::EnumerateKeys");
-
             foreach (var rootKey in EnumerateRootKeys())
             {
                 if (rootKey != null)
@@ -143,7 +141,7 @@ namespace Microsoft.Alm.Authentication
                         }
                         catch
                         {
-                            Trace.WriteLine("failed to open subkey");
+                            Git.Trace.WriteLine("! failed to open subkey.");
                         }
 
                         if (nodeKey != null)
@@ -177,8 +175,6 @@ namespace Microsoft.Alm.Authentication
 
         private IEnumerable<RegistryKey> EnumerateRootKeys()
         {
-            Trace.WriteLine("TokenRegistry::EnumerateRootKeys");
-
             foreach (string version in Versions)
             {
                 RegistryKey result = null;
@@ -191,7 +187,7 @@ namespace Microsoft.Alm.Authentication
                 }
                 catch (Exception exception)
                 {
-                    Trace.WriteLine(exception, "Error");
+                    Git.Trace.WriteLine($"! {exception.Message}");
                 }
 
                 yield return result;

--- a/Microsoft.Alm.Authentication/VstsAadAuthentication.cs
+++ b/Microsoft.Alm.Authentication/VstsAadAuthentication.cs
@@ -106,17 +106,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await this.VstsAuthority.InteractiveAcquireToken(targetUri, this.ClientId, this.Resource, new Uri(RedirectUrl), null)) != null)
                 {
-                    Trace.WriteLine("   token acquisition succeeded.");
+                    Trace.WriteLine("token acquisition succeeded.");
 
                     return await this.GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Trace.WriteLine("   token acquisition failed.");
+                Trace.WriteLine("token acquisition failed.");
             }
 
-            Trace.WriteLine("   interactive logon failed");
+            Trace.WriteLine("interactive logon failed");
             return null;
         }
 
@@ -148,17 +148,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await this.VstsAuthority.NoninteractiveAcquireToken(targetUri, this.ClientId, this.Resource, new Uri(RedirectUrl))) != null)
                 {
-                    Trace.WriteLine("   token acquisition succeeded");
+                    Trace.WriteLine("token acquisition succeeded");
 
                     return await this.GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Trace.WriteLine("   failed to acquire token from VstsAuthority.");
+                Trace.WriteLine("failed to acquire token from VstsAuthority.");
             }
 
-            Trace.WriteLine("   non-interactive logon failed");
+            Trace.WriteLine("non-interactive logon failed");
             return null;
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateCredential(credentials);
 
             Trace.WriteLine("VstsMsaAuthentication::SetCredentials");
-            Trace.WriteLine("   setting AAD credentials is not supported");
+            Trace.WriteLine("setting AAD credentials is not supported");
         }
     }
 }

--- a/Microsoft.Alm.Authentication/VstsAadAuthentication.cs
+++ b/Microsoft.Alm.Authentication/VstsAadAuthentication.cs
@@ -99,24 +99,22 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("VstsAadAuthentication::InteractiveLogon");
-
             try
             {
                 Token token;
                 if ((token = await this.VstsAuthority.InteractiveAcquireToken(targetUri, this.ClientId, this.Resource, new Uri(RedirectUrl), null)) != null)
                 {
-                    Trace.WriteLine("token acquisition succeeded.");
+                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                     return await this.GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Trace.WriteLine("token acquisition failed.");
+                Git.Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
             }
 
-            Trace.WriteLine("interactive logon failed");
+            Git.Trace.WriteLine($"interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -141,24 +139,22 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("VstsAadAuthentication::NoninteractiveLogon");
-
             try
             {
                 Token token;
                 if ((token = await this.VstsAuthority.NoninteractiveAcquireToken(targetUri, this.ClientId, this.Resource, new Uri(RedirectUrl))) != null)
                 {
-                    Trace.WriteLine("token acquisition succeeded");
+                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
 
                     return await this.GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Trace.WriteLine("failed to acquire token from VstsAuthority.");
+                Git.Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
             }
 
-            Trace.WriteLine("non-interactive logon failed");
+            Git.Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -174,9 +170,6 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
-
-            Trace.WriteLine("VstsMsaAuthentication::SetCredentials");
-            Trace.WriteLine("setting AAD credentials is not supported");
         }
     }
 }

--- a/Microsoft.Alm.Authentication/VstsAdalTokenCache.cs
+++ b/Microsoft.Alm.Authentication/VstsAdalTokenCache.cs
@@ -73,8 +73,6 @@ namespace Microsoft.Alm.Authentication
             {
                 if (File.Exists(_cacheFilePath) && this.HasStateChanged)
                 {
-                    Trace.WriteLine("VstsAdalTokenCache::AfterAccessNotification");
-
                     try
                     {
                         byte[] state = this.Serialize();
@@ -87,7 +85,7 @@ namespace Microsoft.Alm.Authentication
                     }
                     catch (Exception exception)
                     {
-                        Trace.WriteLine(exception, "Error");
+                        Git.Trace.WriteLine($"! {exception.Message}");
                     }
                 }
             }
@@ -97,8 +95,6 @@ namespace Microsoft.Alm.Authentication
         {
             lock (@lock)
             {
-                Trace.WriteLine("VstsAdalTokenCache::BeforeAccessNotification");
-
                 if (File.Exists(_cacheFilePath))
                 {
                     try
@@ -111,7 +107,7 @@ namespace Microsoft.Alm.Authentication
                     }
                     catch (Exception exception)
                     {
-                        Trace.WriteLine(exception, "Error");
+                        Git.Trace.WriteLine($"! {exception.Message}");
                     }
                 }
             }

--- a/Microsoft.Alm.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Alm.Authentication/VstsAzureAuthority.cs
@@ -67,8 +67,6 @@ namespace Microsoft.Alm.Authentication
             if (ReferenceEquals(tokenScope, null))
                 throw new ArgumentNullException(nameof(tokenScope));
 
-            Trace.WriteLine("VstsAzureAuthority::GeneratePersonalAccessToken");
-
             try
             {
                 // create a `HttpClient` with a minimum number of redirects, default creds, and a reasonable timeout (access token generation seems to hang occasionally)
@@ -87,13 +85,13 @@ namespace Microsoft.Alm.Authentication
                     switch (accessToken.Type)
                     {
                         case TokenType.Access:
-                            Trace.WriteLine("using Azure access token to acquire personal access token");
+                            Git.Trace.WriteLine($"using Azure access token to acquire personal access token for '{targetUri}'.");
 
                             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AccessTokenHeader, accessToken.Value);
                             break;
 
                         case TokenType.Federated:
-                            Trace.WriteLine("using federated authentication token to acquire personal access token");
+                            Git.Trace.WriteLine($"using federated authentication token to acquire personal access token for '{targetUri}'.");
 
                             httpClient.DefaultRequestHeaders.Add("Cookie", accessToken.Value);
                             break;
@@ -107,8 +105,6 @@ namespace Microsoft.Alm.Authentication
                         Uri requestUri;
                         if (TryCreateRequestUri(targetUri, requireCompactToken, out requestUri))
                         {
-                            Trace.WriteLine("request url is " + requestUri);
-
                             using (StringContent content = GetAccessTokenRequestBody(targetUri, accessToken, tokenScope))
                             using (HttpResponseMessage response = await httpClient.PostAsync(requestUri, content))
                             {
@@ -125,7 +121,7 @@ namespace Microsoft.Alm.Authentication
                                             string tokenValue = tokenMatch.Groups[1].Value;
                                             Token token = new Token(tokenValue, TokenType.Personal);
 
-                                            Trace.WriteLine("personal access token acquisition succeeded.");
+                                            Git.Trace.WriteLine($"personal access token acquisition for '{targetUri}' succeeded.");
 
                                             return token;
                                         }
@@ -138,10 +134,10 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Trace.WriteLine("an error occurred.");
+                Git.Trace.WriteLine("! an error occurred.");
             }
 
-            Trace.WriteLine("personal access token acquisition failed.");
+            Git.Trace.WriteLine($"personal access token acquisition for '{targetUri}' failed.");
 
             return null;
         }
@@ -151,8 +147,6 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateToken(accessToken);
 
-            Trace.WriteLine("VstsAzureAuthority::PopulateTokenTargetId");
-
             string resultId = null;
             Guid instanceId;
 
@@ -161,7 +155,7 @@ namespace Microsoft.Alm.Authentication
                 // create an request to the VSTS deployment data end-point
                 HttpWebRequest request = GetConnectionDataRequest(targetUri, accessToken);
 
-                Trace.WriteLine(String.Format("   access token end-point is {0} {1}", request.Method, request.RequestUri));
+                Git.Trace.WriteLine($"access token end-point is '{request.Method}' '{request.RequestUri}'.");
 
                 // send the request and wait for the response
                 using (var response = await request.GetResponseAsync())
@@ -180,12 +174,12 @@ namespace Microsoft.Alm.Authentication
             }
             catch (WebException webException)
             {
-                Trace.WriteLine("server returned " + webException.Status);
+                Git.Trace.WriteLine($"server returned '{webException.Status}'.");
             }
 
             if (Guid.TryParse(resultId, out instanceId))
             {
-                Trace.WriteLine("target identity is " + resultId);
+                Git.Trace.WriteLine($"target identity is {resultId}.");
                 accessToken.TargetIdentity = instanceId;
 
                 return true;
@@ -208,33 +202,31 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            Trace.WriteLine("VstsAzureAuthority::ValidateCredentials");
-
             try
             {
                 // create an request to the VSTS deployment data end-point
                 HttpWebRequest request = GetConnectionDataRequest(targetUri, credentials);
 
-                Trace.WriteLine("validating credentials against " + request.RequestUri);
+                Git.Trace.WriteLine($"validating credentials against '{request.RequestUri}'.");
 
                 // send the request and wait for the response
                 using (HttpWebResponse response = await request.GetResponseAsync() as HttpWebResponse)
                 {
                     // we're looking for 'OK 200' here, anything else is failure
-                    Trace.WriteLine("server returned: " + response.StatusCode);
+                    Git.Trace.WriteLine($"server returned: '{response.StatusCode}'.");
                     return response.StatusCode == HttpStatusCode.OK;
                 }
             }
             catch (WebException webException)
             {
-                Trace.WriteLine("server returned: " + webException.Message);
+                Git.Trace.WriteLine($"server returned: '{webException.Message}.");
             }
             catch
             {
-                Trace.WriteLine("unexpected error");
+                Git.Trace.WriteLine("! unexpected error");
             }
 
-            Trace.WriteLine("credential validation failed");
+            Git.Trace.WriteLine($"credential validation for '{targetUri}' failed.");
             return false;
         }
 
@@ -252,8 +244,6 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateToken(token);
 
-            Trace.WriteLine("VstsAzureAuthority::ValidateToken");
-
             // personal access tokens are effectively credentials, treat them as such
             if (token.Type == TokenType.Personal)
                 return await this.ValidateCredentials(targetUri, (Credential)token);
@@ -263,26 +253,26 @@ namespace Microsoft.Alm.Authentication
                 // create an request to the VSTS deployment data end-point
                 HttpWebRequest request = GetConnectionDataRequest(targetUri, token);
 
-                Trace.WriteLine("validating token against " + request.Host);
+                Git.Trace.WriteLine($"validating token against '{request.Host}'.");
 
                 // send the request and wait for the response
                 using (HttpWebResponse response = await request.GetResponseAsync() as HttpWebResponse)
                 {
                     // we're looking for 'OK 200' here, anything else is failure
-                    Trace.WriteLine("server returned: " + response.StatusCode);
+                    Git.Trace.WriteLine($"server returned: '{response.StatusCode}'.");
                     return response.StatusCode == HttpStatusCode.OK;
                 }
             }
             catch (WebException webException)
             {
-                Trace.WriteLine("server returned: " + webException.Message);
+                Git.Trace.WriteLine($"! server returned: '{webException.Message}'.");
             }
             catch
             {
-                Trace.WriteLine("unexpected error");
+                Git.Trace.WriteLine("! unexpected error");
             }
 
-            Trace.WriteLine("token validation failed");
+            Git.Trace.WriteLine($"token validation for '{targetUri}' failed.");
             return false;
         }
 
@@ -294,7 +284,7 @@ namespace Microsoft.Alm.Authentication
             Debug.Assert(accessToken != null && (accessToken.Type == TokenType.Access || accessToken.Type == TokenType.Federated), "The accessToken parameter is null or invalid");
             Debug.Assert(tokenScope != null, "The tokenScope parameter is null");
 
-            Trace.WriteLine("creating access token scoped to '" + tokenScope + "' for '" + accessToken.TargetIdentity + "'");
+            Git.Trace.WriteLine($"creating access token scoped to '{tokenScope}' for '{accessToken.TargetIdentity}'");
 
             string jsonContent = String.Format(ContentJsonFormat, tokenScope, accessToken.TargetIdentity, targetUri, Environment.MachineName);
             StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType);
@@ -330,8 +320,6 @@ namespace Microsoft.Alm.Authentication
             Debug.Assert(targetUri != null && targetUri.IsAbsoluteUri, "The targetUri parameter is null or invalid");
             Debug.Assert(token != null && (token.Type == TokenType.Access || token.Type == TokenType.Federated), "The token parameter is null or invalid");
 
-            Trace.WriteLine("VstsAzureAuthority::GetConnectionDataRequest");
-
             // create an request to the VSTS deployment data end-point
             HttpWebRequest request = GetConnectionDataRequest(targetUri);
 
@@ -339,7 +327,7 @@ namespace Microsoft.Alm.Authentication
             switch (token.Type)
             {
                 case TokenType.Access:
-                    Trace.WriteLine("validating adal access token");
+                    Git.Trace.WriteLine($"validating adal access token for '{targetUri}'.");
 
                     // adal access tokens are packed into the Authorization header
                     string sessionAuthHeader = BearerPrefix + token.Value;
@@ -347,14 +335,14 @@ namespace Microsoft.Alm.Authentication
                     break;
 
                 case TokenType.Federated:
-                    Trace.WriteLine("validating federated authentication token");
+                    Git.Trace.WriteLine($"validating federated authentication token for '{targetUri}'.");
 
                     // federated authentication tokens are sent as cookie(s)
                     request.Headers.Add(HttpRequestHeader.Cookie, token.Value);
                     break;
 
                 default:
-                    Trace.WriteLine("unsupported token type");
+                    Git.Trace.WriteLine("! unsupported token type.");
                     break;
             }
 

--- a/Microsoft.Alm.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Alm.Authentication/VstsAzureAuthority.cs
@@ -87,13 +87,13 @@ namespace Microsoft.Alm.Authentication
                     switch (accessToken.Type)
                     {
                         case TokenType.Access:
-                            Trace.WriteLine("   using Azure access token to acquire personal access token");
+                            Trace.WriteLine("using Azure access token to acquire personal access token");
 
                             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AccessTokenHeader, accessToken.Value);
                             break;
 
                         case TokenType.Federated:
-                            Trace.WriteLine("   using federated authentication token to acquire personal access token");
+                            Trace.WriteLine("using federated authentication token to acquire personal access token");
 
                             httpClient.DefaultRequestHeaders.Add("Cookie", accessToken.Value);
                             break;
@@ -107,7 +107,7 @@ namespace Microsoft.Alm.Authentication
                         Uri requestUri;
                         if (TryCreateRequestUri(targetUri, requireCompactToken, out requestUri))
                         {
-                            Trace.WriteLine("   request url is " + requestUri);
+                            Trace.WriteLine("request url is " + requestUri);
 
                             using (StringContent content = GetAccessTokenRequestBody(targetUri, accessToken, tokenScope))
                             using (HttpResponseMessage response = await httpClient.PostAsync(requestUri, content))
@@ -125,7 +125,7 @@ namespace Microsoft.Alm.Authentication
                                             string tokenValue = tokenMatch.Groups[1].Value;
                                             Token token = new Token(tokenValue, TokenType.Personal);
 
-                                            Trace.WriteLine("   personal access token acquisition succeeded.");
+                                            Trace.WriteLine("personal access token acquisition succeeded.");
 
                                             return token;
                                         }
@@ -138,10 +138,10 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Trace.WriteLine("   an error occurred.");
+                Trace.WriteLine("an error occurred.");
             }
 
-            Trace.WriteLine("   personal access token acquisition failed.");
+            Trace.WriteLine("personal access token acquisition failed.");
 
             return null;
         }
@@ -180,12 +180,12 @@ namespace Microsoft.Alm.Authentication
             }
             catch (WebException webException)
             {
-                Trace.WriteLine("   server returned " + webException.Status);
+                Trace.WriteLine("server returned " + webException.Status);
             }
 
             if (Guid.TryParse(resultId, out instanceId))
             {
-                Trace.WriteLine("   target identity is " + resultId);
+                Trace.WriteLine("target identity is " + resultId);
                 accessToken.TargetIdentity = instanceId;
 
                 return true;
@@ -215,26 +215,26 @@ namespace Microsoft.Alm.Authentication
                 // create an request to the VSTS deployment data end-point
                 HttpWebRequest request = GetConnectionDataRequest(targetUri, credentials);
 
-                Trace.WriteLine("   validating credentials against " + request.RequestUri);
+                Trace.WriteLine("validating credentials against " + request.RequestUri);
 
                 // send the request and wait for the response
                 using (HttpWebResponse response = await request.GetResponseAsync() as HttpWebResponse)
                 {
                     // we're looking for 'OK 200' here, anything else is failure
-                    Trace.WriteLine("   server returned: " + response.StatusCode);
+                    Trace.WriteLine("server returned: " + response.StatusCode);
                     return response.StatusCode == HttpStatusCode.OK;
                 }
             }
             catch (WebException webException)
             {
-                Trace.WriteLine("   server returned: " + webException.Message);
+                Trace.WriteLine("server returned: " + webException.Message);
             }
             catch
             {
-                Trace.WriteLine("   unexpected error");
+                Trace.WriteLine("unexpected error");
             }
 
-            Trace.WriteLine("   credential validation failed");
+            Trace.WriteLine("credential validation failed");
             return false;
         }
 
@@ -263,26 +263,26 @@ namespace Microsoft.Alm.Authentication
                 // create an request to the VSTS deployment data end-point
                 HttpWebRequest request = GetConnectionDataRequest(targetUri, token);
 
-                Trace.WriteLine("   validating token against " + request.Host);
+                Trace.WriteLine("validating token against " + request.Host);
 
                 // send the request and wait for the response
                 using (HttpWebResponse response = await request.GetResponseAsync() as HttpWebResponse)
                 {
                     // we're looking for 'OK 200' here, anything else is failure
-                    Trace.WriteLine("   server returned: " + response.StatusCode);
+                    Trace.WriteLine("server returned: " + response.StatusCode);
                     return response.StatusCode == HttpStatusCode.OK;
                 }
             }
             catch (WebException webException)
             {
-                Trace.WriteLine("   server returned: " + webException.Message);
+                Trace.WriteLine("server returned: " + webException.Message);
             }
             catch
             {
-                Trace.WriteLine("   unexpected error");
+                Trace.WriteLine("unexpected error");
             }
 
-            Trace.WriteLine("   token validation failed");
+            Trace.WriteLine("token validation failed");
             return false;
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.Alm.Authentication
             Debug.Assert(accessToken != null && (accessToken.Type == TokenType.Access || accessToken.Type == TokenType.Federated), "The accessToken parameter is null or invalid");
             Debug.Assert(tokenScope != null, "The tokenScope parameter is null");
 
-            Trace.WriteLine("   creating access token scoped to '" + tokenScope + "' for '" + accessToken.TargetIdentity + "'");
+            Trace.WriteLine("creating access token scoped to '" + tokenScope + "' for '" + accessToken.TargetIdentity + "'");
 
             string jsonContent = String.Format(ContentJsonFormat, tokenScope, accessToken.TargetIdentity, targetUri, Environment.MachineName);
             StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType);
@@ -339,7 +339,7 @@ namespace Microsoft.Alm.Authentication
             switch (token.Type)
             {
                 case TokenType.Access:
-                    Trace.WriteLine("   validating adal access token");
+                    Trace.WriteLine("validating adal access token");
 
                     // adal access tokens are packed into the Authorization header
                     string sessionAuthHeader = BearerPrefix + token.Value;
@@ -347,14 +347,14 @@ namespace Microsoft.Alm.Authentication
                     break;
 
                 case TokenType.Federated:
-                    Trace.WriteLine("   validating federated authentication token");
+                    Trace.WriteLine("validating federated authentication token");
 
                     // federated authentication tokens are sent as cookie(s)
                     request.Headers.Add(HttpRequestHeader.Cookie, token.Value);
                     break;
 
                 default:
-                    Trace.WriteLine("   unsupported token type");
+                    Trace.WriteLine("unsupported token type");
                     break;
             }
 

--- a/Microsoft.Alm.Authentication/VstsMsaAuthentication.cs
+++ b/Microsoft.Alm.Authentication/VstsMsaAuthentication.cs
@@ -74,14 +74,12 @@ namespace Microsoft.Alm.Authentication
 
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            Trace.WriteLine("VstsMsaAuthentication::InteractiveLogon");
-
             try
             {
                 Token token;
                 if ((token = await this.VstsAuthority.InteractiveAcquireToken(targetUri, this.ClientId, this.Resource, new Uri(RedirectUrl), QueryParameters)) != null)
                 {
-                    Trace.WriteLine("token successfully acquired.");
+                    Git.Trace.WriteLine($"token '{targetUri}' successfully acquired.");
 
                     return await this.GeneratePersonalAccessToken(targetUri, token, requireCompactToken);
                 }
@@ -91,7 +89,7 @@ namespace Microsoft.Alm.Authentication
                 Debug.Write(exception);
             }
 
-            Trace.WriteLine("failed to acquire token.");
+            Git.Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
             return null;
         }
 
@@ -107,9 +105,6 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
-
-            Trace.WriteLine("VstsMsaAuthentication::SetCredentials");
-            Trace.WriteLine("setting MSA credentials is not supported");
         }
     }
 }

--- a/Microsoft.Alm.Authentication/VstsMsaAuthentication.cs
+++ b/Microsoft.Alm.Authentication/VstsMsaAuthentication.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await this.VstsAuthority.InteractiveAcquireToken(targetUri, this.ClientId, this.Resource, new Uri(RedirectUrl), QueryParameters)) != null)
                 {
-                    Trace.WriteLine("   token successfully acquired.");
+                    Trace.WriteLine("token successfully acquired.");
 
                     return await this.GeneratePersonalAccessToken(targetUri, token, requireCompactToken);
                 }
@@ -91,7 +91,7 @@ namespace Microsoft.Alm.Authentication
                 Debug.Write(exception);
             }
 
-            Trace.WriteLine("   failed to acquire token.");
+            Trace.WriteLine("failed to acquire token.");
             return null;
         }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateCredential(credentials);
 
             Trace.WriteLine("VstsMsaAuthentication::SetCredentials");
-            Trace.WriteLine("   setting MSA credentials is not supported");
+            Trace.WriteLine("setting MSA credentials is not supported");
         }
     }
 }

--- a/Microsoft.Alm.Git/Microsoft.Alm.Git.csproj
+++ b/Microsoft.Alm.Git/Microsoft.Alm.Git.csproj
@@ -52,8 +52,10 @@
     <Compile Include="GitInstallation.cs" />
     <Compile Include="KnownGitDistribution.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Trace.cs" />
     <Compile Include="Where.cs" />
   </ItemGroup>
+  <Import Project="..\CommonShared\CommonShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Microsoft.Alm.Git/Trace.cs
+++ b/Microsoft.Alm.Git/Trace.cs
@@ -89,12 +89,6 @@ namespace Microsoft.Alm.Git
         public static void Flush()
             => Instance.Flush();
 
-        public static void Write(string message,
-            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
-            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
-            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
-            => Instance.InternalWrite(message, filePath, lineNumber, memberName);
-
         public static void WriteLine(string message,
             [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
             [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
@@ -118,7 +112,7 @@ namespace Microsoft.Alm.Git
 
             string details = String.Format(System.Globalization.CultureInfo.InvariantCulture, "[{0}] {1}", memberName, message);
 
-            string text = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:hh:mm:ss.ffffff} {1,-23} {2}", DateTime.Now, source, details);
+            string text = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:hh:mm:ss.ffffff} {1,-23} trace: {2}", DateTime.Now, source, details);
 
             return text;
         }

--- a/Microsoft.Alm.Git/Trace.cs
+++ b/Microsoft.Alm.Git/Trace.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Alm.Git
+{
+    internal interface ITrace
+    {
+        void AddListener(TextWriter listener);
+        void Flush();
+        void WriteLine(string message, string filePath, int lineNumber, string memberName);
+    }
+
+    public sealed class Trace : ITrace
+    {
+        public const string EnvironmentVariableKey = "GCM_TRACE";
+
+        private Trace()
+        {
+            _writers = new List<TextWriter>();
+
+            try
+            {
+                string traceValue = Environment.GetEnvironmentVariable(EnvironmentVariableKey);
+                int val = 0;
+
+                // if the value is true or a number greater than zero, then trace to standard error
+                if (StringComparer.OrdinalIgnoreCase.Equals(traceValue, "true")
+                    || (Int32.TryParse(traceValue, out val) && val > 0))
+                {
+                    _writers.Add(Console.Error);
+                }
+                // if the value is a rooted path, then trace to that file and not to the console
+                else if (Path.IsPathRooted(traceValue))
+                {
+                    // open or create the log file
+                    var stream = File.Open(traceValue, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
+
+                    // seek to the end, no inserting at the front
+                    stream.Seek(0, SeekOrigin.End);
+
+                    // create the writer and add it to the list
+                    var writer = new StreamWriter(stream, Encoding.UTF8, 4096, true);
+                    _writers.Add(writer);
+                }
+            }
+            catch { }
+        }
+
+        ~Trace()
+        {
+            lock (_syncpoint)
+            {
+                foreach (var writer in _writers)
+                {
+                    try
+                    {
+                        writer?.Dispose();
+                    }
+                    catch { }
+                }
+            }
+        }
+
+        internal static ITrace Instance
+        {
+            get
+            {
+                lock (_syncpoint)
+                {
+                    if (_instance == null)
+                    {
+                        _instance = new Trace();
+                    }
+                    return _instance;
+                }
+            }
+            set { _instance = value; }
+        }
+        private static ITrace _instance;
+
+        private static readonly object _syncpoint = new object();
+        private readonly List<TextWriter> _writers;
+
+        public static void AddListener(TextWriter listener)
+            => Instance.AddListener(listener);
+
+        public static void Flush()
+            => Instance.Flush();
+
+        public static void Write(string message,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+            => Instance.InternalWrite(message, filePath, lineNumber, memberName);
+
+        public static void WriteLine(string message,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+            => Instance.WriteLine(message, filePath, lineNumber, memberName);
+
+        private static string FormatText(string message, string filePath, int lineNumber, string memberName)
+        {
+            string source = Path.GetFileName(filePath);
+
+            // the source:line column is 23 characters wide, we need to live within that limit
+            string lnNumStr = Convert.ToString(lineNumber);
+            int maxWidth = 23 - lnNumStr.Length - 1;
+
+            if (source.Length > maxWidth)
+            {
+                source = source.Substring(0, maxWidth);
+            }
+
+            source = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}:{1}", source, lineNumber);
+
+            string details = String.Format(System.Globalization.CultureInfo.InvariantCulture, "[{0}] {1}", memberName, message);
+
+            string text = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:hh:mm:ss.ffffff} {1,-23} {2}", DateTime.Now, source, details);
+
+            return text;
+        }
+
+        void ITrace.AddListener(TextWriter listener)
+        {
+            lock (_syncpoint)
+            {
+                // try not to add the same listener more than once
+                if (_writers.Contains(listener))
+                    return;
+
+                _writers.Add(listener);
+            }
+        }
+
+        void ITrace.Flush()
+        {
+            lock (_syncpoint)
+            {
+                foreach (var writer in _writers)
+                {
+                    writer?.Flush();
+                }
+            }
+        }
+
+        void ITrace.WriteLine(string message, string filePath, int lineNumber, string memberName)
+        {
+            lock (_syncpoint)
+            {
+                if (_writers.Count == 0)
+                    return;
+
+                string text = FormatText(message, filePath, lineNumber, memberName);
+
+                foreach (var writer in _writers)
+                {
+                    writer?.Write(text);
+                    writer?.Write('\n');
+                    writer?.Flush();
+                }
+            }
+        }
+    }
+}

--- a/Microsoft.Alm.Git/Trace.cs
+++ b/Microsoft.Alm.Git/Trace.cs
@@ -35,10 +35,7 @@ namespace Microsoft.Alm.Git
                 else if (Path.IsPathRooted(traceValue))
                 {
                     // open or create the log file
-                    var stream = File.Open(traceValue, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite);
-
-                    // seek to the end, no inserting at the front
-                    stream.Seek(0, SeekOrigin.End);
+                    var stream = File.Open(traceValue, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
 
                     // create the writer and add it to the list
                     var writer = new StreamWriter(stream, Encoding.UTF8, 4096, true);
@@ -112,7 +109,7 @@ namespace Microsoft.Alm.Git
 
             string details = String.Format(System.Globalization.CultureInfo.InvariantCulture, "[{0}] {1}", memberName, message);
 
-            string text = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:hh:mm:ss.ffffff} {1,-23} trace: {2}", DateTime.Now, source, details);
+            string text = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:HH:mm:ss.ffffff} {1,-23} trace: {2}", DateTime.Now, source, details);
 
             return text;
         }

--- a/Microsoft.Alm.Git/Where.cs
+++ b/Microsoft.Alm.Git/Where.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Alm.Git
 
             installations = pathSet.ToList();
 
-            Trace.WriteLine("   " + installations.Count + " Git installation(s) found.");
+            Trace.WriteLine("" + installations.Count + " Git installation(s) found.");
 
             return installations.Count > 0;
         }

--- a/Microsoft.Alm.Git/Where.cs
+++ b/Microsoft.Alm.Git/Where.cs
@@ -44,8 +44,6 @@ namespace Microsoft.Alm.Git
         /// <returns><see langword="True"/> if succeeds; <see langword="false"/> otherwise.</returns>
         static public bool FindApp(string name, out string path)
         {
-            Trace.WriteLine("Where::App");
-
             if (!String.IsNullOrWhiteSpace(name))
             {
                 string pathext = Environment.GetEnvironmentVariable("PATHEXT");
@@ -99,8 +97,6 @@ namespace Microsoft.Alm.Git
             const string GitAppName = @"Git";
             const string GitSubkeyName = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Git_is1";
             const string GitValueName = "InstallLocation";
-
-            Trace.WriteLine("Where::Git");
 
             installations = null;
 
@@ -256,7 +252,7 @@ namespace Microsoft.Alm.Git
 
             installations = pathSet.ToList();
 
-            Trace.WriteLine("" + installations.Count + " Git installation(s) found.");
+            Git.Trace.WriteLine($"found {installations.Count} Git installation(s).");
 
             return installations.Count > 0;
         }
@@ -269,8 +265,6 @@ namespace Microsoft.Alm.Git
         public static bool GitGlobalConfig(out string path)
         {
             const string GlobalConfigFileName = ".gitconfig";
-
-            Trace.WriteLine("Where::GitGlobalConfig");
 
             path = null;
 
@@ -301,8 +295,6 @@ namespace Microsoft.Alm.Git
         {
             const string GitFolderName = ".git";
             const string LocalConfigFileName = "config";
-
-            Trace.WriteLine("Where::GitLocalConfig");
 
             path = null;
 
@@ -436,8 +428,6 @@ namespace Microsoft.Alm.Git
         /// <returns><see langword="True"/> if succeeds; <see langword="false"/> otherwise.</returns>
         public static bool GitSystemConfig(GitInstallation? installation, out string path)
         {
-            Trace.WriteLine("Where::GitSystemConfig");
-
             if (installation.HasValue && File.Exists(installation.Value.Config))
             {
                 path = installation.Value.Path;

--- a/Microsoft.Alm.sln
+++ b/Microsoft.Alm.sln
@@ -29,10 +29,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cli-Askpass", "Cli-AskPass\
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Cli-Shared", "Cli-Shared\Cli-Shared.shproj", "{DBD202C3-94D5-49D3-8ED1-C72637BA7D90}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "CommonShared", "CommonShared\CommonShared.shproj", "{0E1864BD-C462-4600-9C29-06BF8562A9B2}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Cli-Shared\Cli-Shared.projitems*{0653670e-b33a-4ebe-92b8-04c93f43cae0}*SharedItemsImports = 4
+		CommonShared\CommonShared.projitems*{0653670e-b33a-4ebe-92b8-04c93f43cae0}*SharedItemsImports = 4
+		CommonShared\CommonShared.projitems*{0e1864bd-c462-4600-9c29-06bf8562a9b2}*SharedItemsImports = 13
+		CommonShared\CommonShared.projitems*{4827c16d-5c58-406d-ab3f-3700bb0d06fe}*SharedItemsImports = 4
 		Cli-Shared\Cli-Shared.projitems*{62f52119-63d4-40a8-a9df-f1c4b473308a}*SharedItemsImports = 4
+		CommonShared\CommonShared.projitems*{62f52119-63d4-40a8-a9df-f1c4b473308a}*SharedItemsImports = 4
+		CommonShared\CommonShared.projitems*{c1daabc1-b493-459d-bb4f-04fbefb1ba13}*SharedItemsImports = 4
+		CommonShared\CommonShared.projitems*{cf306116-bbf0-4cc7-afce-a506ac4752cb}*SharedItemsImports = 4
 		Cli-Shared\Cli-Shared.projitems*{dbd202c3-94d5-49d3-8ed1-c72637ba7d90}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Adds GIT_TRACE like support by added a new `Trace` class in `Microsoft.Alm.Git`. Requires that the `Microsoft.Alm.Git` assembly be a dependency of basically everything else.

Fixes up many of the strings and formatting of traced data.

Resolves #292 