### PR TITLE
Support New VSTS Identity Service Requirements

### DIFF
--- a/Microsoft.Alm.Authentication/Global.cs
+++ b/Microsoft.Alm.Authentication/Global.cs
@@ -30,6 +30,16 @@ namespace Microsoft.Alm.Authentication
     public static class Global
     {
         /// <summary>
+        /// The maximum number of redirects that the request follows.
+        /// </summary>
+        public const int MaxAutomaticRedirections = 16;
+
+        /// <summary>
+        /// The maximum wait time for a network request before timing out
+        /// </summary>
+        public const int RequestTimeout = 15 * 1000; // 15 second limit
+
+        /// <summary>
         /// <para>Gets or sets the user-agent string sent as part of the header in any HTTP operations.</para>
         /// <para>Defaults to a value contrived based on the executing assembly.</para>
         /// </summary>

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Global.cs" />
     <Compile Include="IGitHubAuthentication.cs" />
     <Compile Include="IGitHubAuthority.cs" />
+    <Compile Include="VstsLocationServiceException.cs" />
     <Compile Include="SecretCache.cs" />
     <Compile Include="TokenScope.cs" />
     <Compile Include="TargetUri.cs" />

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -148,15 +148,6 @@ namespace Microsoft.Alm.Authentication
         }
 
         /// <summary>
-        /// Gets a canonical string representation for the <see cref="ActualUri"/>.
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
-        {
-            return ActualUri.ToString();
-        }
-
-        /// <summary>
         /// Gets the client header enabled to work with proxies as necissary.
         /// </summary>
         public HttpClientHandler HttpClientHandler
@@ -164,14 +155,32 @@ namespace Microsoft.Alm.Authentication
             get
             {
                 bool useProxy = ProxyUri != null;
-                return new HttpClientHandler()
+
+                var client = new HttpClientHandler()
                 {
-                    Proxy = WebProxy,
+                    AllowAutoRedirect = true,
+                    UseCookies = true,
                     UseProxy = useProxy,
-                    MaxAutomaticRedirections = 2,
-                    UseDefaultCredentials = true
+                    MaxAutomaticRedirections = Global.MaxAutomaticRedirections,
+                    UseDefaultCredentials = true,
                 };
+
+                if (useProxy)
+                {
+                    client.Proxy = WebProxy;
+                }
+
+                return client;
             }
+        }
+
+        /// <summary>
+        /// Gets a canonical string representation for the <see cref="ActualUri"/>.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return ActualUri.ToString();
         }
 
         /// <summary>

--- a/Microsoft.Alm.Authentication/VstsLocationServiceException.cs
+++ b/Microsoft.Alm.Authentication/VstsLocationServiceException.cs
@@ -1,0 +1,45 @@
+﻿/**** Git Credential Manager for Windows ****
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the """"Software""""), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+**/
+
+using System;
+
+namespace Microsoft.Alm.Authentication
+{
+    public sealed class VstsLocationServiceException : Exception
+    {
+        internal VstsLocationServiceException(string message)
+            : base(message)
+        { }
+
+        internal VstsLocationServiceException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+
+        [System.Security.SecuritySafeCritical]
+        internal VstsLocationServiceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        { }
+    }
+}


### PR DESCRIPTION
* Add support for for querying Vsts Location Service to discover the dynamic URL of the Vsts Identity service.
* Refactor the heck out of `VstsAzureAuthority` to minimize code duplication.
* Improve `TargetUri.HttpClientHandler` to make use of `Global` values.
* Centralize more of the global constant values in the `Global` class.
* Try to make sure all network connections are using the correct HTTP user-agent value.

Resolves #295 

/CC @alvarollmenezes, @gholliday, @vizeke to help insure this doesn't break existing proxy support