### PR TITLE
Make GCM survive SourceTree

### DIFF
--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Alm.Cli
                     var iter = Environment.GetEnvironmentVariables().GetEnumerator();
                     while (iter.MoveNext())
                     {
-                        _environmentVariables.Add(iter.Key as string, iter.Value as string);
+                        _environmentVariables[iter.Key as string] = iter.Value as string;
                     }
                 }
                 return _environmentVariables;


### PR DESCRIPTION
Fix fault during hash table population caused by SourceTree adding an extranious 'home" environmental variable when "HOME" was already present in the process.

Resolves #278 