### PR TITLE
Add console printing abstraction.

### DIFF
--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -200,19 +200,11 @@ namespace Microsoft.Alm.Cli
                 Exception innerException = exception.InnerExceptions.FirstOrDefault(e => !(e is AggregateException))
                                         ?? exception.InnerException;
 
-                Console.Error.WriteLine("Fatal: " + innerException.GetType().Name + " encountered.");
-                Git.Trace.WriteLine("Fatal: " + exception.ToString());
-                LogEvent(exception.ToString(), EventLogEntryType.Error);
-
-                Environment.ExitCode = -1;
+                Die(innerException);
             }
             catch (Exception exception)
             {
-                Console.Error.WriteLine("Fatal: " + exception.GetType().Name + " encountered.");
-                Git.Trace.WriteLine("Fatal: " + exception.ToString());
-                LogEvent(exception.ToString(), EventLogEntryType.Error);
-
-                Environment.ExitCode = -1;
+                Die(exception);
             }
 
             Trace.Flush();
@@ -246,8 +238,7 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Console.Error.WriteLine("Unable to open help documentation.");
-            Git.Trace.WriteLine("failed to open help documentation.");
+            Die("Unable to open help documentation.");
         }
     }
 }

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Alm.Cli
                     {
                         Program.LogEvent("No Git installation found, unable to continue deployment.", EventLogEntryType.Error);
                         Console.Out.WriteLine();
-                        Console.Error.WriteLine($"Fatal: custom path does not exist: '{_customPath}'. {FailFace}");
+                        Program.WriteLine($"Fatal: custom path does not exist: '{_customPath}'. {FailFace}");
                         Pause();
 
                         Result = ResultValue.InvalidCustomPath;
@@ -248,7 +248,7 @@ namespace Microsoft.Alm.Cli
                 {
                     Program.LogEvent("No Git installation found, unable to continue.", EventLogEntryType.Error);
                     Console.Out.WriteLine();
-                    Console.Error.WriteLine("Fatal: Git was not detected, unable to continue. {FailFace}");
+                    Program.WriteLine("Fatal: Git was not detected, unable to continue. {FailFace}");
                     Pause();
 
                     Result = ResultValue.GitNotFound;
@@ -288,12 +288,12 @@ namespace Microsoft.Alm.Cli
                     else if (_isForced)
                     {
                         Program.LogEvent($"Deployment to '{installation.Path}' failed.", EventLogEntryType.Warning);
-                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
+                        Program.WriteLine($"  deployment failed. {FailFace}");
                     }
                     else
                     {
                         Program.LogEvent($"Deployment to '{installation.Path}' failed.", EventLogEntryType.Error);
-                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
+                        Program.WriteLine($"  deployment failed. {FailFace}");
                         Pause();
 
                         Result = ResultValue.DeploymentFailed;
@@ -334,12 +334,12 @@ namespace Microsoft.Alm.Cli
                 else if (_isForced)
                 {
                     Program.LogEvent($"Deployment to '{UserBinPath}' failed.", EventLogEntryType.Warning);
-                    Console.Error.WriteLine($"  deployment failed. {FailFace}");
+                    Program.WriteLine($"  deployment failed. {FailFace}");
                 }
                 else
                 {
                     Program.LogEvent($"Deployment to '{UserBinPath}' failed.", EventLogEntryType.Error);
-                    Console.Error.WriteLine($"  deployment failed. {FailFace}");
+                    Program.WriteLine($"  deployment failed. {FailFace}");
                     Pause();
 
                     Result = ResultValue.DeploymentFailed;
@@ -373,12 +373,12 @@ namespace Microsoft.Alm.Cli
                     else if (_isForced)
                     {
                         Program.LogEvent($"Deployment to '{CygwinPath}' failed.", EventLogEntryType.Warning);
-                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
+                        Program.WriteLine($"  deployment failed. {FailFace}");
                     }
                     else
                     {
                         Program.LogEvent($"Deployment to '{CygwinPath}' failed.", EventLogEntryType.Error);
-                        Console.Error.WriteLine($"  deployment failed. {FailFace}");
+                        Program.WriteLine($"  deployment failed. {FailFace}");
                         Pause();
 
                         Result = ResultValue.DeploymentFailed;
@@ -398,7 +398,7 @@ namespace Microsoft.Alm.Cli
                     else
                     {
                         Console.Out.WriteLine();
-                        Console.Error.WriteLine("Fatal: Unable to update your ~/.gitconfig correctly.");
+                        Program.WriteLine("Fatal: Unable to update your ~/.gitconfig correctly.");
 
                         Result = ResultValue.GitConfigGlobalFailed;
                         return;
@@ -469,7 +469,7 @@ namespace Microsoft.Alm.Cli
                     if (!Directory.Exists(_customPath))
                     {
                         Console.Out.WriteLine();
-                        Console.Error.WriteLine($"Fatal: custom path does not exist: '{_customPath}'. U_U");
+                        Program.WriteLine($"fatal: custom path does not exist: '{_customPath}'. U_U");
                         Pause();
 
                         Result = ResultValue.InvalidCustomPath;
@@ -511,7 +511,7 @@ namespace Microsoft.Alm.Cli
                 {
                     Program.LogEvent($"Git was not detected, unable to continue with removal.", EventLogEntryType.Error);
                     Console.Out.WriteLine();
-                    Console.Error.WriteLine("Fatal: Git was not detected, unable to continue. U_U");
+                    Program.WriteLine("fatal: Git was not detected, unable to continue. U_U");
                     Pause();
 
                     Result = ResultValue.GitNotFound;
@@ -536,13 +536,13 @@ namespace Microsoft.Alm.Cli
                         if (!_isForced)
                         {
                             // only 'fatal' when not forced
-                            Console.Error.Write("Fatal: ");
+                            Program.Write("Fatal: ");
 
                             Result = ResultValue.GitConfigSystemFailed;
                             return;
                         }
 
-                        Console.Error.WriteLine("Unable to update your /etc/gitconfig correctly.");
+                        Program.WriteLine("Unable to update your /etc/gitconfig correctly.");
                     }
 
                     if ((updateTypes & Configuration.Type.Global) == Configuration.Type.Global)
@@ -552,7 +552,7 @@ namespace Microsoft.Alm.Cli
                     else
                     {
                         Console.Out.WriteLine();
-                        Console.Error.WriteLine("Fatal: Unable to update your ~/.gitconfig correctly.");
+                        Program.WriteLine("Fatal: Unable to update your ~/.gitconfig correctly.");
 
                         Result = ResultValue.GitConfigGlobalFailed;
                         return;

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Alm.Cli
 
                 Git.Trace.WriteLine("prompting user for url.");
 
-                Console.Out.WriteLine(" Target Url:");
+                Program.WriteLine(" Target Url:");
                 url = Console.In.ReadLine();
             }
             else
@@ -118,10 +118,10 @@ namespace Microsoft.Alm.Cli
                         return;
                     }
 
-                    Console.Error.WriteLine(" credentials are protected by perserve flag, clear anyways? [Y]es, [N]o.");
+                    Program.WriteLine(" credentials are protected by perserve flag, clear anyways? [Y]es, [N]o.");
 
                     ConsoleKeyInfo key;
-                    while ((key = Console.ReadKey(true)).Key != ConsoleKey.Escape)
+                    while ((key = Program.ReadKey(true)).Key != ConsoleKey.Escape)
                     {
                         if (key.KeyChar == 'N' || key.KeyChar == 'n')
                             return;
@@ -196,8 +196,7 @@ namespace Microsoft.Alm.Cli
             return;
 
             error_parse:
-            Git.Trace.WriteLine($"Fatal: unable to parse target URI.");
-            Console.Error.WriteLine("Fatal: unable to parse target URI.");
+            Die("Unable to parse target URI.");
         }
 
         private static void Deploy()
@@ -207,7 +206,7 @@ namespace Microsoft.Alm.Cli
 
             Git.Trace.WriteLine($"Installer result = '{installer.Result}', exit code = {installer.ExitCode}.");
 
-            Environment.Exit(installer.ExitCode);
+            Program.Exit(installer.ExitCode);
         }
 
         private static void Erase()
@@ -314,39 +313,19 @@ namespace Microsoft.Alm.Cli
                 Exception innerException = exception.InnerExceptions.FirstOrDefault(e => !(e is AggregateException))
                                         ?? exception.InnerException;
 
-                Console.Error.WriteLine("Fatal: " + innerException.GetType().Name + " encountered.");
-                if (!String.IsNullOrWhiteSpace(innerException.Message))
-                {
-                    Console.Error.WriteLine("   " + innerException.Message);
-                }
-
-                Git.Trace.WriteLine("Fatal: " + exception.ToString());
-                LogEvent(exception.ToString(), EventLogEntryType.Error);
-
-                Environment.ExitCode = -1;
+                Die(exception);
             }
             catch (Exception exception)
             {
-                Console.Error.WriteLine("Fatal: " + exception.GetType().Name + " encountered.");
-                if (!String.IsNullOrWhiteSpace(exception.Message))
-                {
-                    Console.Error.WriteLine("   " + exception.Message);
-                }
-
-                Git.Trace.WriteLine("Fatal: " + exception.ToString());
-                LogEvent(exception.ToString(), EventLogEntryType.Error);
-
-                Environment.ExitCode = -1;
+                Die(exception);
             }
-
-            Trace.Flush();
         }
 
         private static void PrintHelpMessage()
         {
             const string HelpFileName = "git-credential-manager.html";
 
-            Console.Out.WriteLine("usage: git credential-manager [" + String.Join("|", CommandList) + "] [<args>]");
+            Program.WriteLine("usage: git credential-manager [" + String.Join("|", CommandList) + "] [<args>]");
 
             List<Git.GitInstallation> installations;
             if (Git.Where.FindGitInstallations(out installations))
@@ -370,8 +349,7 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Console.Error.WriteLine("Unable to open help documentation.");
-            Git.Trace.WriteLine("failed to open help documentation.");
+            Die("Unable to open help documentation.");
         }
 
         private static void Remove()
@@ -381,7 +359,7 @@ namespace Microsoft.Alm.Cli
 
             Git.Trace.WriteLine($"Installer result = {installer.Result}, exit code = {installer.ExitCode}.");
 
-            Environment.Exit(installer.ExitCode);
+            Program.Exit(installer.ExitCode);
         }
 
         private static void Store()

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -43,8 +43,7 @@ namespace Microsoft.Alm.Cli
 
             if (readableStream == Stream.Null || !readableStream.CanRead)
             {
-                Console.Error.WriteLine("Fatal: unable to read input.");
-                Environment.Exit(-1);
+                Program.Die("Unable to read input.");
             }
             else
             {
@@ -64,6 +63,11 @@ namespace Microsoft.Alm.Cli
                     if (read == buffer.Length)
                     {
                         Array.Resize(ref buffer, buffer.Length * 2);
+                    }
+
+                    if ((read > 0 && read < 3 && buffer[read - 1] == '\n'))
+                    {
+                        Program.Die("Invalid input, please see 'https://www.kernel.org/pub/software/scm/git/docs/git-credential.html'.");
                     }
 
                     // the input ends with LFLF, check for that and break the read loop


### PR DESCRIPTION
Basically, all output from the GCM should go to stderr, this adds indirection to insure it does. Additionally, ReadKey doesn't block waiting for input from the user if there's no TTY present.