### PR TITLE
Added useHttpUsername setting

### DIFF
--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -191,6 +191,49 @@ namespace Microsoft.Alm.Cli.Test
             CreateTargetUriTestWithPath(input);
         }
 
+        [TestMethod]
+        public void CreateTargetUri_GithubUseUsername()
+        {
+            var input = new InputArg()
+            {
+                Protocol = "https",
+                Host = "github.com",
+                Username = "username",
+                Path = "server/path",
+            };
+
+            CreateTargetUriTestUseUsername(input, false, false, "https://github.com/");
+            CreateTargetUriTestUseUsername(input, false, true, "https://username@github.com/");
+            CreateTargetUriTestUseUsername(input, true, false, "https://github.com/server/path");
+            CreateTargetUriTestUseUsername(input, true, true, "https://username@github.com/server/path");
+        }
+
+
+        private void CreateTargetUriTestUseUsername(InputArg input, bool useHttpPath, bool useHttpUsername, string expectedUri)
+        {
+            using (var memory = new MemoryStream())
+            using (var writer = new StreamWriter(memory))
+            {
+                writer.Write(input.ToString());
+                writer.Flush();
+
+                memory.Seek(0, SeekOrigin.Begin);
+
+                var oparg = new OperationArguments(memory);
+                oparg.UseHttpPath = useHttpPath;
+                oparg.UseHttpUsername = useHttpUsername;
+
+                Assert.IsNotNull(oparg);
+                Assert.AreEqual(input.Protocol ?? string.Empty, oparg.QueryProtocol);
+                Assert.AreEqual(input.Host ?? string.Empty, oparg.QueryHost);
+                Assert.AreEqual(input.Path, oparg.QueryPath);
+                Assert.AreEqual(input.Username, oparg.CredUsername);
+                Assert.AreEqual(input.Password, oparg.CredPassword);
+
+                Assert.AreEqual(expectedUri, oparg.TargetUri.ToString());
+            }
+        }
+
         private void CreateTargetUriTestDefault(InputArg input)
         {
             using (var memory = new MemoryStream())

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Alm.Cli
             this.ValidateCredentials = true;
             this.WriteLog = false;
             _useHttpPath = false;
+            _useHttpUsername = false;
         }
 
         public AuthorityType Authority { get; set; }
@@ -274,6 +275,15 @@ namespace Microsoft.Alm.Cli
                 CreateTargetUri();
             }
         }
+        public bool UseHttpUsername
+        {
+            get { return _useHttpUsername; }
+            set
+            {
+                _useHttpUsername = value;
+                CreateTargetUri();
+            }
+        }
         public bool UseModalUi { get; set; }
         public bool ValidateCredentials { get; set; }
         public bool WriteLog { get; set; }
@@ -287,6 +297,7 @@ namespace Microsoft.Alm.Cli
         private string _queryProtocol;
         private TargetUri _targetUri;
         private bool _useHttpPath;
+        private bool _useHttpUsername;
         private string _username;
 
         public void LoadConfiguration()
@@ -372,6 +383,15 @@ namespace Microsoft.Alm.Cli
             string queryUrl = null;
             string proxyUrl = _proxyUri?.ToString();
 
+            string userPrefix = "";
+            if (_useHttpUsername)
+            {
+                if (!String.IsNullOrWhiteSpace(_username))
+                {
+                    userPrefix = Uri.EscapeDataString(_username) + "@";
+                }
+            }
+
             // when the target requests a path...
             if (UseHttpPath)
             {
@@ -388,6 +408,7 @@ namespace Microsoft.Alm.Cli
                     {
                         queryUrl = $"{_queryHost}/{_queryPath}";
                     }
+					actualUrl = queryUrl;
                 }
                 // and has a protocol...
                 else
@@ -395,16 +416,16 @@ namespace Microsoft.Alm.Cli
                     // and the target lacks a path, combine protocol + host
                     if (String.IsNullOrWhiteSpace(_queryPath))
                     {
-                        queryUrl = $"{_queryProtocol}://{_queryHost}";
+                        queryUrl = $"{_queryProtocol}://{userPrefix}{_queryHost}";
+                        actualUrl = $"{_queryProtocol}://{_queryHost}";
                     }
                     // combine protocol + host + path
                     else
                     {
-                        queryUrl = $"{_queryProtocol}://{_queryHost}/{_queryPath}";
+                        queryUrl = $"{_queryProtocol}://{userPrefix}{_queryHost}/{_queryPath}";
+                        actualUrl = $"{_queryProtocol}://{_queryHost}/{_queryPath}";
                     }
                 }
-
-                actualUrl = queryUrl;
             }
             // when the target ignores paths...
             else
@@ -453,15 +474,15 @@ namespace Microsoft.Alm.Cli
                 // combine the protocol + host
                 else
                 {
-                    queryUrl = $"{_queryProtocol}://{_queryHost}";
+                    queryUrl = $"{_queryProtocol}://{userPrefix}{_queryHost}";
 
                     if (String.IsNullOrWhiteSpace(_queryPath))
                     {
-                        actualUrl = queryUrl;
+                        actualUrl = $"{_queryProtocol}://{_queryHost}";
                     }
                     else
                     {
-                        actualUrl = $"{queryUrl}/{_queryPath}";
+                        actualUrl = $"{_queryProtocol}://{_queryHost}/{_queryPath}";
                     }
                 }
             }

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Alm.Cli
         internal const string ConfigNamespaceKey = "namespace";
         internal const string ConfigPreserveCredentialsKey = "preserve";
         internal const string ConfigUseHttpPathKey = "useHttpPath";
+        internal const string ConfigUseHttpUsernameKey = "useHttpUsername";
         internal const string ConfigUseModalPromptKey = "modalPrompt";
         internal const string ConfigValidateKey = "validate";
         internal const string ConfigWritelogKey = "writelog";
@@ -609,6 +610,13 @@ namespace Microsoft.Alm.Cli
             if (TryReadBoolean(operationArguments, ConfigUseHttpPathKey, null, operationArguments.UseHttpPath, out useHttpPath))
             {
                 operationArguments.UseHttpPath = useHttpPath.Value;
+            }
+
+            // look for http username user config settings
+            bool? useHttpUsername;
+            if (TryReadBoolean(operationArguments, ConfigUseHttpUsernameKey, null, operationArguments.UseHttpUsername, out useHttpUsername))
+            {
+                operationArguments.UseHttpUsername = useHttpUsername.Value;
             }
 
             // look for http proxy config settings


### PR DESCRIPTION
I've implemented a new option useHttpUserName to support #322. It adds the username to the targetURL for http(s) repositories when this option is true.