### PR TITLE
Improve basic authentication support.

### DIFF
--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -361,6 +361,20 @@ namespace Microsoft.Alm.Cli
             var secrets = new SecretStore(secretsNamespace, null, null, Secret.UriToName);
             BaseAuthentication authority = null;
 
+            var basicCredentialCallback = (operationArguments.UseModalUi)
+                    ? new AcquireCredentialsDelegate(Program.ModalPromptForCredentials)
+                    : new AcquireCredentialsDelegate(Program.BasicCredentialPrompt);
+
+            var githubCredentialCallback = (operationArguments.UseModalUi)
+                    ? new GitHubAuthentication.AcquireCredentialsDelegate(GitHub.Authentication.AuthenticationPrompts.CredentialModalPrompt)
+                    : new GitHubAuthentication.AcquireCredentialsDelegate(Program.GitHubCredentialPrompt);
+
+            var githubAuthcodeCallback = (operationArguments.UseModalUi)
+                    ? new GitHubAuthentication.AcquireAuthenticationCodeDelegate(GitHub.Authentication.AuthenticationPrompts.AuthenticationCodeModalPrompt)
+                    : new GitHubAuthentication.AcquireAuthenticationCodeDelegate(Program.GitHubAuthCodePrompt);
+
+            NtlmSupport basicNtlmSupport = NtlmSupport.Auto;
+
             switch (operationArguments.Authority)
             {
                 case AuthorityType.Auto:
@@ -373,13 +387,9 @@ namespace Microsoft.Alm.Cli
                              ?? GitHubAuthentication.GetAuthentication(operationArguments.TargetUri,
                                                                        GitHubCredentialScope,
                                                                        secrets,
-                                                                       operationArguments.UseModalUi
-                                                                         ? new GitHubAuthentication.AcquireCredentialsDelegate(GitHub.Authentication.AuthenticationPrompts.CredentialModalPrompt)
-                                                                         : new GitHubAuthentication.AcquireCredentialsDelegate(GitHubCredentialPrompt),
-                                                                       operationArguments.UseModalUi
-                                                                         ? new GitHubAuthentication.AcquireAuthenticationCodeDelegate(GitHub.Authentication.AuthenticationPrompts.AuthenticationCodeModalPrompt)
-                                                                         : new GitHubAuthentication.AcquireAuthenticationCodeDelegate(GitHubAuthCodePrompt),
-                                                                       null); ;
+                                                                       githubCredentialCallback,
+                                                                       githubAuthcodeCallback,
+                                                                       null);
 
                     if (authority != null)
                     {
@@ -412,28 +422,20 @@ namespace Microsoft.Alm.Cli
                     return authority ?? new VstsAadAuthentication(Guid.Empty, VstsCredentialScope, secrets);
 
                 case AuthorityType.Basic:
-                default:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is basic.");
-
-                    // return a generic username + password authentication object
-                    return authority ?? new BasicAuthentication(secrets,
-                                                                operationArguments.UseModalUi
-                                                                  ? new AcquireCredentialsDelegate(Program.ModalPromptForCredentials)
-                                                                  : new AcquireCredentialsDelegate(Program.BasicCredentialPrompt),
-                                                                null);
+                    // enforce basic authentication only
+                    basicNtlmSupport = NtlmSupport.Never;
+                    goto default;                    
 
                 case AuthorityType.GitHub:
                     Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is GitHub.");
 
+                    
+
                     // return a GitHub authentication object
                     return authority ?? new GitHubAuthentication(GitHubCredentialScope,
                                                                  secrets,
-                                                                 operationArguments.UseModalUi
-                                                                    ? new GitHubAuthentication.AcquireCredentialsDelegate(GitHub.Authentication.AuthenticationPrompts.CredentialModalPrompt)
-                                                                    : new GitHubAuthentication.AcquireCredentialsDelegate(GitHubCredentialPrompt),
-                                                                 operationArguments.UseModalUi
-                                                                    ? new GitHubAuthentication.AcquireAuthenticationCodeDelegate(GitHub.Authentication.AuthenticationPrompts.AuthenticationCodeModalPrompt)
-                                                                    : new GitHubAuthentication.AcquireAuthenticationCodeDelegate(GitHubAuthCodePrompt),
+                                                                 githubCredentialCallback,
+                                                                 githubAuthcodeCallback,
                                                                  null);
 
                 case AuthorityType.MicrosoftAccount:
@@ -441,6 +443,17 @@ namespace Microsoft.Alm.Cli
 
                     // return the allocated authority or a generic MSA backed VSTS authentication object
                     return authority ?? new VstsMsaAuthentication(VstsCredentialScope, secrets);
+
+                case AuthorityType.Ntlm:
+                    // enforce NTLM authentication only
+                    basicNtlmSupport = NtlmSupport.Always;
+                    goto default;
+
+                default:
+                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is basic with NTLM={basicNtlmSupport}.");
+
+                    // return a generic username + password authentication object
+                    return authority ?? new BasicAuthentication(secrets, basicNtlmSupport, basicCredentialCallback, null);
             }
         }
 
@@ -970,7 +983,8 @@ namespace Microsoft.Alm.Cli
                         Task.Run(async () =>
                         {
                             // attempt to get cached creds or acquire creds if interactivity is allowed
-                            if ((credentials = authentication.GetCredentials(operationArguments.TargetUri)) != null
+                            if ((operationArguments.Interactivity != Interactivity.Always
+                                    &&(credentials = authentication.GetCredentials(operationArguments.TargetUri)) != null)
                                 || (operationArguments.Interactivity != Interactivity.Never
                                     && (credentials = await basicAuth.AcquireCredentials(operationArguments.TargetUri)) != null))
                             {

--- a/Microsoft.Alm.Authentication.Test/BasicAuthTests.cs
+++ b/Microsoft.Alm.Authentication.Test/BasicAuthTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Alm.Authentication.Test
         {
             ICredentialStore credentialStore = new SecretCache(@namespace);
 
-            return new BasicAuthentication(credentialStore, null, null);
+            return new BasicAuthentication(credentialStore, NtlmSupport.Auto, null, null);
         }
     }
 }

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Global.cs" />
     <Compile Include="IGitHubAuthentication.cs" />
     <Compile Include="IGitHubAuthority.cs" />
+    <Compile Include="NtlmSupport.cs" />
     <Compile Include="WwwAuthenticateHelper.cs" />
     <Compile Include="VstsLocationServiceException.cs" />
     <Compile Include="SecretCache.cs" />

--- a/Microsoft.Alm.Authentication/NtlmSupport.cs
+++ b/Microsoft.Alm.Authentication/NtlmSupport.cs
@@ -1,0 +1,47 @@
+﻿/**** Git Credential Manager for Windows ****
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the """"Software""""), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+**/
+
+namespace Microsoft.Alm.Authentication
+{
+    public enum NtlmSupport
+    {
+        /// <summary>
+        /// <para>The authentication class should attempt to detect and prefer
+        /// NTML credentials over basic credentials.</para>
+        /// <para>This is the default.</para>
+        /// </summary>
+        Auto,
+        /// <summary>
+        /// The authentication class should only detect and return NTML
+        /// credentials.
+        /// </summary>
+        Never,
+        /// <summary>
+        /// The authentication class should never detect nor return
+        /// NTML credentials.
+        /// </summary>
+        Always,
+    }
+}


### PR DESCRIPTION
Allow for enforcement of how to handle NTLM: auto, always, or never (aka basic only).