### PR TITLE
Add AAD login hint for VSTS non-interactive authentication.

### DIFF
--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -190,6 +190,7 @@ namespace Microsoft.Alm.Cli
             }
         }
         public Interactivity Interactivity { get; set; }
+        public string LoginHint  { get; set; }
         public bool PreserveCredentials { get; set; }
         public Uri ProxyUri
         {

--- a/Docs/Automation.md
+++ b/Docs/Automation.md
@@ -27,3 +27,7 @@
  To avoid unnecessary service account credential validation, when relying on Microsoft Account or Azure Active Directory use:
 
      git config --global credential.validate false
+
+ If your Azure Directory uses an ADFS authority other than visualstudio.com, use:
+	
+	 git config --global authority.microsoft.visualstudio.com.loginhint microsoft.com

--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -53,6 +53,15 @@
   `git config --global credential.microsoft.visualstudio.com.interactive never`
 
 
+### loginhint
+
+ Specifies an Azure Active Directory login hint. 
+ This is helpful in non-interactive scenarios requiring an authoritative domain apart from visualstudio.com.
+
+ Hints are typically of the form: "username@domain" or "domain" without quotes.
+
+  `git config --global authority.microsoft.visualstudio.com.loginhint microsoft.com`
+
 ### modalPrompt
 
  Forces authentication to use a modal dialog instead of asking for credentials at the command prompt.

--- a/Microsoft.Alm.Authentication.Test/AuthorityFake.cs
+++ b/Microsoft.Alm.Authentication.Test/AuthorityFake.cs
@@ -1,10 +1,18 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Alm.Authentication.Test
 {
     internal class AuthorityFake : IVstsAuthority
     {
+        public AuthorityFake(string expectedQueryParameters)
+        {
+            this.ExpectedQueryParameters = expectedQueryParameters;
+        }
+
+        internal readonly string ExpectedQueryParameters; 
+
         public async Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token accessToken, VstsTokenScope tokenScope, bool requireCompactToken)
         {
             return await Task.Run(() => { return new Token("personal-access-token", TokenType.Personal); });
@@ -12,11 +20,15 @@ namespace Microsoft.Alm.Authentication.Test
 
         public async Task<Token> InteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri, string queryParameters = null)
         {
+            Assert.AreEqual(this.ExpectedQueryParameters, queryParameters);
+
             return await Task.Run(() => { return new Token("token-access", TokenType.Access); });
         }
 
         public async Task<Token> NoninteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri, string queryParameters = null)
         {
+            Assert.AreEqual(this.ExpectedQueryParameters, queryParameters);
+
             return await Task.Run(() => { return new Token("token-access", TokenType.Access); });
         }
 

--- a/Microsoft.Alm.Authentication.Test/VstsMsaTests.cs
+++ b/Microsoft.Alm.Authentication.Test/VstsMsaTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Alm.Authentication.Test
         {
             ICredentialStore tokenStore1 = new SecretCache(@namespace + 1);
             ITokenStore tokenStore2 = new SecretCache(@namespace + 2);
-            IVstsAuthority liveAuthority = new AuthorityFake();
+            IVstsAuthority liveAuthority = new AuthorityFake(VstsMsaAuthentication.QueryParameters);
             return new VstsMsaAuthentication(tokenStore1, tokenStore2, liveAuthority);
         }
     }

--- a/Microsoft.Alm.Authentication/BaseVstsAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BaseVstsAuthentication.cs
@@ -243,13 +243,15 @@ namespace Microsoft.Alm.Authentication
         /// An implementation of <see cref="BaseAuthentication"/> if one was detected;
         /// <see langword="null"/> otherwise.
         /// </param>
+        /// <param name="authenticationHint">An optional authentication hint for AAD</param>
         /// <returns>
         /// <see langword="true"/> if an authority could be determined; <see langword="false"/> otherwise.
         /// </returns>
         public static BaseAuthentication GetAuthentication(
             TargetUri targetUri,
             VstsTokenScope scope,
-            ICredentialStore personalAccessTokenStore)
+            ICredentialStore personalAccessTokenStore,
+            string authenticationHint)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             if (ReferenceEquals(scope, null))
@@ -271,7 +273,7 @@ namespace Microsoft.Alm.Authentication
                 else
                 {
                     Git.Trace.WriteLine($"AAD authority for tenant '{tenantId}' detected.");
-                    authentication = new VstsAadAuthentication(tenantId, scope, personalAccessTokenStore);
+                    authentication = new VstsAadAuthentication(tenantId, scope, personalAccessTokenStore, authenticationHint);
                     (authentication as VstsAadAuthentication).TenantId = tenantId;
                 }
             }

--- a/Microsoft.Alm.Authentication/VstsMsaAuthentication.cs
+++ b/Microsoft.Alm.Authentication/VstsMsaAuthentication.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Alm.Authentication
     public sealed class VstsMsaAuthentication : BaseVstsAuthentication, IVstsMsaAuthentication
     {
         public const string DefaultAuthorityHost = AzureAuthority.AuthorityHostUrlBase + "/live.com";
+        internal const string QueryParameters = "domain_hint=live.com&display=popup&site_id=501454&nux=1";
 
         public VstsMsaAuthentication(VstsTokenScope tokenScope, ICredentialStore personalAccessTokenStore)
             : base(tokenScope, personalAccessTokenStore)
@@ -70,8 +71,6 @@ namespace Microsoft.Alm.Authentication
         /// otherwise <see langword="null"/>.</returns>
         public async Task<Credential> InteractiveLogon(TargetUri targetUri, bool requireCompactToken)
         {
-            const string QueryParameters = "domain_hint=live.com&display=popup&site_id=501454&nux=1";
-
             BaseSecureStore.ValidateTargetUri(targetUri);
 
             try


### PR DESCRIPTION
Azure Active Directory service's non-interactive flow relies greatly on knowledge of the authoritative domain to perform ADFS checks, which in turn are necessary to allow non-interactive authentication. Since VSTS hosted services are always found @visualstudio.com, Azure isn't always able to lookup the authoritative ADFS domain. Including the domain information in the request, greatly increases the likelihood of non-interactive authentication succeeding when allowed.