### PR TITLE
Fix analyzer warning

### DIFF
--- a/Microsoft.Alm.Authentication/VstsLocationServiceException.cs
+++ b/Microsoft.Alm.Authentication/VstsLocationServiceException.cs
@@ -27,6 +27,7 @@ using System;
 
 namespace Microsoft.Alm.Authentication
 {
+    [Serializable]
     public sealed class VstsLocationServiceException : Exception
     {
         internal VstsLocationServiceException(string message)


### PR DESCRIPTION
The analyzer was warning about ISerializable not having Serializable attribute. This change should silence that.