### PR TITLE
Remove unneeded switches from deployment scripts.

### DIFF
--- a/Cli-Askpass/Cli-Askpass.csproj
+++ b/Cli-Askpass/Cli-Askpass.csproj
@@ -102,18 +102,18 @@ SET src=$(TargetDir)
 
 IF NOT EXIST "%25dst%25" MKDIR "%25dst%25"
 
-COPY /V /Y "$(SolutionDir)LICENSE.txt" /A "%25src%25LICENSE.txt" /A
-COPY /V /Y "$(SolutionDir)README.md" /A "%25src%25README.md" /A
-COPY /V /Y "$(MSBuildProjectDirectory)\install.cmd" /A "%25src%25install.cmd" /A
-COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B
-COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" /B
-COPY /V /Y "%25src%25Microsoft.Alm.Authentication.dll" /B "%25dst%25Microsoft.Alm.Authentication.dll" /B
-COPY /V /Y "%25src%25Microsoft.Alm.Git.dll" /B "%25dst%25Microsoft.Alm.Git.dll" /B
-COPY /V /Y "%25src%25GitHub.Authentication.dll" /B "%25dst%25GitHub.Authentication.dll" /B
-COPY /V /Y "%25src%25git-askpass.exe" /B "%25dst%25git-askpass.exe" /B
-COPY /V /Y "%25src%25install.cmd" /A "%25dst%25install.cmd" /A
-COPY /V /Y "%25src%25README.md" /A "%25dst%25README.md" /A
-COPY /V /Y "%25src%25LICENSE.txt" /A "%25dst%25LICENSE.txt" /A
+COPY /V /Y "$(SolutionDir)LICENSE.txt" "%25src%25LICENSE.txt"
+COPY /V /Y "$(SolutionDir)README.md" "%25src%25README.md"
+COPY /V /Y "$(MSBuildProjectDirectory)\install.cmd" "%25src%25install.cmd"
+COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
+COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll"
+COPY /V /Y "%25src%25Microsoft.Alm.Authentication.dll" "%25dst%25Microsoft.Alm.Authentication.dll"
+COPY /V /Y "%25src%25Microsoft.Alm.Git.dll" "%25dst%25Microsoft.Alm.Git.dll"
+COPY /V /Y "%25src%25GitHub.Authentication.dll" "%25dst%25GitHub.Authentication.dll"
+COPY /V /Y "%25src%25git-askpass.exe" "%25dst%25git-askpass.exe"
+COPY /V /Y "%25src%25install.cmd" "%25dst%25install.cmd"
+COPY /V /Y "%25src%25README.md" "%25dst%25README.md"
+COPY /V /Y "%25src%25LICENSE.txt" "%25dst%25LICENSE.txt"
     </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/Cli-CredentialHelper/Cli-CredentialHelper.csproj
+++ b/Cli-CredentialHelper/Cli-CredentialHelper.csproj
@@ -83,18 +83,18 @@ SET src=$(TargetDir)
 
 IF NOT EXIST "%25dst%25" MKDIR "%25dst%25"
 
-COPY /V /Y "$(SolutionDir)LICENSE.txt" /A "%25src%25LICENSE.txt" /A
-COPY /V /Y "$(SolutionDir)README.md" /A "%25src%25README.md" /A
-COPY /V /Y "$(MSBuildProjectDirectory)\install.cmd" /A "%25src%25install.cmd" /A
-COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" /B
-COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll" /B "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll" /B
-COPY /V /Y "%25src%25Microsoft.Alm.Authentication.dll" /B "%25dst%25Microsoft.Alm.Authentication.dll" /B
-COPY /V /Y "%25src%25Microsoft.Alm.Git.dll" /B "%25dst%25Microsoft.Alm.Git.dll" /B
-COPY /V /Y "%25src%25GitHub.Authentication.exe" /B "%25dst%25GitHub.Authentication.exe" /B
-COPY /V /Y "%25src%25git-credential-manager.exe" /B "%25dst%25git-credential-manager.exe" /B
-COPY /V /Y "%25src%25install.cmd" /A "%25dst%25install.cmd" /A
-COPY /V /Y "%25src%25README.md" /A "%25dst%25README.md" /A
-COPY /V /Y "%25src%25LICENSE.txt" /A "%25dst%25LICENSE.txt" /A
+COPY /V /Y "$(SolutionDir)LICENSE.txt" "%25src%25LICENSE.txt"
+COPY /V /Y "$(SolutionDir)README.md" "%25src%25README.md"
+COPY /V /Y "$(MSBuildProjectDirectory)\install.cmd" "%25src%25install.cmd"
+COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll" "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
+COPY /V /Y "%25src%25Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll" "%25dst%25Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll"
+COPY /V /Y "%25src%25Microsoft.Alm.Authentication.dll" "%25dst%25Microsoft.Alm.Authentication.dll"
+COPY /V /Y "%25src%25Microsoft.Alm.Git.dll" "%25dst%25Microsoft.Alm.Git.dll"
+COPY /V /Y "%25src%25GitHub.Authentication.exe" "%25dst%25GitHub.Authentication.exe"
+COPY /V /Y "%25src%25git-credential-manager.exe" "%25dst%25git-credential-manager.exe"
+COPY /V /Y "%25src%25install.cmd" "%25dst%25install.cmd"
+COPY /V /Y "%25src%25README.md" "%25dst%25README.md"
+COPY /V /Y "%25src%25LICENSE.txt" "%25dst%25LICENSE.txt"
 
 "$(ProjectDir)build-docs.cmd"
     </PostBuildEvent>

--- a/GitHub.Authentication/GitHub.Authentication.csproj
+++ b/GitHub.Authentication/GitHub.Authentication.csproj
@@ -233,12 +233,12 @@ SET src=$(TargetDir)
 
 IF NOT EXIST "%25dst%25" MKDIR "%25dst%25"
 
-COPY /V /Y "$(SolutionDir)LICENSE.txt" /A "%25src%25LICENSE.txt" /A
-COPY /V /Y "$(SolutionDir)README.md" /A "%25src%25README.md" /A
-COPY /V /Y "%25src%25github.authentication.exe" /B "%25dst%25github.authentication.exe" /B
-COPY /V /Y "%25src%25install.cmd" /A "%25dst%25install.cmd" /A
-COPY /V /Y "%25src%25README.md" /A "%25dst%25README.md" /A
-COPY /V /Y "%25src%25LICENSE.txt" /A "%25dst%25LICENSE.txt" /A
+COPY /V /Y "$(SolutionDir)LICENSE.txt" "%25src%25LICENSE.txt"
+COPY /V /Y "$(SolutionDir)README.md" "%25src%25README.md"
+COPY /V /Y "%25src%25github.authentication.exe" "%25dst%25github.authentication.exe"
+COPY /V /Y "%25src%25install.cmd" "%25dst%25install.cmd"
+COPY /V /Y "%25src%25README.md" "%25dst%25README.md"
+COPY /V /Y "%25src%25LICENSE.txt" "%25dst%25LICENSE.txt"
     </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
Without this patch we end up with bogus characters in the deployed files.

![before](https://cloud.githubusercontent.com/assets/349621/22009520/7d2389a2-dc8c-11e6-8eb6-9afacf75def8.png)
