### PR TITLE
Cache VSTS Tenant Identities.

### DIFF
--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.Alm.Cli
 {
@@ -169,7 +170,8 @@ namespace Microsoft.Alm.Cli
 
                 LoadOperationArguments(operationArguments);
 
-                BaseAuthentication authentication = CreateAuthentication(operationArguments);
+                var task = Task.Run(async () => { return await CreateAuthentication(operationArguments); });
+                BaseAuthentication authentication = task.Result;
 
                 switch (operationArguments.Authority)
                 {
@@ -374,7 +376,8 @@ namespace Microsoft.Alm.Cli
                 EnableTraceLogging(operationArguments);
 
                 Credential credentials = new Credential(operationArguments.CredUsername, operationArguments.CredPassword);
-                BaseAuthentication authentication = CreateAuthentication(operationArguments);
+                var task = Task.Run(async () => { return await CreateAuthentication(operationArguments); });
+                BaseAuthentication authentication = task.Result;
 
                 switch (operationArguments.Authority)
                 {

--- a/Microsoft.Vsts.Authentication/VstsAadAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/VstsAadAuthentication.cs
@@ -75,8 +75,7 @@ namespace Microsoft.Alm.Authentication
             : base(personalAccessTokenStore,
                    vstsIdeTokenCache,
                    vstsAuthority)
-        {
-        }
+        { }
 
         /// <summary>
         /// <para>Creates an interactive logon session, using ADAL secure browser GUI, which


### PR DESCRIPTION
Querying VSTS tenant identities from visualstudio.com is time consuming (on the order of a second) and is completely unnecissary if it has already been done. Therefore adding a file system cache will improve overall performance for VSTS users after the initial query has completed.