### PR TITLE
Fix vsts detect

### DIFF
--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -420,8 +420,15 @@ namespace Microsoft.Alm.Cli
                 case AuthorityType.AzureDirectory:
                     Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Azure Directory.");
 
+                    Guid tenantId = Guid.Empty;
+
                     // Get the identity of the tenant.
-                    Guid tenantId = await BaseVstsAuthentication.DetectAuthority(operationArguments.TargetUri);
+                    var result = await BaseVstsAuthentication.DetectAuthority(operationArguments.TargetUri);
+
+                    if (result.Key)
+                    {
+                        tenantId = result.Value;
+                    }
 
                     // return the allocated authority or a generic AAD backed VSTS authentication object
                     return authority ?? new VstsAadAuthentication(tenantId, VstsCredentialScope, secrets);


### PR DESCRIPTION
Improve the authority detection logic for VSTS authorities by not always claiming every request is for VSTS, even when the URL doesn't match 'visualstudio.com'.

Add compression to the tenant cache file.

Visuals Studio moved their ADAL token cache between 2015 and 2017, this enables the GCM to find the newer cache and rely on it.