### PR TITLE
Fix reading of Boolean config/environment values.

### DIFF
--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -1160,12 +1160,18 @@ namespace Microsoft.Alm.Cli
             // parse the value into a bool
             parse_localval:
 
+            // An empty value is unset / should not be there, so treat it as if it isn't.
+            if (String.IsNullOrWhiteSpace(localVal))
+            {
+                value = null;
+                return false;
+            }
+
             // Test `localValue` for a Git 'true' equivalent value
-            if (String.IsNullOrEmpty(localVal)
-                || ConfigValueComparer.Equals(localVal, "yes")
+            if (ConfigValueComparer.Equals(localVal, "yes")
                 || ConfigValueComparer.Equals(localVal, "true")
                 || ConfigValueComparer.Equals(localVal, "1")
-                || ConfigValueComparer.Equals(localVal, "off"))
+                || ConfigValueComparer.Equals(localVal, "on"))
             {
                 value = true;
                 return true;


### PR DESCRIPTION
Keys with no values should be considered unset, and values of "off" should be considered `false`.

Resolves #396, #399