### PR TITLE
Make Proxies Great Again (not really)

### DIFF
--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -285,7 +285,10 @@ namespace Microsoft.Alm.Cli
                 this.UseModalUi = true;
                 this.ValidateCredentials = true;
                 this.WriteLog = false;
+                _preserveCredentials = false;
                 _useHttpPath = false;
+                _useLocalConfig = true;
+                _useSystemConfig = true;
             }
 
             private AuthorityType _authorityType;

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -497,6 +497,11 @@ namespace Microsoft.Alm.Cli
                 }
                 else
                 {
+                    if (!string.IsNullOrWhiteSpace(url))
+                    {
+                        Git.Trace.WriteLine($"failed to parse '{url}'.");
+                    }
+
                     Git.Trace.WriteLine("proxy cleared.");
                 }
                 this.ProxyUri = tmp;


### PR DESCRIPTION
Use the correct defaults when initializing `OperationArguments`, otherwise local and global config values will be ignore.

Add additional tracing to `OperationArguments.SetProxy` to know when a proxy value is cleared due to paring issues versus an actual request to clear the value.

Related to #403