### PR TITLE
Do not assume Basic vs Ntlm, default Auto.

### DIFF
--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -421,9 +421,7 @@ namespace Microsoft.Alm.Cli
                             goto case AuthorityType.GitHub;
                         }
                     }
-
-                    operationArguments.Authority = AuthorityType.Basic;
-                    goto case AuthorityType.Basic;
+                    goto default;
 
                 case AuthorityType.AzureDirectory:
                     Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Azure Directory.");


### PR DESCRIPTION
Remove code which assumes authentication is basic, if not VSTS or GitHub.