### PR TITLE
Make askpass work when username is known.

### DIFF
--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -991,7 +991,20 @@ namespace Microsoft.Alm.Cli
 
         private static Credential ModalPromptForCredentials(TargetUri targetUri)
         {
-            string message = String.Format("Enter your credentials for {0}.", targetUri);
+            string message = String.Format("Enter your credentials for {0}.", targetUri.ToString(port: true, path: true));
+
+            if (!string.IsNullOrEmpty(targetUri.ActualUri.UserInfo))
+            {
+                string username = targetUri.ActualUri.UserInfo;
+
+                if (!targetUri.ActualUri.UserEscaped)
+                {
+                    username = Uri.UnescapeDataString(username);
+                }
+
+                return ModalPromptForPassword(targetUri, message, username);
+            }
+
             return ModalPromptForCredentials(targetUri, message);
         }
 
@@ -1029,7 +1042,7 @@ namespace Microsoft.Alm.Cli
                 NativeMethods.CredPackAuthenticationBuffer(flags: authPackage,
                                                            username: username,
                                                            password: String.Empty,
-                                                           packedCredentials: inBufferPtr,
+                                                           packedCredentials: IntPtr.Zero,
                                                            packedCredentialsSize: ref inBufferSize);
                 if (inBufferSize <= 0)
                 {

--- a/Microsoft.Alm.Authentication/BasicAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BasicAuthentication.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Alm.Authentication
                 }
             }
 
+            // If credentials have been acquired, write them to the secret store.
+            if (credentials != null)
+            {
+                _credentialStore.WriteCredentials(targetUri, credentials);
+            }
+
             return credentials;
         }
 

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -209,7 +209,44 @@ namespace Microsoft.Alm.Authentication
         /// <returns></returns>
         public override string ToString()
         {
-            return QueryUri.ToString();
+            return ToString(false, true, true);
+        }
+
+        public string ToString(bool username = false, bool port = false, bool path = false)
+        {
+            // Start building up a url with the scheme
+            var url = QueryUri.Scheme + "://";
+
+            // Append the username if asked for an it exiusts.
+            if (username && QueryUri.UserInfo != null)
+            {
+                url += (QueryUri.UserEscaped)
+                        ? QueryUri.UserInfo
+                        : Uri.EscapeDataString(QueryUri.UserInfo);
+                url += '@';
+            }
+
+            // Append the host name
+            url += QueryUri.Host;
+
+            // Append the port information if asked for and relevant
+            if ((port && !QueryUri.IsDefaultPort))
+            {
+                url += ':';
+                url += QueryUri.Port;
+            }
+
+            // Append some amount of path to the url
+            if (path)
+            {
+                url += QueryUri.AbsolutePath;
+            }
+            else
+            {
+                url += '/';
+            }
+
+            return url;
         }
 
         /// <summary>


### PR DESCRIPTION
Make it so that Cli-Askpass functions correctly when the username is known. This includes keeping the username portion of the `TargetUri.ActualUri`.

Make Cli-Askpass try harder to parse credentials from queries passed to it from Git.

Make Cli-Askpass correctly captured basic credentials, for readback at a later time.

Make basic credential modal prompt only ask for password when the username is already known.