### PR TITLE
Corrected link to usage/CredentialManager

### DIFF
--- a/Docs/Index.md
+++ b/Docs/Index.md
@@ -37,7 +37,7 @@ To build and install the GCM yourself, clone the sources, open the solution file
 #### Additional Resources
 
 * [Configuration Options](Configuration.md)
-* [Usage Options](Usage.md)
+* [Usage Options](CredentialManager.md)
 * [Build Agent and Automation Support](Automation.md)
 * [Frequently Asked Questions](Faq.md)
 * [Development and Debugging](Development.md)


### PR DESCRIPTION
404 due to the file Usage.md not existing. 
CredientialManager.md contains the instructions for usage, so changed link to that file.