### PR TITLE
Improve error messaging when Adal cache fails.

### DIFF
--- a/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
+++ b/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
@@ -81,11 +81,11 @@ namespace Microsoft.Alm.Authentication
 
                         File.WriteAllBytes(_cacheFilePath, data);
 
-                        this.HasStateChanged = false;
+                        HasStateChanged = false;
                     }
                     catch (Exception exception)
                     {
-                        Git.Trace.WriteLine($"! {exception.Message}");
+                        Git.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
                     }
                 }
             }
@@ -103,11 +103,11 @@ namespace Microsoft.Alm.Authentication
 
                         byte[] state = ProtectedData.Unprotect(data, null, DataProtectionScope.CurrentUser);
 
-                        this.Deserialize(state);
+                        Deserialize(state);
                     }
                     catch (Exception exception)
                     {
-                        Git.Trace.WriteLine($"! {exception.Message}");
+                        Git.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
                     }
                 }
             }


### PR DESCRIPTION
Written in response to #426 , which was initially considered to be a result of lack of robustness in the `VstsAdalTokenCache` type, however it seems the type was robust but the logging was poor. This improves the logging. 