### PR TITLE
GitSystemConfig

### DIFF
--- a/Microsoft.Alm.Git/Where.cs
+++ b/Microsoft.Alm.Git/Where.cs
@@ -448,6 +448,7 @@ namespace Microsoft.Alm.Git
             if (installation.HasValue && File.Exists(installation.Value.Config))
             {
                 path = installation.Value.Path;
+                return true;
             }
             // find Git on the local disk - the system config is stored relative to it
             else
@@ -458,6 +459,7 @@ namespace Microsoft.Alm.Git
                     && File.Exists(installations[0].Config))
                 {
                     path = installations[0].Config;
+                    return true;
                 }
             }
 

--- a/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Alm.Authentication
                     }
                 }
             }
-            catch
+            catch (Exception e)
             {
-                Git.Trace.WriteLine("! an error occurred.");
+                Git.Trace.WriteLine($"! an error occurred: {e.Message}");
             }
 
             Git.Trace.WriteLine($"personal access token acquisition for '{targetUri}' failed.");


### PR DESCRIPTION
This change fixes an issue we have had with the git-credential-manager when used with our corporate proxy.  git-credential-manager didn't pick up the proxy from git system config and therefore failed to get the personal access token - meaning that all VSTS operations didn't work.  We found some workarounds, but they didn't always work and I think this is a better fix.  (the original code I changed just seemed wrong on face value anyway)

I've also trace logged the exception message to one of the catch statements.  It was previously hiding a bunch of exceptions that are relevant to problem diagnosis (invalid proxy url).  I'm not sure if that was left out to avoid some sort of security threat.  But it would be generally great if the catch statements would output some details about what went wrong unless it knows for sure that the exception is ignorable - rather than just swallowing the exception.