### PR TITLE
Issue 440

### DIFF
--- a/Bitbucket.Authentication.Test/AuthenticationTest.cs
+++ b/Bitbucket.Authentication.Test/AuthenticationTest.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Alm.Authentication;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
 
 namespace Atlassian.Bitbucket.Authentication.Test
 {
     [TestClass]
-    public class BitbucketAuthenticationTest
+    public class AuthenticationTest
     {
         [TestMethod]
         public void VerifyBitbucketOrgIsIdentified()
@@ -101,6 +102,56 @@ namespace Atlassian.Bitbucket.Authentication.Test
             var bbAuth = new Authentication(credentialStore, null, null);
 
             bbAuth.DeleteCredentials(null);
+        }
+
+        [TestMethod]
+        public void VerifyGetPerUserTargetUriInsertsMissingUsernameToActualUri()
+        {
+            var credentialStore = new MockCredentialStore();
+            var bbAuth = new Authentication(credentialStore, null, null);
+
+            var targetUri = new TargetUri("https://example.com");
+            var username = "johnsquire";
+
+            var resultUri = bbAuth.GetPerUserTargetUri(targetUri, username);
+
+            Assert.AreEqual("/", resultUri.AbsolutePath);
+            Assert.AreEqual("https://johnsquire@example.com/", resultUri.ActualUri.AbsoluteUri);
+            Assert.AreEqual("example.com", resultUri.DnsSafeHost);
+            Assert.AreEqual("example.com", resultUri.Host);
+            Assert.AreEqual(true, resultUri.IsAbsoluteUri);
+            Assert.AreEqual(true, resultUri.IsDefaultPort);
+            Assert.AreEqual(443, resultUri.Port);
+            Assert.AreEqual(null, resultUri.ProxyUri);
+            Assert.AreEqual("https://johnsquire@example.com/", resultUri.QueryUri.AbsoluteUri);
+            Assert.AreEqual("https", resultUri.Scheme);
+            Assert.AreEqual(new WebProxy().Address, resultUri.WebProxy.Address);
+            Assert.AreEqual("https://example.com/", resultUri.ToString());
+        }
+
+        [TestMethod]
+        public void VerifyGetPerUserTargetUriDoesNotDuplicateUsernameOnActualUri()
+        {
+            var credentialStore = new MockCredentialStore();
+            var bbAuth = new Authentication(credentialStore, null, null);
+
+            var targetUri = new TargetUri("https://johnsquire@example.com");
+            var username = "johnsquire";
+
+            var resultUri = bbAuth.GetPerUserTargetUri(targetUri, username);
+
+            Assert.AreEqual("/", resultUri.AbsolutePath);
+            Assert.AreEqual("https://johnsquire@example.com/", resultUri.ActualUri.AbsoluteUri);
+            Assert.AreEqual("example.com", resultUri.DnsSafeHost);
+            Assert.AreEqual("example.com", resultUri.Host);
+            Assert.AreEqual(true, resultUri.IsAbsoluteUri);
+            Assert.AreEqual(true, resultUri.IsDefaultPort);
+            Assert.AreEqual(443, resultUri.Port);
+            Assert.AreEqual(null, resultUri.ProxyUri);
+            Assert.AreEqual("https://johnsquire@example.com/", resultUri.QueryUri.AbsoluteUri);
+            Assert.AreEqual("https", resultUri.Scheme);
+            Assert.AreEqual(new WebProxy().Address, resultUri.WebProxy.Address);
+            Assert.AreEqual("https://example.com/", resultUri.ToString());
         }
     }
 

--- a/Bitbucket.Authentication.Test/AuthenticationTest.cs
+++ b/Bitbucket.Authentication.Test/AuthenticationTest.cs
@@ -257,6 +257,7 @@ namespace Atlassian.Bitbucket.Authentication.Test
             Assert.IsFalse(deleteCalls.Any(rc => rc.Key[0].Equals("https://example.com/refresh_token")));
             Assert.IsFalse(deleteCalls.Any(rc => rc.Key[0].Equals("https://example.com/")));
         }
+
         [TestMethod]
         public void VerifyGetPerUserTargetUriInsertsMissingUsernameToActualUri()
         {
@@ -266,7 +267,7 @@ namespace Atlassian.Bitbucket.Authentication.Test
             var targetUri = new TargetUri("https://example.com");
             var username = "johnsquire";
 
-            var resultUri = bbAuth.GetPerUserTargetUri(targetUri, username);
+            var resultUri = targetUri.GetPerUserTargetUri(username);
 
             Assert.AreEqual("/", resultUri.AbsolutePath);
             Assert.AreEqual("https://johnsquire@example.com/", resultUri.ActualUri.AbsoluteUri);
@@ -291,7 +292,7 @@ namespace Atlassian.Bitbucket.Authentication.Test
             var targetUri = new TargetUri("https://johnsquire@example.com");
             var username = "johnsquire";
 
-            var resultUri = bbAuth.GetPerUserTargetUri(targetUri, username);
+            var resultUri = targetUri.GetPerUserTargetUri(username);
 
             Assert.AreEqual("/", resultUri.AbsolutePath);
             Assert.AreEqual("https://johnsquire@example.com/", resultUri.ActualUri.AbsoluteUri);

--- a/Bitbucket.Authentication.Test/Bitbucket.Authentication.Test.csproj
+++ b/Bitbucket.Authentication.Test/Bitbucket.Authentication.Test.csproj
@@ -51,7 +51,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BitbucketAuthTests.cs" />
-    <Compile Include="BitbucketAuthenticationTest.cs" />
+    <Compile Include="AuthenticationTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Alm.Cli
                                                                        githubAuthcodeCallback,
                                                                        null)
                             ?? Bitbucket.Authentication.GetAuthentication(operationArguments.TargetUri,
-                                                                          new SecretStore(secretsNamespace, Secret.UriToPerUserName),
+                                                                          new SecretStore(secretsNamespace, Secret.UriToActualUri),
                                                                           bitbucketCredentialCallback,
                                                                           bitbucketOauthCallback);
 
@@ -935,6 +935,8 @@ namespace Microsoft.Alm.Cli
                     }
                 }
             }
+
+            Git.Trace.WriteLine($"GCM arguments:{Environment.NewLine}{operationArguments}");
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "operationArguments")]

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Alm.Cli
                                                                        githubAuthcodeCallback,
                                                                        null)
                             ?? Bitbucket.Authentication.GetAuthentication(operationArguments.TargetUri,
-                                                                          new SecretStore(secretsNamespace, Secret.UriToActualUri),
+                                                                          new SecretStore(secretsNamespace, Secret.UriToActualUrl),
                                                                           bitbucketCredentialCallback,
                                                                           bitbucketOauthCallback);
 

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Alm.Cli
                                                                        githubAuthcodeCallback,
                                                                        null)
                             ?? Bitbucket.Authentication.GetAuthentication(operationArguments.TargetUri,
-                                                                          new SecretStore(secretsNamespace, Secret.UriToUrl),
+                                                                          new SecretStore(secretsNamespace, Secret.UriToPerUserName),
                                                                           bitbucketCredentialCallback,
                                                                           bitbucketOauthCallback);
 

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -935,8 +935,9 @@ namespace Microsoft.Alm.Cli
                     }
                 }
             }
-
+#if DEBUG
             Git.Trace.WriteLine($"GCM arguments:{Environment.NewLine}{operationArguments}");
+#endif
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "operationArguments")]

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -54,7 +54,11 @@ namespace Microsoft.Alm.Authentication
             return targetName;
         }
 
-        public static string UriToPerUserName(TargetUri targetUri, string @namespace)
+        /// <summary>
+        ///     Generate a key based on the ActualUri.
+        ///     This may include username, port, etc
+        /// </summary>
+        public static string UriToActualUri(TargetUri targetUri, string @namespace)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             if (String.IsNullOrWhiteSpace(@namespace))

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -54,6 +54,18 @@ namespace Microsoft.Alm.Authentication
             return targetName;
         }
 
+        public static string UriToPerUserName(TargetUri targetUri, string @namespace)
+        {
+            BaseSecureStore.ValidateTargetUri(targetUri);
+            if (String.IsNullOrWhiteSpace(@namespace))
+                throw new ArgumentNullException(@namespace);
+
+            string targetName = $"{@namespace}:{targetUri.ActualUri.AbsoluteUri}";
+            targetName = targetName.TrimEnd('/', '\\');
+
+            return targetName;
+        }
+
         public delegate string UriNameConversion(TargetUri targetUri, string @namespace);
     }
 }

--- a/Microsoft.Alm.Authentication/Secret.cs
+++ b/Microsoft.Alm.Authentication/Secret.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Alm.Authentication
         ///     Generate a key based on the ActualUri.
         ///     This may include username, port, etc
         /// </summary>
-        public static string UriToActualUri(TargetUri targetUri, string @namespace)
+        public static string UriToActualUrl(TargetUri targetUri, string @namespace)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             if (String.IsNullOrWhiteSpace(@namespace))

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -307,5 +307,47 @@ namespace Microsoft.Alm.Authentication
                 ? null
                 : new TargetUri(uri);
         }
+
+        /// <summary>
+        ///     Get a version of this <see cref="TargetUri"/> that contains the specified username.
+        /// </summary>
+        /// <remarks>
+        ///     If the <see cref="TargetUri"/> already contains a username, that one is kept NOT overwritten.
+        /// </remarks>
+        public TargetUri GetPerUserTargetUri(string username)
+        {
+            // belt and braces, don't add a username if the URI already contains one.
+            if (string.IsNullOrWhiteSpace(username) || TargetUriContainsUsername)
+            {
+                return this;
+            }
+
+            return new TargetUri(ActualUri.AbsoluteUri.Replace(Host, username + "@" + Host));
+        }
+
+        /// <summary>
+        ///     Get a version of this <see cref="TargetUri"/> that does NOT contain any username.
+        /// </summary>
+        public TargetUri GetHostTargetUri()
+        {
+            // belt and braces, don't add a username if the URI already contains one.
+            if (!TargetUriContainsUsername)
+            {
+                return this;
+            }
+
+            // default ToString() does not include any UserInfo
+            return new TargetUri(this.ToString());
+        }
+
+        /// <summary>
+        ///     Determine if the ActualUri of this <see cref="TargetUri"/> contains UserInfo
+        /// </summary>
+        public bool TargetUriContainsUsername{ get { return this.ActualUri.AbsoluteUri.Contains("@"); }}
+
+        /// <summary>
+        ///     Get username contained in the ActualUri of this <see cref="TargetUri"/>
+        /// </summary>
+        public string TargetUriUsername { get { return this.ActualUri.UserInfo; }  }
     }
 }


### PR DESCRIPTION
This addresses issue #440 

Fixes Bitbucket authentication to match changes in TargetUri data.
Corrects parsing URIs including usernames and saving credentials using per user URIs for credentials keys.