### PR TITLE
Fix DefaultUserAgent return null in MSTest UnitTest Project issue

### DIFF
--- a/Microsoft.Alm.Authentication/Global.cs
+++ b/Microsoft.Alm.Authentication/Global.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Alm.Authentication
         {
             get
             {
-                var assemblyName = System.Reflection.Assembly.GetEntryAssembly().GetName();
+                var assembly = System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetCallingAssembly();
+                var assemblyName = assembly.GetName();
                 var name = assemblyName.Name;
                 var version = assemblyName.Version;
                 var useragent = string.Format("{0} ({1}; {2}; {3}) CLR/{4} git-tools/{5}",

--- a/Microsoft.Alm.Authentication/Global.cs
+++ b/Microsoft.Alm.Authentication/Global.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Alm.Authentication
         {
             get
             {
-                var assembly = System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetCallingAssembly();
+                var assembly = System.Reflection.Assembly.GetEntryAssembly() ?? typeof(Global).Assembly;
                 var assemblyName = assembly.GetName();
                 var name = assemblyName.Name;
                 var version = assemblyName.Version;


### PR DESCRIPTION
System.Reflection.Assembly.GetEntryAssembly() will return null in visualstudio unittest project that use MSTest as test framework.

This fix will use System.Reflection.Assembly.GetCallingAssembly() when System.Reflection.Assembly.GetEntryAssembly() return null