### PR TITLE
Fix boolean config values getting lost

### DIFF
--- a/Bitbucket.Authentication/Authentication.cs
+++ b/Bitbucket.Authentication/Authentication.cs
@@ -315,7 +315,7 @@ namespace Atlassian.Bitbucket.Authentication
             {
                 AuthenticationResult result;
 
-                if (result = await BitbucketAuthority.AcquireToken(targetUri, username, password, AuthenticationResultType.None, this.TokenScope))
+                if (result = await BitbucketAuthority.AcquireToken(targetUri, username, password, AuthenticationResultType.None, TokenScope))
                 {
                     Trace.WriteLine("token acquisition succeeded");
 
@@ -336,7 +336,7 @@ namespace Atlassian.Bitbucket.Authentication
                     // the user to run the OAuth dance.
                     if (AcquireAuthenticationOAuthCallback("", targetUri, result, username))
                     {
-                        if (result = await BitbucketAuthority.AcquireToken(targetUri, username, password, AuthenticationResultType.TwoFactor, this.TokenScope))
+                        if (result = await BitbucketAuthority.AcquireToken(targetUri, username, password, AuthenticationResultType.TwoFactor, TokenScope))
                         {
                             Trace.WriteLine("token acquisition succeeded");
 

--- a/Bitbucket.Authentication/Authentication.cs
+++ b/Bitbucket.Authentication/Authentication.cs
@@ -235,7 +235,7 @@ namespace Atlassian.Bitbucket.Authentication
             {
                 var realUsername = GetRealUsername(credentials, username);
                 Credential tempCredentials = new Credential(realUsername, credentials.Password);
-                SetCredentials(targetUri.GetPerUserTargetUri(username), tempCredentials, null);
+                SetCredentials(targetUri.GetPerUserTargetUri(realUsername), tempCredentials, null);
             }
 
             PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
@@ -254,7 +254,7 @@ namespace Atlassian.Bitbucket.Authentication
                 return username;
             }
 
-            // otherwise 
+            // otherwise
             return remoteUsername;
         }
 

--- a/Bitbucket.Authentication/Authority.cs
+++ b/Bitbucket.Authentication/Authority.cs
@@ -192,7 +192,7 @@ namespace Atlassian.Bitbucket.Authentication
         /// </summary>
         private static string GetEncodedCredentials(string user, string password)
         {
-            string authString = String.Format("{0}:{1}", user, password);
+            string authString = string.Format("{0}:{1}", user, password);
             byte[] authBytes = Encoding.UTF8.GetBytes(authString);
             string authEncode = Convert.ToBase64String(authBytes);
             return authEncode;

--- a/Bitbucket.Authentication/BasicAuth/BasicAuthAuthenticator.cs
+++ b/Bitbucket.Authentication/BasicAuth/BasicAuthAuthenticator.cs
@@ -19,7 +19,7 @@ namespace Atlassian.Bitbucket.Authentication.BasicAuth
             // use the provided username and password and attempt a Basic Auth request to a known
             // REST API resource.
             
-            string basicAuthValue = String.Format("{0}:{1}", username, password);
+            string basicAuthValue = string.Format("{0}:{1}", username, password);
             byte[] authBytes = Encoding.UTF8.GetBytes(basicAuthValue);
             basicAuthValue = Convert.ToBase64String(authBytes);
             var authHeader = "Basic " + basicAuthValue;

--- a/Bitbucket.Authentication/TokenScope.cs
+++ b/Bitbucket.Authentication/TokenScope.cs
@@ -36,7 +36,7 @@ namespace Atlassian.Bitbucket.Authentication
     /// </summary>
     public sealed class TokenScope: Microsoft.Alm.Authentication.TokenScope
     {
-        public static readonly TokenScope None = new TokenScope(String.Empty);
+        public static readonly TokenScope None = new TokenScope(string.Empty);
 
         /// <summary>
         /// Access accounts

--- a/Bitbucket.Authentication/ViewModels/OAuthViewModel.cs
+++ b/Bitbucket.Authentication/ViewModels/OAuthViewModel.cs
@@ -42,7 +42,7 @@ namespace Atlassian.Bitbucket.Authentication.ViewModels
 
         public OAuthViewModel(bool resultType)
         {
-            this._resultType = resultType;
+            _resultType = resultType;
 
             OkCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Ok);
             CancelCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Cancel);

--- a/Cli-Askpass/UserPromptDialog.xaml.cs
+++ b/Cli-Askpass/UserPromptDialog.xaml.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Alm.Gui
         {
             string hintText = null;
 
-            this.Title = _title;
+            Title = _title;
 
             switch (_kind)
             {
@@ -230,9 +230,9 @@ namespace Microsoft.Alm.Gui
                 ? Visibility.Visible
                 : Visibility.Collapsed;
 
-            this.Topmost = true;
-            this.BringIntoView();
-            this.Activate();
+            Topmost = true;
+            BringIntoView();
+            Activate();
 
             if (hintText != null)
             {
@@ -244,7 +244,7 @@ namespace Microsoft.Alm.Gui
                     _textboxAdorner = new PasswordBoxHintAdorner(PassphrasePasswordBox, hintText, style, IsAdornerVisible);
                 }
 
-                this.PassphrasePasswordBox.Focus();
+                PassphrasePasswordBox.Focus();
             }
             else
             {

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -846,7 +846,7 @@ namespace Microsoft.Alm.Cli
         {
             if (_isPassive)
             {
-                this.Result = ResultValue.Unprivileged;
+                Result = ResultValue.Unprivileged;
             }
             else
             {
@@ -897,12 +897,12 @@ namespace Microsoft.Alm.Cli
                     Git.Trace.WriteLine($"process exited with {elevated.ExitCode}.");
 
                     // exit with the elevated process' exit code
-                    this.ExitCode = elevated.ExitCode;
+                    ExitCode = elevated.ExitCode;
                 }
                 catch (Exception exception)
                 {
                     Git.Trace.WriteLine($"process failed with '{exception.Message}'");
-                    this.Result = ResultValue.Unprivileged;
+                    Result = ResultValue.Unprivileged;
                 }
             }
         }
@@ -951,7 +951,7 @@ namespace Microsoft.Alm.Cli
         {
             if (_isPassive)
             {
-                this.Result = ResultValue.Unprivileged;
+                Result = ResultValue.Unprivileged;
             }
             else
             {
@@ -1002,12 +1002,12 @@ namespace Microsoft.Alm.Cli
                     Git.Trace.WriteLine($"process exited with {elevated.ExitCode}.");
 
                     // exit with the elevated process' exit code
-                    this.ExitCode = elevated.ExitCode;
+                    ExitCode = elevated.ExitCode;
                 }
                 catch (Exception exception)
                 {
                     Git.Trace.WriteLine($"! process failed with '{exception.Message}'.");
-                    this.Result = ResultValue.Unprivileged;
+                    Result = ResultValue.Unprivileged;
                 }
             }
         }

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -737,6 +737,7 @@ namespace Microsoft.Alm.Cli
             if (!string.IsNullOrWhiteSpace(configKey)
                 && config.TryGetEntry(Program.ConfigPrefix, operationArguments.QueryUri, configKey, out entry))
             {
+                localVal = entry.Value;
                 goto parse_localval;
             }
 

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Alm.Cli
                         }
                     }
 
-                    this.CreateTargetUri();
+                    CreateTargetUri();
                 }
             }
 
@@ -530,7 +530,7 @@ namespace Microsoft.Alm.Cli
 
                     Git.Trace.WriteLine("proxy cleared.");
                 }
-                this.ProxyUri = tmp;
+                ProxyUri = tmp;
             }
 
             public sealed override string ToString()

--- a/GitHub.Authentication.Test/Xunit/WpfTestCase.cs
+++ b/GitHub.Authentication.Test/Xunit/WpfTestCase.cs
@@ -52,7 +52,7 @@ namespace Xunit
                     SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
 
                     // Start off the test method.
-                    var testCaseTask = this.testCase.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+                    var testCaseTask = testCase.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
 
                     // Arrange to pump messages to execute any async work associated with the test.
                     var frame = new DispatcherFrame();

--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -93,9 +93,9 @@ namespace GitHub.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            if (this.PersonalAccessTokenStore.ReadCredentials(targetUri) != null)
+            if (PersonalAccessTokenStore.ReadCredentials(targetUri) != null)
             {
-                this.PersonalAccessTokenStore.DeleteCredentials(targetUri);
+                PersonalAccessTokenStore.DeleteCredentials(targetUri);
                 Git.Trace.WriteLine($"credentials for '{targetUri}' deleted");
             }
         }
@@ -158,7 +158,7 @@ namespace GitHub.Authentication
 
             Credential credentials = null;
 
-            if ((credentials = this.PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
+            if ((credentials = PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
             {
                 Git.Trace.WriteLine($"credentials for '{targetUri}' found.");
             }
@@ -185,12 +185,12 @@ namespace GitHub.Authentication
             {
                 AuthenticationResult result;
 
-                if (result = await Authority.AcquireToken(targetUri, username, password, null, this.TokenScope))
+                if (result = await Authority.AcquireToken(targetUri, username, password, null, TokenScope))
                 {
                     Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
 
                     credentials = (Credential)result.Token;
-                    this.PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
+                    PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
 
                     // if a result callback was registered, call it
                     AuthenticationResultCallback?.Invoke(targetUri, result);
@@ -203,12 +203,12 @@ namespace GitHub.Authentication
                     string authenticationCode;
                     if (AcquireAuthenticationCodeCallback(targetUri, result, username, out authenticationCode))
                     {
-                        if (result = await Authority.AcquireToken(targetUri, username, password, authenticationCode, this.TokenScope))
+                        if (result = await Authority.AcquireToken(targetUri, username, password, authenticationCode, TokenScope))
                         {
                             Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                             credentials = (Credential)result.Token;
-                            this.PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
+                            PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
 
                             // if a result callback was registered, call it
                             AuthenticationResultCallback?.Invoke(targetUri, result);
@@ -253,7 +253,7 @@ namespace GitHub.Authentication
             Credential credentials = null;
 
             AuthenticationResult result;
-            if (result = await Authority.AcquireToken(targetUri, username, password, authenticationCode, this.TokenScope))
+            if (result = await Authority.AcquireToken(targetUri, username, password, authenticationCode, TokenScope))
             {
                 Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 

--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -245,9 +245,9 @@ namespace GitHub.Authentication
         public async Task<Credential> NoninteractiveLogonWithCredentials(TargetUri targetUri, string username, string password, string authenticationCode)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
-            if (String.IsNullOrWhiteSpace(username))
+            if (string.IsNullOrWhiteSpace(username))
                 throw new ArgumentNullException("username", "The `username` parameter is null or invalid.");
-            if (String.IsNullOrWhiteSpace(password))
+            if (string.IsNullOrWhiteSpace(password))
                 throw new ArgumentNullException("username", "The `password` parameter is null or invalid.");
 
             Credential credentials = null;

--- a/GitHub.Authentication/AuthenticationResult.cs
+++ b/GitHub.Authentication/AuthenticationResult.cs
@@ -51,13 +51,13 @@ namespace GitHub.Authentication
         {
             return (obj is AuthenticationResult
                     || obj is GitHubAuthenticationResultType)
-                && this.Equals((AuthenticationResult)obj);
+                && Equals((AuthenticationResult)obj);
         }
 
         public bool Equals(AuthenticationResult other)
         {
-            return this.Type == other.Type
-                && this.Token == other.Token;
+            return Type == other.Type
+                && Token == other.Token;
         }
 
         public static AuthenticationResult FromResultType(GitHubAuthenticationResultType type)

--- a/GitHub.Authentication/Authority.cs
+++ b/GitHub.Authentication/Authority.cs
@@ -86,13 +86,13 @@ namespace GitHub.Authentication
                 httpClient.DefaultRequestHeaders.Add("User-Agent", Global.UserAgent);
                 httpClient.DefaultRequestHeaders.Add("Accept", GitHubApiAcceptsHeaderValue);
 
-                string basicAuthValue = String.Format("{0}:{1}", username, password);
+                string basicAuthValue = string.Format("{0}:{1}", username, password);
                 byte[] authBytes = Encoding.UTF8.GetBytes(basicAuthValue);
                 basicAuthValue = Convert.ToBase64String(authBytes);
 
                 httpClient.DefaultRequestHeaders.Add("Authorization", "Basic " + basicAuthValue);
 
-                if (!String.IsNullOrWhiteSpace(authenticationCode))
+                if (!string.IsNullOrWhiteSpace(authenticationCode))
                 {
                     httpClient.DefaultRequestHeaders.Add(GitHubOptHeader, authenticationCode);
                 }
@@ -119,7 +119,7 @@ namespace GitHub.Authentication
 
                 scopesBuilder.Append(']');
 
-                string jsonContent = String.Format(JsonContentFormat, scopesBuilder, targetUri, Environment.MachineName, DateTime.Now);
+                string jsonContent = string.Format(JsonContentFormat, scopesBuilder, targetUri, Environment.MachineName, DateTime.Now);
 
                 using (StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType))
                 using (HttpResponseMessage response = await httpClient.PostAsync(_authorityUrl, content))
@@ -155,10 +155,10 @@ namespace GitHub.Authentication
 
                         case HttpStatusCode.Unauthorized:
                             {
-                                if (String.IsNullOrWhiteSpace(authenticationCode)
-                                    && response.Headers.Any(x => String.Equals(GitHubOptHeader, x.Key, StringComparison.OrdinalIgnoreCase)))
+                                if (string.IsNullOrWhiteSpace(authenticationCode)
+                                    && response.Headers.Any(x => string.Equals(GitHubOptHeader, x.Key, StringComparison.OrdinalIgnoreCase)))
                                 {
-                                    var mfakvp = response.Headers.First(x => String.Equals(GitHubOptHeader, x.Key, StringComparison.OrdinalIgnoreCase) && x.Value != null && x.Value.Count() > 0);
+                                    var mfakvp = response.Headers.First(x => string.Equals(GitHubOptHeader, x.Key, StringComparison.OrdinalIgnoreCase) && x.Value != null && x.Value.Count() > 0);
 
                                     if (mfakvp.Value.First().Contains("app"))
                                     {
@@ -191,7 +191,7 @@ namespace GitHub.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            string authString = String.Format("{0}:{1}", credentials.Username, credentials.Password);
+            string authString = string.Format("{0}:{1}", credentials.Username, credentials.Password);
             byte[] authBytes = Encoding.UTF8.GetBytes(authString);
             string authEncode = Convert.ToBase64String(authBytes);
 

--- a/GitHub.Authentication/Controls/Octicons/OcticonPath.cs
+++ b/GitHub.Authentication/Controls/Octicons/OcticonPath.cs
@@ -64,7 +64,7 @@ namespace GitHub.UI
 
         protected override Geometry DefiningGeometry
         {
-            get { return GetGeometryForIcon(this.Icon); }
+            get { return GetGeometryForIcon(Icon); }
         }
 
         public static Geometry GetGeometryForIcon(Octicon icon)

--- a/GitHub.Authentication/Controls/Octicons/OcticonPath.cs
+++ b/GitHub.Authentication/Controls/Octicons/OcticonPath.cs
@@ -76,7 +76,7 @@ namespace GitHub.UI
                 return g.Value;
 
             throw new ArgumentException(
-                String.Format(CultureInfo.InvariantCulture, "Unknown Octicon: {0}", icon), nameof(icon));
+                string.Format(CultureInfo.InvariantCulture, "Unknown Octicon: {0}", icon), nameof(icon));
         }
 
         // Initializes the cache dictionary with lazy entries for all available octicons

--- a/GitHub.Authentication/Controls/TwoFactorInput.xaml.cs
+++ b/GitHub.Authentication/Controls/TwoFactorInput.xaml.cs
@@ -92,7 +92,7 @@ namespace GitHub.UI
 
         private void SetText(string text)
         {
-            if (String.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text))
             {
                 foreach (var textBox in TextBoxes)
                 {
@@ -106,7 +106,7 @@ namespace GitHub.UI
             {
                 TextBoxes[i].Text = digits[i].ToString();
             }
-            SetValue(TextProperty, String.Join("", digits));
+            SetValue(TextProperty, string.Join("", digits));
         }
 
         public string Text
@@ -175,7 +175,7 @@ namespace GitHub.UI
 
             textBox.TextChanged += (sender, args) =>
             {
-                SetValue(TextProperty, String.Join("", GetTwoFactorCode()));
+                SetValue(TextProperty, string.Join("", GetTwoFactorCode()));
                 var change = args.Changes.FirstOrDefault();
                 args.Handled = (change != null && change.AddedLength > 0) && MoveNext();
             };
@@ -205,12 +205,12 @@ namespace GitHub.UI
 
         private static string GetTextBoxValue(TextBox textBox)
         {
-            return String.IsNullOrEmpty(textBox.Text) ? " " : textBox.Text;
+            return string.IsNullOrEmpty(textBox.Text) ? " " : textBox.Text;
         }
 
         private string GetTwoFactorCode()
         {
-            return String.Join("", TextBoxes.Select(textBox => textBox.Text));
+            return string.Join("", TextBoxes.Select(textBox => textBox.Text));
         }
     }
 }

--- a/GitHub.Authentication/TokenScope.cs
+++ b/GitHub.Authentication/TokenScope.cs
@@ -33,7 +33,7 @@ namespace GitHub.Authentication
 {
     public sealed class TokenScope: Microsoft.Alm.Authentication.TokenScope, IEquatable<TokenScope>
     {
-        public static readonly TokenScope None = new TokenScope(String.Empty);
+        public static readonly TokenScope None = new TokenScope(string.Empty);
 
         /// <summary>
         /// Create gists

--- a/Microsoft.Alm.Authentication/BaseSecureStore.cs
+++ b/Microsoft.Alm.Authentication/BaseSecureStore.cs
@@ -126,8 +126,8 @@ namespace Microsoft.Alm.Authentication
 
                     string password = passwordLength > 0
                                     ? Marshal.PtrToStringUni(credStruct.CredentialBlob, passwordLength / sizeof(char))
-                                    : String.Empty;
-                    string username = credStruct.UserName ?? String.Empty;
+                                    : string.Empty;
+                    string username = credStruct.UserName ?? string.Empty;
 
                     credentials = new Credential(username, password);
 
@@ -289,7 +289,7 @@ namespace Microsoft.Alm.Authentication
         {
             if (ReferenceEquals(token, null))
                 throw new ArgumentNullException(nameof(token));
-            if (String.IsNullOrEmpty(token.Value))
+            if (string.IsNullOrEmpty(token.Value))
                 throw new ArgumentException(nameof(token.Value));
         }
     }

--- a/Microsoft.Alm.Authentication/BasicAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BasicAuthentication.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            this.CredentialStore.DeleteCredentials(targetUri);
+            CredentialStore.DeleteCredentials(targetUri);
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            return this.CredentialStore.ReadCredentials(targetUri);
+            return CredentialStore.ReadCredentials(targetUri);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            this.CredentialStore.WriteCredentials(targetUri, credentials);
+            CredentialStore.WriteCredentials(targetUri, credentials);
         }
     }
 }

--- a/Microsoft.Alm.Authentication/Credential.cs
+++ b/Microsoft.Alm.Authentication/Credential.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Alm.Authentication
             if (username == null)
                 throw new ArgumentNullException(nameof(username));
 
-            this.Username = username;
-            this.Password = password ?? string.Empty;
+            Username = username;
+            Password = password ?? string.Empty;
         }
 
         /// <summary>

--- a/Microsoft.Alm.Authentication/Credential.cs
+++ b/Microsoft.Alm.Authentication/Credential.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Alm.Authentication
     /// </summary>
     public sealed class Credential: Secret, IEquatable<Credential>
     {
-        public static readonly Credential Empty = new Credential(String.Empty, String.Empty);
+        public static readonly Credential Empty = new Credential(string.Empty, string.Empty);
 
         /// <summary>
         /// Creates a credential object with a username and password pair.
@@ -45,7 +45,7 @@ namespace Microsoft.Alm.Authentication
                 throw new ArgumentNullException(nameof(username));
 
             this.Username = username;
-            this.Password = password ?? String.Empty;
+            this.Password = password ?? string.Empty;
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         /// <param name="username">The username value of the <see cref="Credential"/>.</param>
         public Credential(string username)
-            : this(username, String.Empty)
+            : this(username, string.Empty)
         { }
 
         /// <summary>
@@ -111,8 +111,8 @@ namespace Microsoft.Alm.Authentication
             if (ReferenceEquals(credential1, null) || ReferenceEquals(null, credential2))
                 return false;
 
-            return String.Equals(credential1.Username, credential2.Username, StringComparison.Ordinal)
-                && String.Equals(credential1.Password, credential2.Password, StringComparison.Ordinal);
+            return string.Equals(credential1.Username, credential2.Username, StringComparison.Ordinal)
+                && string.Equals(credential1.Password, credential2.Password, StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/Microsoft.Alm.Authentication/SecretCache.cs
+++ b/Microsoft.Alm.Authentication/SecretCache.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Alm.Authentication
 
         public SecretCache(string @namespace, Secret.UriNameConversion getTargetName)
         {
-            if (String.IsNullOrWhiteSpace(@namespace))
+            if (string.IsNullOrWhiteSpace(@namespace))
                 throw new ArgumentNullException(@namespace);
 
             _namespace = @namespace;

--- a/Microsoft.Alm.Authentication/SecretCache.cs
+++ b/Microsoft.Alm.Authentication/SecretCache.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             lock (_cache)
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             lock (_cache)
             {
@@ -118,7 +118,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
 
             Credential credentials = null;
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             lock (_cache)
             {
@@ -145,7 +145,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
 
             Token token = null;
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             lock (_cache)
             {
@@ -172,7 +172,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             lock (_cache)
             {
@@ -197,7 +197,7 @@ namespace Microsoft.Alm.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             Token.Validate(token);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             lock (_cache)
             {

--- a/Microsoft.Alm.Authentication/SecretStore.cs
+++ b/Microsoft.Alm.Authentication/SecretStore.cs
@@ -89,9 +89,9 @@ namespace Microsoft.Alm.Authentication
         {
             ValidateTargetUri(targetUri);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
-            this.Delete(targetName);
+            Delete(targetName);
 
             _credentialCache.DeleteCredentials(targetUri);
         }
@@ -104,9 +104,9 @@ namespace Microsoft.Alm.Authentication
         {
             ValidateTargetUri(targetUri);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
-            this.Delete(targetName);
+            Delete(targetName);
             _tokenCache.DeleteToken(targetUri);
         }
 
@@ -128,10 +128,10 @@ namespace Microsoft.Alm.Authentication
         {
             ValidateTargetUri(targetUri);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             return _credentialCache.ReadCredentials(targetUri)
-                ?? this.ReadCredentials(targetName);
+                ?? ReadCredentials(targetName);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Microsoft.Alm.Authentication
         {
             ValidateTargetUri(targetUri);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
             return _tokenCache.ReadToken(targetUri)
                 ?? ReadToken(targetName);
@@ -159,9 +159,9 @@ namespace Microsoft.Alm.Authentication
             ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
-            this.WriteCredential(targetName, credentials);
+            WriteCredential(targetName, credentials);
 
             _credentialCache.WriteCredentials(targetUri, credentials);
         }
@@ -176,9 +176,9 @@ namespace Microsoft.Alm.Authentication
             ValidateTargetUri(targetUri);
             Token.Validate(token);
 
-            string targetName = this.GetTargetName(targetUri);
+            string targetName = GetTargetName(targetUri);
 
-            this.WriteToken(targetName, token);
+            WriteToken(targetName, token);
 
             _tokenCache.WriteToken(targetUri, token);
         }

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -342,18 +342,18 @@ namespace Microsoft.Alm.Authentication
             }
 
             // default ToString() does not include any UserInfo
-            return new TargetUri(this.ToString());
+            return new TargetUri(ToString());
         }
 
         /// <summary>
         ///     Determine if the ActualUri of this <see cref="TargetUri"/> contains UserInfo
         /// </summary>
-        public bool TargetUriContainsUsername{ get { return this.ActualUri.AbsoluteUri.Contains("@"); }}
+        public bool TargetUriContainsUsername{ get { return ActualUri.AbsoluteUri.Contains("@"); }}
 
         /// <summary>
         ///     Get username contained in the ActualUri of this <see cref="TargetUri"/>
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
-        public string TargetUriUsername { get { return this.ActualUri.UserInfo; }  }
+        public string TargetUriUsername { get { return ActualUri.UserInfo; }  }
     }
 }

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Alm.Authentication
 
             Debug.Assert(Enum.IsDefined(typeof(TokenType), type), $"The `{nameof(type)}` parameter is invalid");
 
-            this.Type = type;
-            this.Value = value;
+            Type = type;
+            Value = value;
         }
 
         public Token(string value, string typeName)
@@ -67,9 +67,9 @@ namespace Microsoft.Alm.Authentication
             if ((type & ~(TokenType.Access | TokenType.Federated | TokenType.Personal | TokenType.Test)) != 0)
                 throw new ArgumentOutOfRangeException(nameof(type));
 
-            this.TargetIdentity = tenantId;
-            this.Type = type;
-            this.Value = value;
+            TargetIdentity = tenantId;
+            Type = type;
+            Value = value;
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Microsoft.Alm.Authentication
         /// <returns>True is equal; false otherwise.</returns>
         public override bool Equals(Object obj)
         {
-            return this.Equals(obj as Token);
+            return Equals(obj as Token);
         }
 
         /// <summary>

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Alm.Authentication
 
         public Token(string value, TokenType type)
         {
-            if (String.IsNullOrWhiteSpace(value))
+            if (string.IsNullOrWhiteSpace(value))
                 throw new ArgumentNullException(nameof(value));
 
             Debug.Assert(Enum.IsDefined(typeof(TokenType), type), $"The `{nameof(type)}` parameter is invalid");
@@ -50,9 +50,9 @@ namespace Microsoft.Alm.Authentication
 
         public Token(string value, string typeName)
         {
-            if (String.IsNullOrWhiteSpace(value))
+            if (string.IsNullOrWhiteSpace(value))
                 throw new ArgumentNullException(nameof(value));
-            if (String.IsNullOrWhiteSpace(typeName))
+            if (string.IsNullOrWhiteSpace(typeName))
                 throw new ArgumentNullException(nameof(typeName));
 
             TokenType type;
@@ -126,7 +126,7 @@ namespace Microsoft.Alm.Authentication
 
         public static bool GetTypeFromFriendlyName(string name, out TokenType type)
         {
-            if (String.IsNullOrWhiteSpace(name))
+            if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentNullException(nameof(name));
 
             type = TokenType.Unknown;
@@ -138,7 +138,7 @@ namespace Microsoft.Alm.Authentication
                 string typename;
                 if (GetFriendlyNameFromType(type, out typename))
                 {
-                    if (String.Equals(name, typename, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(name, typename, StringComparison.OrdinalIgnoreCase))
                         return true;
                 }
             }
@@ -175,7 +175,7 @@ namespace Microsoft.Alm.Authentication
         {
             if (token == null)
                 throw new ArgumentNullException(nameof(token));
-            if (String.IsNullOrWhiteSpace(token.Value))
+            if (string.IsNullOrWhiteSpace(token.Value))
                 throw new ArgumentException("Value property returned null or empty.", nameof(token));
             if (token.Value.Length > NativeMethods.Credential.PasswordMaxLength)
                 throw new ArgumentOutOfRangeException(nameof(token));
@@ -212,7 +212,7 @@ namespace Microsoft.Alm.Authentication
                     {
                         string value = Encoding.UTF8.GetString(bytes, preamble, bytes.Length - preamble);
 
-                        if (!String.IsNullOrWhiteSpace(value))
+                        if (!string.IsNullOrWhiteSpace(value))
                         {
                             token = new Token(value, type);
                             token.TargetIdentity = targetIdentity;
@@ -225,7 +225,7 @@ namespace Microsoft.Alm.Authentication
                 {
                     string value = Encoding.UTF8.GetString(bytes);
 
-                    if (!String.IsNullOrWhiteSpace(value))
+                    if (!string.IsNullOrWhiteSpace(value))
                     {
                         token = new Token(value, type);
                     }
@@ -243,7 +243,7 @@ namespace Microsoft.Alm.Authentication
         {
             if (ReferenceEquals(token, null))
                 throw new ArgumentNullException(nameof(token));
-            if (String.IsNullOrWhiteSpace(token.Value))
+            if (string.IsNullOrWhiteSpace(token.Value))
                 throw new ArgumentException("Value property returned null or empty.", nameof(token));
 
             bytes = null;

--- a/Microsoft.Alm.Authentication/TokenScope.cs
+++ b/Microsoft.Alm.Authentication/TokenScope.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Alm.Authentication
     {
         protected TokenScope(string value)
         {
-            if (String.IsNullOrWhiteSpace(value))
+            if (string.IsNullOrWhiteSpace(value))
             {
                 _scopes = new string[0];
             }
@@ -63,7 +63,7 @@ namespace Microsoft.Alm.Authentication
             _scopes = result;
         }
 
-        public string Value { get { return String.Join(" ", _scopes); } }
+        public string Value { get { return string.Join(" ", _scopes); } }
 
         protected readonly IReadOnlyList<string> _scopes;
 

--- a/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
+++ b/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Alm.Authentication
 {
     internal class WwwAuthenticateHelper
     {
-        public static readonly Credential Credentials = new Credential(String.Empty, String.Empty);
+        public static readonly Credential Credentials = new Credential(string.Empty, string.Empty);
         public static readonly AuthenticationHeaderValue NtlmHeader = new AuthenticationHeaderValue("NTLM");
         public static readonly AuthenticationHeaderValue NegotiateHeader = new AuthenticationHeaderValue("Negotiate");
 

--- a/Microsoft.Alm.Git.Test/ConfigurationTests.cs
+++ b/Microsoft.Alm.Git.Test/ConfigurationTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Alm.Git.Test
         public void GitConfig_ParseSampleFile()
         {
             var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            var me = this.GetType();
+            var me = GetType();
             var us = me.Assembly;
 
             using (var rs = us.GetManifestResourceStream(me, "sample.gitconfig"))

--- a/Microsoft.Alm.Git/GitInstallation.cs
+++ b/Microsoft.Alm.Git/GitInstallation.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Alm.Git
 
         internal GitInstallation(string path, KnownGitDistribution version)
         {
-            Debug.Assert(!String.IsNullOrWhiteSpace(path), $"The `{nameof(path)}` parameter is null or invalid.");
+            Debug.Assert(!string.IsNullOrWhiteSpace(path), $"The `{nameof(path)}` parameter is null or invalid.");
             Debug.Assert(CommonConfigPaths.ContainsKey(version), $"The `{nameof(version)}` parameter not found in `{nameof(CommonConfigPaths)}`.");
             Debug.Assert(CommonCmdPaths.ContainsKey(version), $"The `{nameof(version)}` parameter not found in `{nameof(CommonCmdPaths)}`.");
             Debug.Assert(CommonGitPaths.ContainsKey(version), $"The `{nameof(version)}` parameter not found in `{nameof(CommonGitPaths)}`.");
@@ -252,7 +252,7 @@ namespace Microsoft.Alm.Git
             return StringComparer.OrdinalIgnoreCase.GetHashCode(Path);
         }
 
-        public override String ToString()
+        public override string ToString()
         {
             return Path;
         }

--- a/Microsoft.Alm.Git/Trace.cs
+++ b/Microsoft.Alm.Git/Trace.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Alm.Git
             const int SourceColumnMaxWidth = 23;
 
             // source column format is file:line
-            string source = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}:{1}", filePath, lineNumber);
+            string source = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}:{1}", filePath, lineNumber);
 
             if (source.Length > SourceColumnMaxWidth)
             {
@@ -163,7 +163,7 @@ namespace Microsoft.Alm.Git
             }
 
             // Git's trace format is "{timestamp,-15} {source,-23} trace: {details}"
-            string text = String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:HH:mm:ss.ffffff} {1,-23} trace: [{2}] {3}", DateTime.Now, source, memberName, message);
+            string text = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:HH:mm:ss.ffffff} {1,-23} trace: [{2}] {3}", DateTime.Now, source, memberName, message);
 
             return text;
         }

--- a/Microsoft.Alm.Git/Where.cs
+++ b/Microsoft.Alm.Git/Where.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Alm.Git
         /// <returns><see langword="True"/> if succeeds; <see langword="false"/> otherwise.</returns>
         static public bool FindApp(string name, out string path)
         {
-            if (!String.IsNullOrWhiteSpace(name))
+            if (!string.IsNullOrWhiteSpace(name))
             {
                 string pathext = Environment.GetEnvironmentVariable("PATHEXT");
                 string envpath = Environment.GetEnvironmentVariable("PATH");
@@ -54,15 +54,15 @@ namespace Microsoft.Alm.Git
 
                 for (int i = 0; i < paths.Length; i++)
                 {
-                    if (String.IsNullOrWhiteSpace(paths[i]))
+                    if (string.IsNullOrWhiteSpace(paths[i]))
                         continue;
 
                     for (int j = 0; j < exts.Length; j++)
                     {
-                        if (String.IsNullOrWhiteSpace(exts[j]))
+                        if (string.IsNullOrWhiteSpace(exts[j]))
                             continue;
 
-                        string value = String.Format("{0}\\{1}{2}", paths[i], name, exts[j]);
+                        string value = string.Format("{0}\\{1}{2}", paths[i], name, exts[j]);
                         if (File.Exists(value))
                         {
                             value = value.Replace("\\\\", "\\");
@@ -100,24 +100,24 @@ namespace Microsoft.Alm.Git
 
             installations = null;
 
-            var programFiles32Path = String.Empty;
-            var programFiles64Path = String.Empty;
-            var appDataRoamingPath = String.Empty;
-            var appDataLocalPath = String.Empty;
-            var programDataPath = String.Empty;
-            var reg32HklmPath = String.Empty;
-            var reg64HklmPath = String.Empty;
-            var reg32HkcuPath = String.Empty;
-            var reg64HkcuPath = String.Empty;
-            var shellPathValue = String.Empty;
+            var programFiles32Path = string.Empty;
+            var programFiles64Path = string.Empty;
+            var appDataRoamingPath = string.Empty;
+            var appDataLocalPath = string.Empty;
+            var programDataPath = string.Empty;
+            var reg32HklmPath = string.Empty;
+            var reg64HklmPath = string.Empty;
+            var reg32HkcuPath = string.Empty;
+            var reg64HkcuPath = string.Empty;
+            var shellPathValue = string.Empty;
 
             using (var reg32HklmKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
             using (var reg32HkcuKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry32))
             using (var reg32HklmSubKey = reg32HklmKey?.OpenSubKey(GitSubkeyName))
             using (var reg32HkcuSubKey = reg32HkcuKey?.OpenSubKey(GitSubkeyName))
             {
-                reg32HklmPath = reg32HklmSubKey?.GetValue(GitValueName, reg32HklmPath) as String;
-                reg32HkcuPath = reg32HkcuSubKey?.GetValue(GitValueName, reg32HkcuPath) as String;
+                reg32HklmPath = reg32HklmSubKey?.GetValue(GitValueName, reg32HklmPath) as string;
+                reg32HkcuPath = reg32HkcuSubKey?.GetValue(GitValueName, reg32HkcuPath) as string;
             }
 
             if ((programFiles32Path = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)) != null)
@@ -132,8 +132,8 @@ namespace Microsoft.Alm.Git
                 using (var reg64HklmSubKey = reg64HklmKey?.OpenSubKey(GitSubkeyName))
                 using (var reg64HkcuSubKey = reg64HkcuKey?.OpenSubKey(GitSubkeyName))
                 {
-                    reg64HklmPath = reg64HklmSubKey?.GetValue(GitValueName, reg64HklmPath) as String;
-                    reg64HkcuPath = reg64HkcuSubKey?.GetValue(GitValueName, reg64HkcuPath) as String;
+                    reg64HklmPath = reg64HklmSubKey?.GetValue(GitValueName, reg64HklmPath) as string;
+                    reg64HkcuPath = reg64HkcuSubKey?.GetValue(GitValueName, reg64HkcuPath) as string;
                 }
 
                 if ((programFiles64Path = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)) != null)
@@ -172,46 +172,46 @@ namespace Microsoft.Alm.Git
                 candidates.Add(new GitInstallation(shellPathValue, KnownGitDistribution.GitForWindows32v1));
             }
 
-            if (!String.IsNullOrEmpty(reg64HklmPath))
+            if (!string.IsNullOrEmpty(reg64HklmPath))
             {
                 candidates.Add(new GitInstallation(reg64HklmPath, KnownGitDistribution.GitForWindows64v2));
             }
-            if (!String.IsNullOrEmpty(programFiles32Path))
+            if (!string.IsNullOrEmpty(programFiles32Path))
             {
                 candidates.Add(new GitInstallation(programFiles64Path, KnownGitDistribution.GitForWindows64v2));
             }
-            if (!String.IsNullOrEmpty(reg64HkcuPath))
+            if (!string.IsNullOrEmpty(reg64HkcuPath))
             {
                 candidates.Add(new GitInstallation(reg64HkcuPath, KnownGitDistribution.GitForWindows64v2));
             }
-            if (!String.IsNullOrEmpty(reg32HklmPath))
+            if (!string.IsNullOrEmpty(reg32HklmPath))
             {
                 candidates.Add(new GitInstallation(reg32HklmPath, KnownGitDistribution.GitForWindows32v2));
                 candidates.Add(new GitInstallation(reg32HklmPath, KnownGitDistribution.GitForWindows32v1));
             }
-            if (!String.IsNullOrEmpty(programFiles32Path))
+            if (!string.IsNullOrEmpty(programFiles32Path))
             {
                 candidates.Add(new GitInstallation(programFiles32Path, KnownGitDistribution.GitForWindows32v2));
                 candidates.Add(new GitInstallation(programFiles32Path, KnownGitDistribution.GitForWindows32v1));
             }
-            if (!String.IsNullOrEmpty(reg32HkcuPath))
+            if (!string.IsNullOrEmpty(reg32HkcuPath))
             {
                 candidates.Add(new GitInstallation(reg32HkcuPath, KnownGitDistribution.GitForWindows32v2));
                 candidates.Add(new GitInstallation(reg32HkcuPath, KnownGitDistribution.GitForWindows32v1));
             }
-            if (!String.IsNullOrEmpty(programDataPath))
+            if (!string.IsNullOrEmpty(programDataPath))
             {
                 candidates.Add(new GitInstallation(programDataPath, KnownGitDistribution.GitForWindows64v2));
                 candidates.Add(new GitInstallation(programDataPath, KnownGitDistribution.GitForWindows32v2));
                 candidates.Add(new GitInstallation(programDataPath, KnownGitDistribution.GitForWindows32v1));
             }
-            if (!String.IsNullOrEmpty(appDataLocalPath))
+            if (!string.IsNullOrEmpty(appDataLocalPath))
             {
                 candidates.Add(new GitInstallation(appDataLocalPath, KnownGitDistribution.GitForWindows64v2));
                 candidates.Add(new GitInstallation(appDataLocalPath, KnownGitDistribution.GitForWindows32v2));
                 candidates.Add(new GitInstallation(appDataLocalPath, KnownGitDistribution.GitForWindows32v1));
             }
-            if (!String.IsNullOrEmpty(appDataRoamingPath))
+            if (!string.IsNullOrEmpty(appDataRoamingPath))
             {
                 candidates.Add(new GitInstallation(appDataRoamingPath, KnownGitDistribution.GitForWindows64v2));
                 candidates.Add(new GitInstallation(appDataRoamingPath, KnownGitDistribution.GitForWindows32v2));
@@ -311,7 +311,7 @@ namespace Microsoft.Alm.Git
             const string GitFolderName = ".git";
             const string LocalConfigFileName = "config";
 
-            if (!String.IsNullOrWhiteSpace(startingDirectory))
+            if (!string.IsNullOrWhiteSpace(startingDirectory))
             {
                 var dir = new DirectoryInfo(startingDirectory);
 

--- a/Microsoft.Vsts.Authentication.Test/AuthorityFake.cs
+++ b/Microsoft.Vsts.Authentication.Test/AuthorityFake.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Alm.Authentication.Test
     {
         public AuthorityFake(string expectedQueryParameters)
         {
-            this.ExpectedQueryParameters = expectedQueryParameters;
+            ExpectedQueryParameters = expectedQueryParameters;
         }
 
         internal readonly string ExpectedQueryParameters;
@@ -20,7 +20,7 @@ namespace Microsoft.Alm.Authentication.Test
 
         public async Task<Token> InteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri, string queryParameters = null)
         {
-            Assert.Equal(this.ExpectedQueryParameters, queryParameters);
+            Assert.Equal(ExpectedQueryParameters, queryParameters);
 
             return await Task.FromResult(new Token("token-access", TokenType.Access));
         }

--- a/Microsoft.Vsts.Authentication/TokenRegistry.cs
+++ b/Microsoft.Vsts.Authentication/TokenRegistry.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Alm.Authentication
                             value = Encoding.UTF8.GetString(data);
 
                             TokenType tokenType;
-                            if (String.Equals(type, "Federated", StringComparison.OrdinalIgnoreCase))
+                            if (string.Equals(type, "Federated", StringComparison.OrdinalIgnoreCase))
                             {
                                 tokenType = TokenType.Federated;
                             }

--- a/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
+++ b/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
@@ -71,11 +71,11 @@ namespace Microsoft.Alm.Authentication
         {
             lock (_syncpoint)
             {
-                if (File.Exists(_cacheFilePath) && this.HasStateChanged)
+                if (File.Exists(_cacheFilePath) && HasStateChanged)
                 {
                     try
                     {
-                        byte[] state = this.Serialize();
+                        byte[] state = Serialize();
 
                         byte[] data = ProtectedData.Protect(state, null, DataProtectionScope.CurrentUser);
 

--- a/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Alm.Authentication
 
             // personal access tokens are effectively credentials, treat them as such
             if (token.Type == TokenType.Personal)
-                return await this.ValidateCredentials(targetUri, (Credential)token);
+                return await ValidateCredentials(targetUri, (Credential)token);
 
             try
             {

--- a/Microsoft.Vsts.Authentication/VstsTokenScope.cs
+++ b/Microsoft.Vsts.Authentication/VstsTokenScope.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Alm.Authentication
 {
     public class VstsTokenScope: TokenScope
     {
-        public static readonly VstsTokenScope None = new VstsTokenScope(String.Empty);
+        public static readonly VstsTokenScope None = new VstsTokenScope(string.Empty);
 
         /// <summary>
         /// Grants the ability to access build artifacts, including build results, definitions, and


### PR DESCRIPTION
The `TryReadBoolean` method was losing value set by git-config, this fixes that issue.

Includes a fix for stack overflow in `Bitbucket.Authentication.SetCredentials` which were blocking unit-tests.

Resolves #465

/CC @mminns 