### PR TITLE
Avoid throwing from secret stores.

### DIFF
--- a/Bitbucket.Authentication.Test/AuthenticationTest.cs
+++ b/Bitbucket.Authentication.Test/AuthenticationTest.cs
@@ -359,10 +359,11 @@ namespace Atlassian.Bitbucket.Authentication.Test
             get { throw new NotImplementedException(); }
         }
 
-        public void DeleteCredentials(TargetUri targetUri)
+        public bool DeleteCredentials(TargetUri targetUri)
         {
             // do nothing
             RecordMethodCall("DeleteCredentials", new List<string>() { targetUri.ActualUri.AbsoluteUri });
+            return true;
         }
 
         public Credential ReadCredentials(TargetUri targetUri)
@@ -372,10 +373,11 @@ namespace Atlassian.Bitbucket.Authentication.Test
             return Credentials != null && Credentials.Keys.Contains(targetUri.ActualUri.AbsoluteUri) ? Credentials[targetUri.ActualUri.AbsoluteUri] : null;
         }
 
-        public void WriteCredentials(TargetUri targetUri, Credential credentials)
+        public bool WriteCredentials(TargetUri targetUri, Credential credentials)
         {
             // do nothing
             RecordMethodCall("WriteCredentials", new List<string>() { targetUri.ActualUri.AbsoluteUri, credentials.Username, credentials.Password });
+            return true;
         }
 
         private void RecordMethodCall(string methodName, List<string> args)

--- a/Microsoft.Alm.Authentication/BaseSecureStore.cs
+++ b/Microsoft.Alm.Authentication/BaseSecureStore.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Alm.Authentication
         public static readonly char[] IllegalCharacters = new[] { ':', ';', '\\', '?', '@', '=', '&', '%', '$' };
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        protected void Delete(string targetName)
+        protected bool Delete(string targetName)
         {
             try
             {
@@ -62,7 +62,10 @@ namespace Microsoft.Alm.Authentication
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
+                return false;
             }
+
+            return true;
         }
 
         protected abstract string GetTargetName(TargetUri targetUri);
@@ -112,6 +115,7 @@ namespace Microsoft.Alm.Authentication
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         protected Credential ReadCredentials(string targetName)
         {
             Credential credentials = null;
@@ -134,6 +138,14 @@ namespace Microsoft.Alm.Authentication
                     Git.Trace.WriteLine($"credentials for '{targetName}' read from store.");
                 }
             }
+            catch (Exception exception)
+            {
+                Debug.WriteLine(exception);
+
+                Git.Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
+
+                return null;
+            }
             finally
             {
                 if (credPtr != IntPtr.Zero)
@@ -145,6 +157,7 @@ namespace Microsoft.Alm.Authentication
             return credentials;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         protected Token ReadToken(string targetName)
         {
             Token token = null;
@@ -171,6 +184,14 @@ namespace Microsoft.Alm.Authentication
                     }
                 }
             }
+            catch(Exception exception)
+            {
+                Debug.WriteLine(exception);
+
+                Git.Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
+
+                return null;
+            }
             finally
             {
                 if (credPtr != IntPtr.Zero)
@@ -182,7 +203,8 @@ namespace Microsoft.Alm.Authentication
             return token;
         }
 
-        protected void WriteCredential(string targetName, Credential credentials)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        protected bool WriteCredential(string targetName, Credential credentials)
         {
             if (ReferenceEquals(targetName, null))
                 throw new ArgumentNullException(nameof(targetName));
@@ -209,6 +231,14 @@ namespace Microsoft.Alm.Authentication
 
                 Git.Trace.WriteLine($"credentials for '{targetName}' written to store.");
             }
+            catch (Exception exception)
+            {
+                Debug.WriteLine(exception);
+
+                Git.Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
+
+                return false;
+            }
             finally
             {
                 if (credential.CredentialBlob != IntPtr.Zero)
@@ -216,9 +246,12 @@ namespace Microsoft.Alm.Authentication
                     Marshal.FreeCoTaskMem(credential.CredentialBlob);
                 }
             }
+
+            return true;
         }
 
-        protected void WriteToken(string targetName, Token token)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        protected bool WriteToken(string targetName, Token token)
         {
             if (ReferenceEquals(targetName, null))
                 throw new ArgumentNullException(nameof(targetName));
@@ -253,6 +286,14 @@ namespace Microsoft.Alm.Authentication
 
                         Git.Trace.WriteLine($"token for '{targetName}' written to store.");
                     }
+                    catch (Exception exception)
+                    {
+                        Debug.WriteLine(exception);
+
+                        Git.Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
+
+                        return false;
+                    }
                     finally
                     {
                         if (credential.CredentialBlob != IntPtr.Zero)
@@ -262,6 +303,8 @@ namespace Microsoft.Alm.Authentication
                     }
                 }
             }
+
+            return true;
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]

--- a/Microsoft.Alm.Authentication/ICredentialStore.cs
+++ b/Microsoft.Alm.Authentication/ICredentialStore.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Alm.Authentication
 
         Secret.UriNameConversion UriNameConversion { get; }
 
-        void DeleteCredentials(TargetUri targetUri);
+        bool DeleteCredentials(TargetUri targetUri);
 
         Credential ReadCredentials(TargetUri targetUri);
 
-        void WriteCredentials(TargetUri targetUri, Credential credentials);
+        bool WriteCredentials(TargetUri targetUri, Credential credentials);
     }
 }

--- a/Microsoft.Alm.Authentication/ITokenStore.cs
+++ b/Microsoft.Alm.Authentication/ITokenStore.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Alm.Authentication
         /// Deletes a <see cref="Token"/> from the underlying storage.
         /// </summary>
         /// <param name="targetUri">The key identifying which token is being deleted.</param>
-        void DeleteToken(TargetUri targetUri);
+        bool DeleteToken(TargetUri targetUri);
 
         /// <summary>
         /// Reads a <see cref="Token"/> from the underlying storage.
@@ -47,6 +47,6 @@ namespace Microsoft.Alm.Authentication
         /// Unique identifier for the token, used when reading back from storage.
         /// </param>
         /// <param name="token">The <see cref="Token"/> to be written.</param>
-        void WriteToken(TargetUri targetUri, Token token);
+        bool WriteToken(TargetUri targetUri, Token token);
     }
 }

--- a/Microsoft.Alm.Authentication/SecretCache.cs
+++ b/Microsoft.Alm.Authentication/SecretCache.cs
@@ -28,7 +28,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Alm.Authentication
 {
-    public sealed class SecretCache: ICredentialStore, ITokenStore
+    public sealed class SecretCache : ICredentialStore, ITokenStore
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         public static readonly StringComparer KeyComparer = StringComparer.OrdinalIgnoreCase;
@@ -74,7 +74,7 @@ namespace Microsoft.Alm.Authentication
         /// Deletes a credential from the cache.
         /// </summary>
         /// <param name="targetUri">The URI of the target for which credentials are being deleted</param>
-        public void DeleteCredentials(TargetUri targetUri)
+        public bool DeleteCredentials(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
@@ -82,10 +82,9 @@ namespace Microsoft.Alm.Authentication
 
             lock (_cache)
             {
-                if (_cache.ContainsKey(targetName) && _cache[targetName] is Credential)
-                {
-                    _cache.Remove(targetName);
-                }
+                return _cache.ContainsKey(targetName)
+                    && _cache[targetName] is Credential
+                    && _cache.Remove(targetName);
             }
         }
 
@@ -93,7 +92,7 @@ namespace Microsoft.Alm.Authentication
         /// Deletes a token from the cache.
         /// </summary>
         /// <param name="targetUri">The key which to find and delete the token with.</param>
-        public void DeleteToken(TargetUri targetUri)
+        public bool DeleteToken(TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
@@ -101,10 +100,9 @@ namespace Microsoft.Alm.Authentication
 
             lock (_cache)
             {
-                if (_cache.ContainsKey(targetName) && _cache[targetName] is Token)
-                {
-                    _cache.Remove(targetName);
-                }
+                return _cache.ContainsKey(targetName)
+                    && _cache[targetName] is Token
+                    && _cache.Remove(targetName);
             }
         }
 
@@ -167,7 +165,7 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         /// <param name="targetUri">The URI of the target for which credentials are being stored</param>
         /// <param name="credentials">The credentials to be stored</param>
-        public void WriteCredentials(TargetUri targetUri, Credential credentials)
+        public bool WriteCredentials(TargetUri targetUri, Credential credentials)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
@@ -185,6 +183,8 @@ namespace Microsoft.Alm.Authentication
                     _cache.Add(targetName, credentials);
                 }
             }
+
+            return true;
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         /// <param name="targetUri">The key which to index the token by.</param>
         /// <param name="token">The token to write to the cache.</param>
-        public void WriteToken(TargetUri targetUri, Token token)
+        public bool WriteToken(TargetUri targetUri, Token token)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
             Token.Validate(token);
@@ -210,6 +210,8 @@ namespace Microsoft.Alm.Authentication
                     _cache.Add(targetName, token);
                 }
             }
+
+            return true;
         }
 
         /// <summary>

--- a/Microsoft.Alm.Authentication/SecretStore.cs
+++ b/Microsoft.Alm.Authentication/SecretStore.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Alm.Authentication
     /// Interface to secure secrets storage which indexes values by target and utilizes the operating
     /// system keychain / secrets vault.
     /// </summary>
-    public sealed class SecretStore: BaseSecureStore, ICredentialStore, ITokenStore
+    public sealed class SecretStore : BaseSecureStore, ICredentialStore, ITokenStore
     {
         /// <summary>
         /// Creates a new <see cref="SecretStore"/> backed by the operating system keychain / secrets vault.
@@ -85,29 +85,28 @@ namespace Microsoft.Alm.Authentication
         /// Deletes credentials for target URI from the credential store
         /// </summary>
         /// <param name="targetUri">The URI of the target for which credentials are being deleted</param>
-        public void DeleteCredentials(TargetUri targetUri)
+        public bool DeleteCredentials(TargetUri targetUri)
         {
             ValidateTargetUri(targetUri);
 
             string targetName = GetTargetName(targetUri);
 
-            Delete(targetName);
-
-            _credentialCache.DeleteCredentials(targetUri);
+            return Delete(targetName)
+                && _credentialCache.DeleteCredentials(targetUri);
         }
 
         /// <summary>
         /// Deletes the token for target URI from the token store
         /// </summary>
         /// <param name="targetUri">The URI of the target for which the token is being deleted</param>
-        public void DeleteToken(TargetUri targetUri)
+        public bool DeleteToken(TargetUri targetUri)
         {
             ValidateTargetUri(targetUri);
 
             string targetName = GetTargetName(targetUri);
 
-            Delete(targetName);
-            _tokenCache.DeleteToken(targetUri);
+            return Delete(targetName)
+                && _tokenCache.DeleteToken(targetUri);
         }
 
         /// <summary>
@@ -154,16 +153,15 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         /// <param name="targetUri">The URI of the target for which credentials are being stored</param>
         /// <param name="credentials">The credentials to be stored</param>
-        public void WriteCredentials(TargetUri targetUri, Credential credentials)
+        public bool WriteCredentials(TargetUri targetUri, Credential credentials)
         {
             ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
             string targetName = GetTargetName(targetUri);
 
-            WriteCredential(targetName, credentials);
-
-            _credentialCache.WriteCredentials(targetUri, credentials);
+            return WriteCredential(targetName, credentials)
+                && _credentialCache.WriteCredentials(targetUri, credentials);
         }
 
         /// <summary>
@@ -171,16 +169,15 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         /// <param name="targetUri">The URI of the target for which a token is being stored</param>
         /// <param name="token">The token to be stored</param>
-        public void WriteToken(TargetUri targetUri, Token token)
+        public bool WriteToken(TargetUri targetUri, Token token)
         {
             ValidateTargetUri(targetUri);
             Token.Validate(token);
 
             string targetName = GetTargetName(targetUri);
 
-            WriteToken(targetName, token);
-
-            _tokenCache.WriteToken(targetUri, token);
+            return WriteToken(targetName, token)
+                && _tokenCache.WriteToken(targetUri, token);
         }
 
         /// <summary>

--- a/Microsoft.Vsts.Authentication/TokenRegistry.cs
+++ b/Microsoft.Vsts.Authentication/TokenRegistry.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Alm.Authentication
         /// Not supported
         /// </summary>
         /// <param name="targetUri"></param>
-        public void DeleteToken(TargetUri targetUri)
+        public bool DeleteToken(TargetUri targetUri)
         {
             // we've decided to not support registry deletes until the rules are established
             throw new NotSupportedException("Deletes from the registry are not supported by this library.");
@@ -121,13 +121,13 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         /// <param name="targetUri"></param>
         /// <param name="token"></param>
-        public void WriteToken(TargetUri targetUri, Token token)
+        public bool WriteToken(TargetUri targetUri, Token token)
         {
             // we've decided to not support registry writes until the format is standardized
             throw new NotSupportedException("Writes to the registry are not supported by this library.");
         }
 
-        private IEnumerable<RegistryKey> EnumerateKeys(bool writeable)
+        private static IEnumerable<RegistryKey> EnumerateKeys(bool writeable)
         {
             foreach (var rootKey in EnumerateRootKeys())
             {


### PR DESCRIPTION
Change the secret stores (credential and token) to returning success/failure instead of throwing exceptions. This is to enable users who cannot read from/write to their credential managers from faulting and therefore being unable to pass credentials to git.exe.

#477
