### PR TITLE
Add information to the GUI screens if the 'path' parameter is passed into the GCM

### DIFF
--- a/Bitbucket.Authentication/AuthenticationPrompts.cs
+++ b/Bitbucket.Authentication/AuthenticationPrompts.cs
@@ -80,7 +80,7 @@ namespace Atlassian.Bitbucket.Authentication
         public static bool CredentialModalPrompt(string title, TargetUri targetUri, out string username, out string password)
         {
             // if there is a user in the remote URL then prepopulate the UI with it.
-            var credentialViewModel = new CredentialsViewModel(GetUserFromTargetUri(targetUri));
+            var credentialViewModel = new CredentialsViewModel(GetUserFromTargetUri(targetUri), targetUri.ActualUri.AbsolutePath);
 
             Trace.WriteLine("prompting user for credentials.");
 
@@ -105,7 +105,7 @@ namespace Atlassian.Bitbucket.Authentication
         /// </returns>
         public static bool AuthenticationOAuthModalPrompt(string title, TargetUri targetUri, AuthenticationResultType resultType, string username)
         {
-            var oauthViewModel = new OAuthViewModel(resultType == AuthenticationResultType.TwoFactor);
+            var oauthViewModel = new OAuthViewModel(resultType == AuthenticationResultType.TwoFactor, targetUri.ActualUri.AbsolutePath);
 
             Trace.WriteLine("prompting user for authentication code.");
 

--- a/Bitbucket.Authentication/Controls/CredentialsControl.xaml
+++ b/Bitbucket.Authentication/Controls/CredentialsControl.xaml
@@ -46,7 +46,7 @@
                 <Setter Property="Margin" Value="0,10,0,0" />
             </Style>
             <Style TargetType="{x:Type DockPanel}">
-                <Setter Property="Margin" Value="0,20,0,0" />
+                <Setter Property="Margin" Value="0,10,0,0" />
                 <Setter Property="LastChildFill" Value="True" />
             </Style>
             <Style x:Key="FormFieldStackPanel" TargetType="{x:Type StackPanel}">
@@ -58,10 +58,10 @@
             <StackPanel
                 Orientation="Horizontal"
                 HorizontalAlignment="Center"
-                Margin="0,0,0,15">
+                Margin="0,0,0,0">
                 <Button
+                    x:Name="LoginButton"
                     TabIndex="2"
-                    IsDefault="True"
                     Command="{Binding LoginCommand}"
                     IsEnabled="{Binding IsValid, Mode=OneWay}"
                     Content="{x:Static properties:Resources.LoginLabel}"
@@ -98,21 +98,44 @@
         <StackPanel DockPanel.Dock="Top">
             <Image Style="{StaticResource AtlassianLogo}" />
             <controls:HorizontalShadowDivider />
-            <Image Style="{StaticResource BitbucketLogo}" />
+            <Image Style="{StaticResource BitbucketLogo}" 
+                   Margin="0,0,0,10"/>
             <Image Style="{StaticResource SourceTreeLogo}" />
         </StackPanel>
 
         <StackPanel Style="{StaticResource FormFieldStackPanel}">
 
+            <TextBlock x:Name="Organisation"
+                       Visibility="{Binding HasPath}"
+                       TextTrimming="CharacterEllipsis"
+                       Margin="0,10,0,0">
+                <Run Text="{x:Static properties:Resources.OrganisationLabel}"
+                     FontWeight="Bold"/>
+                <Run Text=": "/>
+                <Run Text="{Binding Organisation, Mode=OneTime}"
+                     ToolTip="{Binding Organisation, Mode=OneTime}"/>
+            </TextBlock>
+
+            <TextBlock x:Name="Repository"
+                       Visibility="{Binding HasPath}"
+                       TextTrimming="CharacterEllipsis"
+                       Margin="0,10,0,0">
+                <Run Text="{x:Static properties:Resources.RepositoryLabel}"
+                     FontWeight="Bold"/>
+                <Run Text=": "/>
+                <Run Text="{Binding Repository, Mode=OneTime}"
+                     ToolTip="{Binding Repository, Mode=OneTime}"/>
+            </TextBlock>
+
             <sharedControls:PromptTextBox
-                x:Name="loginTextBox"
+                x:Name="LoginTextBox"
                 PromptText="{x:Static properties:Resources.LoginPromptText}"
                 Text="{Binding Login, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
             <controls:ValidationMessage Validator="{Binding LoginValidator, Mode=OneWay}" />
 
             <sharedControls:MaskedPasswordBox
-                x:Name="passwordTextBox"
+                x:Name="PasswordTextBox"
                 Password="{Binding Password, Mode=OneWayToSource}"
                 PromptText="{x:Static properties:Resources.PasswordPromptText}" />
 

--- a/Bitbucket.Authentication/Controls/CredentialsControl.xaml.cs
+++ b/Bitbucket.Authentication/Controls/CredentialsControl.xaml.cs
@@ -41,13 +41,17 @@ namespace Atlassian.Bitbucket.Authentication.Controls
 
         protected override void SetFocus()
         {
-            if (string.IsNullOrWhiteSpace(loginTextBox.Text))
+            if (string.IsNullOrWhiteSpace(LoginTextBox.Text))
             {
-                loginTextBox.TryFocus().Wait(TimeSpan.FromSeconds(1));
+                LoginTextBox.TryFocus().Wait(TimeSpan.FromSeconds(1));
+            }
+            else if (string.IsNullOrWhiteSpace(PasswordTextBox.Text))
+            {
+                PasswordTextBox.TryFocus().Wait(TimeSpan.FromSeconds(1));
             }
             else
             {
-                passwordTextBox.TryFocus().Wait(TimeSpan.FromSeconds(1));
+                LoginButton.TryFocus().Wait(TimeSpan.FromSeconds(1));
             }
         }
     }

--- a/Bitbucket.Authentication/Controls/HorizontalShadowDivider.xaml
+++ b/Bitbucket.Authentication/Controls/HorizontalShadowDivider.xaml
@@ -36,7 +36,7 @@
     Width="200"
     Opacity=".6"
     Height="2"
-    Margin="0,0,0,25"
+    Margin="0,0,0,10"
     IsHitTestVisible="False"
     VerticalAlignment="Top">
     <Grid IsHitTestVisible="False">

--- a/Bitbucket.Authentication/Controls/OAuthControl.xaml
+++ b/Bitbucket.Authentication/Controls/OAuthControl.xaml
@@ -40,14 +40,15 @@
     Style="{DynamicResource DialogUserControl}">
 
     <StackPanel
-        Style="{DynamicResource DialogContainerStackPanel}"
-        sharedHelpers:AccessKeysManagerScoping.IsEnabled="True">
+        Style="{DynamicResource DialogContainerStackPanel}">
+
         <StackPanel DockPanel.Dock="Top">
             <Image Style="{StaticResource AtlassianLogo}" />
             <controls:HorizontalShadowDivider />
             <Image Style="{StaticResource BitbucketLogo}" />
             <Image Style="{StaticResource SourceTreeLogo}" />
         </StackPanel>
+        
         <WrapPanel Orientation="Vertical" HorizontalAlignment="Center" Margin="0,0,0,12">
             <TextBlock
                 Text="{x:Static properties:Resources.OAuthAuthText}"
@@ -76,14 +77,33 @@
                 <TextBlock Text="{x:Static properties:Resources.LearnMoreLink}" />
             </Hyperlink>
         </TextBlock>
-        <!--<ui:TwoFactorInput
-            x:Name="authenticationCode"
-            Text="{Binding AuthenticationCode, Mode=OneWayToSource}"
-            TabIndex="1" />-->
+        
+        <StackPanel MaxWidth="250" Margin="0,0,0,10">
+            <TextBlock x:Name="Organisation"
+                       Visibility="{Binding HasPath}"
+                       TextTrimming="CharacterEllipsis"
+                       Margin="0,10,0,0">
+                <Run Text="{x:Static properties:Resources.OrganisationLabel}"
+                     FontWeight="Bold"/>
+                <Run Text=": "/>
+                <Run Text="{Binding Organisation, Mode=OneTime}"/>
+            </TextBlock>
+
+            <TextBlock x:Name="Repository"
+                       Visibility="{Binding HasPath}"
+                       TextTrimming="CharacterEllipsis"
+                       Margin="0,10,0,0">
+                <Run Text="{x:Static properties:Resources.RepositoryLabel}"
+                     FontWeight="Bold"/>
+                <Run Text=": "/>
+                <Run Text="{Binding Repository, Mode=OneTime}"/>
+            </TextBlock>
+        </StackPanel>
+        
         <StackPanel
             Orientation="Horizontal"
             HorizontalAlignment="Center"
-            Margin="0,38,0,60">
+            Margin="0,10,0,60">
             <Button
                 TabIndex="2"
                 IsDefault="True"

--- a/Bitbucket.Authentication/Properties/Resources.Designer.cs
+++ b/Bitbucket.Authentication/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Atlassian.Bitbucket.Authentication.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -133,6 +133,15 @@ namespace Atlassian.Bitbucket.Authentication.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Organisation.
+        /// </summary>
+        public static string OrganisationLabel {
+            get {
+                return ResourceManager.GetString("OrganisationLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
         public static string PasswordPromptText {
@@ -147,6 +156,15 @@ namespace Atlassian.Bitbucket.Authentication.Properties {
         public static string PasswordRequired {
             get {
                 return ResourceManager.GetString("PasswordRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repository.
+        /// </summary>
+        public static string RepositoryLabel {
+            get {
+                return ResourceManager.GetString("RepositoryLabel", resourceCulture);
             }
         }
         

--- a/Bitbucket.Authentication/Properties/Resources.resx
+++ b/Bitbucket.Authentication/Properties/Resources.resx
@@ -141,11 +141,17 @@
   <data name="OAuthAuthText" xml:space="preserve">
     <value>OAuth Authentication</value>
   </data>
+  <data name="OrganisationLabel" xml:space="preserve">
+    <value>Organisation</value>
+  </data>
   <data name="PasswordPromptText" xml:space="preserve">
     <value>Password</value>
   </data>
   <data name="PasswordRequired" xml:space="preserve">
     <value>A password is required</value>
+  </data>
+  <data name="RepositoryLabel" xml:space="preserve">
+    <value>Repository</value>
   </data>
   <data name="SignUpLinkText" xml:space="preserve">
     <value>Sign up.</value>

--- a/Bitbucket.Authentication/ViewModels/CredentialsViewModel.cs
+++ b/Bitbucket.Authentication/ViewModels/CredentialsViewModel.cs
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using System.Windows;
 using System.Windows.Input;
 using Atlassian.Bitbucket.Authentication.Properties;
 using GitHub.Shared.Helpers;
@@ -36,14 +37,14 @@ namespace Atlassian.Bitbucket.Authentication.ViewModels
     /// </summary>
     public class CredentialsViewModel: DialogViewModel
     {
-        public CredentialsViewModel() : this(string.Empty)
+        public CredentialsViewModel() : this(string.Empty, string.Empty)
         {
             // without this default constructor get nullreferenceexceptions during binding i guess
             // 'cos the view is built before the 'official' viewmodel and hence generates it own
             // viewmodel while building?
         }
 
-        public CredentialsViewModel(string username)
+        public CredentialsViewModel(string username, string path)
         {
             LoginCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Ok);
             CancelCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Cancel);
@@ -65,6 +66,24 @@ namespace Atlassian.Bitbucket.Authentication.ViewModels
             if (!string.IsNullOrWhiteSpace(username))
             {
                 Login = username;
+            }
+
+            HasPath = Visibility.Hidden;
+            if (!string.IsNullOrWhiteSpace(path) 
+                && path.Contains("/"))
+            {
+                // bitbucket format should be /org/repo.git
+                var parts = path.Split('/');
+                if (parts.Length == 3)
+                {
+                    Organisation = parts[1];
+                    if (!string.IsNullOrWhiteSpace(parts[2])
+                        && parts[2].EndsWith(".git"))
+                    {
+                        Repository = parts[2].Substring(0, parts[2].Length - ".git".Length);
+                        HasPath = Visibility.Visible;
+                    }
+                }
             }
         }
 
@@ -106,6 +125,21 @@ namespace Atlassian.Bitbucket.Authentication.ViewModels
                 RaisePropertyChangedEvent(nameof(Password));
             }
         }
+
+        /// <summary>
+        ///     Gets the repository name, as found from the path
+        /// </summary>
+        public string Repository { get;  }
+
+        /// <summary>
+        ///     Gets the organisation name, as found from the path
+        /// </summary>
+        public string Organisation { get; }
+
+        /// <summary>
+        ///     Gets a flag indicating if there is a org and repo to show
+        /// </summary>
+        public Visibility HasPath { get; }
 
         public PropertyValidator<string> PasswordValidator { get; }
 

--- a/Bitbucket.Authentication/ViewModels/OAuthViewModel.cs
+++ b/Bitbucket.Authentication/ViewModels/OAuthViewModel.cs
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using System.Windows;
 using System.Windows.Input;
 using GitHub.Shared.Helpers;
 using GitHub.Shared.ViewModels;
@@ -36,11 +37,11 @@ namespace Atlassian.Bitbucket.Authentication.ViewModels
     {
         private bool _resultType;
 
-        public OAuthViewModel() : this(false)
+        public OAuthViewModel() : this(false, string.Empty)
         {
         }
 
-        public OAuthViewModel(bool resultType)
+        public OAuthViewModel(bool resultType, string path)
         {
             _resultType = resultType;
 
@@ -49,7 +50,40 @@ namespace Atlassian.Bitbucket.Authentication.ViewModels
 
             // just a notification dialog so its always valid.
             IsValid = true;
+
+            HasPath = Visibility.Hidden;
+            if (!string.IsNullOrWhiteSpace(path)
+                && path.Contains("/"))
+            {
+                // bitbucket format should be /org/repo.git
+                var parts = path.Split('/');
+                if (parts.Length == 3)
+                {
+                    Organisation = parts[1];
+                    if (!string.IsNullOrWhiteSpace(parts[2])
+                        && parts[2].EndsWith(".git"))
+                    {
+                        Repository = parts[2].Substring(0, parts[2].Length - ".git".Length);
+                        HasPath = Visibility.Visible;
+                    }
+                }
+            }
         }
+
+        /// <summary>
+        ///     Gets the repository name, as found from the path
+        /// </summary>
+        public string Repository { get; }
+
+        /// <summary>
+        ///     Gets the organisation name, as found from the path
+        /// </summary>
+        public string Organisation { get; }
+
+        /// <summary>
+        ///     Gets a flag indicating if there is a org and repo to show
+        /// </summary>
+        public Visibility HasPath { get; }
 
         /// <summary>
         /// Provides a link to Bitbucket OAuth documentation

--- a/Bitbucket.Authentication/Views/CredentialsWindow.xaml
+++ b/Bitbucket.Authentication/Views/CredentialsWindow.xaml
@@ -39,14 +39,14 @@
     UseLayoutRounding="True"
     ResizeMode="NoResize"
     Title="Bitbucket Login"
-    MinHeight="380"
-    Height="420"
+    MinHeight="440"
+    Height="440"
     Width="420"
     Icon="pack://application:,,,/Bitbucket.Authentication;component/Assets/SourceTree.ico">
     <Window.DataContext>
         <viewmodels:CredentialsViewModel />
     </Window.DataContext>
     <Grid>
-        <controls:CredentialsControl x:Name="credentialsControl" />
+        <controls:CredentialsControl x:Name="credentialsControl"/>
     </Grid>
 </sharedControls:AuthenticationDialogWindow>

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Alm.Cli
                 string actualUrl = null;
                 string queryUrl = null;
                 string proxyUrl = _proxyUri?.OriginalString;
-
+                
                 // when the target requests a path...
                 if (UseHttpPath)
                 {

--- a/GitHub.Authentication.Test/CredentialsViewModelTests.cs
+++ b/GitHub.Authentication.Test/CredentialsViewModelTests.cs
@@ -1,4 +1,5 @@
-﻿using GitHub.Authentication.ViewModels;
+﻿using System;
+using GitHub.Authentication.ViewModels;
 using Xunit;
 
 namespace GitHub.Authentication.Test
@@ -8,7 +9,7 @@ namespace GitHub.Authentication.Test
         [Fact]
         public void ValidatesLoginAndPassword()
         {
-            var viewModel = new CredentialsViewModel();
+            var viewModel = new CredentialsViewModel(String.Empty);
             Assert.False(viewModel.LoginValidator.ValidationResult.IsValid);
             Assert.False(viewModel.PasswordValidator.ValidationResult.IsValid);
 
@@ -22,7 +23,7 @@ namespace GitHub.Authentication.Test
         [Fact]
         public void IsValidWhenBothLoginAndPasswordIsValid()
         {
-            var viewModel = new CredentialsViewModel();
+            var viewModel = new CredentialsViewModel(String.Empty);
             Assert.False(viewModel.ModelValidator.IsValid);
             viewModel.Login = "Tyrion";
             Assert.False(viewModel.ModelValidator.IsValid);

--- a/GitHub.Authentication/AuthenticationPrompts.cs
+++ b/GitHub.Authentication/AuthenticationPrompts.cs
@@ -41,7 +41,7 @@ namespace GitHub.Authentication
     {
         public static bool CredentialModalPrompt(TargetUri targetUri, out string username, out string password)
         {
-            var credentialViewModel = new CredentialsViewModel();
+            var credentialViewModel = new CredentialsViewModel(targetUri.ActualUri.AbsolutePath);
 
             Git.Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
 
@@ -55,7 +55,7 @@ namespace GitHub.Authentication
 
         public static bool AuthenticationCodeModalPrompt(TargetUri targetUri, GitHubAuthenticationResultType resultType, string username, out string authenticationCode)
         {
-            var twoFactorViewModel = new TwoFactorViewModel(resultType == GitHubAuthenticationResultType.TwoFactorSms);
+            var twoFactorViewModel = new TwoFactorViewModel(resultType == GitHubAuthenticationResultType.TwoFactorSms, targetUri.ActualUri.AbsolutePath);
 
             Git.Trace.WriteLine($"prompting user for authentication code for '{targetUri}'.");
 

--- a/GitHub.Authentication/Controls/CredentialsControl.xaml
+++ b/GitHub.Authentication/Controls/CredentialsControl.xaml
@@ -94,6 +94,29 @@
                 PromptText="{x:Static properties:Resources.PasswordPromptText}" />
 
             <controls:ValidationMessage Validator="{Binding PasswordValidator, Mode=OneWay}" />
+
+            <TextBlock x:Name="Organisation"
+                       Visibility="{Binding HasPath}"
+                       TextTrimming="CharacterEllipsis"
+                       Margin="0,10,0,0">
+                <Run Text="{x:Static properties:Resources.OrganisationLabel}"
+                     FontWeight="Bold"/>
+                <Run Text=": "/>
+                <Run Text="{Binding Organisation, Mode=OneTime}"
+                     ToolTip="{Binding Organisation, Mode=OneTime}"/>
+            </TextBlock>
+
+            <TextBlock x:Name="Repository"
+                       Visibility="{Binding HasPath}"
+                       TextTrimming="CharacterEllipsis"
+                       Margin="0,10,0,0">
+                <Run Text="{x:Static properties:Resources.RepositoryLabel}"
+                     FontWeight="Bold"/>
+                <Run Text=": "/>
+                <Run Text="{Binding Repository, Mode=OneTime}"
+                     ToolTip="{Binding Repository, Mode=OneTime}"/>
+            </TextBlock>
+
         </StackPanel>
     </DockPanel>
 </sharedControls:DialogUserControl>

--- a/GitHub.Authentication/Properties/Resources.Designer.cs
+++ b/GitHub.Authentication/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GitHub.Authentication.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -142,6 +142,15 @@ namespace GitHub.Authentication.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Organisation.
+        /// </summary>
+        public static string OrganisationLabel {
+            get {
+                return ResourceManager.GetString("OrganisationLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
         public static string PasswordPromptText {
@@ -156,6 +165,15 @@ namespace GitHub.Authentication.Properties {
         public static string PasswordRequired {
             get {
                 return ResourceManager.GetString("PasswordRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repository.
+        /// </summary>
+        public static string RepositoryLabel {
+            get {
+                return ResourceManager.GetString("RepositoryLabel", resourceCulture);
             }
         }
         

--- a/GitHub.Authentication/Properties/Resources.resx
+++ b/GitHub.Authentication/Properties/Resources.resx
@@ -162,4 +162,10 @@
   <data name="ForgotPasswordText" xml:space="preserve">
     <value>Forgot your password?</value>
   </data>
+  <data name="OrganisationLabel" xml:space="preserve">
+    <value>Organisation</value>
+  </data>
+  <data name="RepositoryLabel" xml:space="preserve">
+    <value>Repository</value>
+  </data>
 </root>

--- a/GitHub.Authentication/ViewModels/CredentialsViewModel.cs
+++ b/GitHub.Authentication/ViewModels/CredentialsViewModel.cs
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using System.Windows;
 using System.Windows.Input;
 using GitHub.Authentication.Properties;
 using GitHub.Shared.Helpers;
@@ -33,7 +34,14 @@ namespace GitHub.Authentication.ViewModels
 {
     public class CredentialsViewModel: DialogViewModel
     {
-        public CredentialsViewModel()
+        public CredentialsViewModel() : this(string.Empty)
+        {
+            // without this default constructor get nullreferenceexceptions during binding i guess
+            // 'cos the view is built before the 'official' viewmodel and hence generates it own
+            // viewmodel while building?
+        }
+
+        public CredentialsViewModel(string path)
         {
             LoginCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Ok);
             CancelCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Cancel);
@@ -52,6 +60,24 @@ namespace GitHub.Authentication.ViewModels
                     IsValid = ModelValidator.IsValid;
                 }
             };
+
+            HasPath = Visibility.Hidden;
+            if (!string.IsNullOrWhiteSpace(path)
+                && path.Contains("/"))
+            {
+                // bitbucket format should be /org/repo.git
+                var parts = path.Split('/');
+                if (parts.Length == 3)
+                {
+                    Organisation = parts[1];
+                    if (!string.IsNullOrWhiteSpace(parts[2])
+                        && parts[2].EndsWith(".git"))
+                    {
+                        Repository = parts[2].Substring(0, parts[2].Length - ".git".Length);
+                        HasPath = Visibility.Visible;
+                    }
+                }
+            }
         }
 
         private string _login;
@@ -88,6 +114,21 @@ namespace GitHub.Authentication.ViewModels
                 RaisePropertyChangedEvent(nameof(Password));
             }
         }
+
+        /// <summary>
+        ///     Gets the repository name, as found from the path
+        /// </summary>
+        public string Repository { get; }
+
+        /// <summary>
+        ///     Gets the organisation name, as found from the path
+        /// </summary>
+        public string Organisation { get; }
+
+        /// <summary>
+        ///     Gets a flag indicating if there is a org and repo to show
+        /// </summary>
+        public Visibility HasPath { get; }
 
         public PropertyValidator<string> PasswordValidator { get; }
 

--- a/GitHub.Authentication/ViewModels/TwoFactorViewModel.cs
+++ b/GitHub.Authentication/ViewModels/TwoFactorViewModel.cs
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using System.Windows;
 using System.Windows.Input;
 using GitHub.Authentication.Properties;
 using GitHub.Shared.Helpers;
@@ -38,13 +39,13 @@ namespace GitHub.Authentication.ViewModels
         /// <summary>
         /// This is used by the GitHub.Authentication test application
         /// </summary>
-        public TwoFactorViewModel() : this(false) { }
+        public TwoFactorViewModel() : this(false, string.Empty) { }
 
         /// <summary>
         /// This quite obviously creates an instance of a <see cref="TwoFactorViewModel"/>.
         /// </summary>
         /// <param name="isSms">True if the 2fa authentication code is sent via SMS</param>
-        public TwoFactorViewModel(bool isSms)
+        public TwoFactorViewModel(bool isSms, string path)
         {
             OkCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Ok);
             CancelCommand = new ActionCommand(_ => Result = AuthenticationDialogResult.Cancel);
@@ -59,6 +60,24 @@ namespace GitHub.Authentication.ViewModels
                     IsValid = AuthenticationCode.Length == 6;
                 }
             };
+
+            HasPath = Visibility.Hidden;
+            if (!string.IsNullOrWhiteSpace(path)
+                && path.Contains("/"))
+            {
+                // bitbucket format should be /org/repo.git
+                var parts = path.Split('/');
+                if (parts.Length == 3)
+                {
+                    Organisation = parts[1];
+                    if (!string.IsNullOrWhiteSpace(parts[2])
+                        && parts[2].EndsWith(".git"))
+                    {
+                        Repository = parts[2].Substring(0, parts[2].Length - ".git".Length);
+                        HasPath = Visibility.Visible;
+                    }
+                }
+            }
         }
 
         private string _authenticationCode;
@@ -87,6 +106,20 @@ namespace GitHub.Authentication.ViewModels
                     : Resources.OpenTwoFactorAuthAppText;
             }
         }
+        /// <summary>
+        ///     Gets the repository name, as found from the path
+        /// </summary>
+        public string Repository { get; }
+
+        /// <summary>
+        ///     Gets the organisation name, as found from the path
+        /// </summary>
+        public string Organisation { get; }
+
+        /// <summary>
+        ///     Gets a flag indicating if there is a org and repo to show
+        /// </summary>
+        public Visibility HasPath { get; }
 
         public ICommand LearnMoreCommand { get; }
             = new HyperLinkCommand();

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Alm.Authentication
             // Append some amount of path to the url
             if (path)
             {
-                url += QueryUri.AbsolutePath;
+                url += ActualUri.AbsolutePath;
             }
             else
             {

--- a/Microsoft.Alm.Git/Trace.cs
+++ b/Microsoft.Alm.Git/Trace.cs
@@ -186,7 +186,15 @@ namespace Microsoft.Alm.Git
             {
                 foreach (var writer in _writers)
                 {
-                    writer?.Flush();
+                    try
+                    {
+                        writer?.Flush();
+                    }
+                    catch (Exception e)
+                    {
+                        // swallow any errors as we're shutting down.
+                    }
+                    
                 }
             }
         }


### PR DESCRIPTION
_Work In Progress_

This provides a possible improvement for the situation described in https://github.com/Microsoft/Git-Credential-Manager-for-Windows/issues/188

If the git config includes credential.useHttpPath=true then a 'path' parameter will be passed to the GCM by Git. This can be used to show the user the full repo path or parsed to show organisation and repository information.

This is useful when you don't know what process triggered git and the GCM prompt and which repo it was doing it for e.g. in Sourcetree or VS Code background tasks.

Needs some tests adding, and some review of the GH UI change which is very basic, but functionally it appears to be working as hoped.