### PR TITLE
Authenticate gist repos properly

### DIFF
--- a/GitHub.Authentication.Test/AuthenticationTests.cs
+++ b/GitHub.Authentication.Test/AuthenticationTests.cs
@@ -1,0 +1,51 @@
+﻿using GitHub.Authentication.Test.Fakes;
+using Microsoft.Alm.Authentication;
+using System;
+using Xunit;
+
+namespace GitHub.Authentication.Test
+{
+    public class AuthenticationTests
+    {
+        [Theory]
+        [InlineData("https://github.com/", "https://github.com/")]
+        [InlineData("https://gist.github.com/", "https://gist.github.com/")]
+        [InlineData("https://github.com/", "https://gist.github.com/")]
+        [InlineData("https://gist.github.com/", "https://gist.github.com/")]
+        public void GetSetCredentialsNormalizesGistUrls(string writeUriString, string retrieveUriString)
+        {
+            var retrieveUri = new Uri(retrieveUriString);
+            var credentialStore = new InMemoryCredentialStore();
+            
+            var authentication = new Authentication(
+                new Uri(writeUriString),
+                TokenScope.Gist,
+                credentialStore,
+                new Authentication.AcquireCredentialsDelegate(AuthenticationPrompts.CredentialModalPrompt),
+                new Authentication.AcquireAuthenticationCodeDelegate(AuthenticationPrompts.AuthenticationCodeModalPrompt),
+                null);
+
+            authentication.SetCredentials(new Uri(writeUriString), new Credential("haacked"));
+            Assert.Equal("haacked", authentication.GetCredentials(retrieveUri).Username);
+        }
+
+        [Fact]
+        public void GetSetCredentialsDoesNotReturnCredentialForRandomUrl()
+        {
+            var retrieveUri = new Uri("https://example.com/");
+            var credentialStore = new InMemoryCredentialStore();
+
+            var authentication = new Authentication(
+                new Uri("https://github.com/"),
+                TokenScope.Gist,
+                credentialStore,
+                new Authentication.AcquireCredentialsDelegate(AuthenticationPrompts.CredentialModalPrompt),
+                new Authentication.AcquireAuthenticationCodeDelegate(AuthenticationPrompts.AuthenticationCodeModalPrompt),
+                null);
+
+            authentication.SetCredentials(new Uri("https://github.com/"), new Credential("haacked"));
+
+            Assert.Null(authentication.GetCredentials(retrieveUri));
+        }
+    }
+}

--- a/GitHub.Authentication.Test/Fakes/InMemoryCredentialStore.cs
+++ b/GitHub.Authentication.Test/Fakes/InMemoryCredentialStore.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Alm.Authentication;
+using System;
+using System.Collections.Generic;
+
+namespace GitHub.Authentication.Test.Fakes
+{
+    public class InMemoryCredentialStore : ICredentialStore
+    {
+        Dictionary<Uri, Credential> _credentials = new Dictionary<Uri, Credential>();
+
+        public string Namespace => "??";
+
+        public Secret.UriNameConversion UriNameConversion => null;
+
+        public bool DeleteCredentials(TargetUri targetUri)
+        {
+            _credentials.Remove(targetUri);
+            return true;
+        }
+
+        public Credential ReadCredentials(TargetUri targetUri)
+        {
+            Credential result;
+            return _credentials.TryGetValue(targetUri, out result)
+                ? result
+                : null;
+        }
+
+        public bool WriteCredentials(TargetUri targetUri, Credential credentials)
+        {
+            _credentials[targetUri] = credentials;
+            return true;
+        }
+    }
+}

--- a/GitHub.Authentication.Test/GitHub.Authentication.Test.csproj
+++ b/GitHub.Authentication.Test/GitHub.Authentication.Test.csproj
@@ -59,8 +59,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActionCommandTests.cs" />
+    <Compile Include="AuthenticationTests.cs" />
     <Compile Include="Controls\MaskedPasswordBoxTests.cs" />
     <Compile Include="CredentialsViewModelTests.cs" />
+    <Compile Include="Fakes\InMemoryCredentialStore.cs" />
     <Compile Include="GitHubTokenScopeTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="TwoFactorViewModelTests.cs" />

--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -36,6 +36,7 @@ namespace GitHub.Authentication
     public class Authentication : BaseAuthentication, IAuthentication
     {
         const string GitHubBaseUrlHost = "github.com";
+        const string GistBaseUrlHost = "gist." + GitHubBaseUrlHost;
         static readonly Uri GitHubBaseUri = new Uri("https://" + GitHubBaseUrlHost);
 
         /// <summary>
@@ -346,7 +347,7 @@ namespace GitHub.Authentication
         {
             // Special case for gist.github.com which are git backed repositories under the hood.
             // Credentials for these repos are the same as the one stored with "github.com"
-            if (targetUri.DnsSafeHost.StartsWith("gist.", StringComparison.OrdinalIgnoreCase) && targetUri.DnsSafeHost.EndsWith(".github.com", StringComparison.OrdinalIgnoreCase))
+            if (targetUri.DnsSafeHost.Equals(GistBaseUrlHost, StringComparison.OrdinalIgnoreCase))
                 return GitHubBaseUri;
 
             return targetUri;

--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -36,6 +36,7 @@ namespace GitHub.Authentication
     public class Authentication : BaseAuthentication, IAuthentication
     {
         const string GitHubBaseUrlHost = "github.com";
+        static readonly Uri GitHubBaseUri = new Uri("https://" + GitHubBaseUrlHost);
 
         /// <summary>
         /// Creates a new authentication
@@ -346,7 +347,7 @@ namespace GitHub.Authentication
             // Special case for gist.github.com which are git backed repositories under the hood.
             // Credentials for these repos are the same as the one stored with "github.com"
             if (targetUri.DnsSafeHost.StartsWith("gist.", StringComparison.OrdinalIgnoreCase) && targetUri.DnsSafeHost.EndsWith(".github.com", StringComparison.OrdinalIgnoreCase))
-                return new Uri("https://" + GitHubBaseUrlHost);
+                return GitHubBaseUri;
 
             return targetUri;
         }

--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -35,6 +35,8 @@ namespace GitHub.Authentication
     /// </summary>
     public class Authentication : BaseAuthentication, IAuthentication
     {
+        const string GitHubBaseUrlHost = "github.com";
+
         /// <summary>
         /// Creates a new authentication
         /// </summary>
@@ -65,7 +67,7 @@ namespace GitHub.Authentication
             TokenScope = tokenScope;
 
             PersonalAccessTokenStore = personalAccessTokenStore;
-            Authority = new Authority(targetUri);
+            Authority = new Authority(NormalizeUri(targetUri));
 
             AcquireCredentialsCallback = acquireCredentialsCallback;
             AcquireAuthenticationCodeCallback = acquireAuthenticationCodeCallback;
@@ -93,10 +95,11 @@ namespace GitHub.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            if (PersonalAccessTokenStore.ReadCredentials(targetUri) != null)
+            var normalizedTargetUri = NormalizeUri(targetUri);
+            if (PersonalAccessTokenStore.ReadCredentials(normalizedTargetUri) != null)
             {
-                PersonalAccessTokenStore.DeleteCredentials(targetUri);
-                Git.Trace.WriteLine($"credentials for '{targetUri}' deleted");
+                PersonalAccessTokenStore.DeleteCredentials(normalizedTargetUri);
+                Git.Trace.WriteLine($"credentials for '{normalizedTargetUri}' deleted");
             }
         }
 
@@ -120,8 +123,6 @@ namespace GitHub.Authentication
             AcquireAuthenticationCodeDelegate acquireAuthenticationCodeCallback,
             AuthenticationResultDelegate authenticationResultCallback)
         {
-            const string GitHubBaseUrlHost = "github.com";
-
             BaseAuthentication authentication = null;
 
             BaseSecureStore.ValidateTargetUri(targetUri);
@@ -130,8 +131,9 @@ namespace GitHub.Authentication
 
             if (targetUri.DnsSafeHost.EndsWith(GitHubBaseUrlHost, StringComparison.OrdinalIgnoreCase))
             {
-                authentication = new Authentication(targetUri, tokenScope, personalAccessTokenStore, acquireCredentialsCallback, acquireAuthenticationCodeCallback, authenticationResultCallback);
-                Git.Trace.WriteLine($"created GitHub authentication for '{targetUri}'.");
+                var normalizedTargetUri = NormalizeUri(targetUri);
+                authentication = new Authentication(normalizedTargetUri, tokenScope, personalAccessTokenStore, acquireCredentialsCallback, acquireAuthenticationCodeCallback, authenticationResultCallback);
+                Git.Trace.WriteLine($"created GitHub authentication for '{normalizedTargetUri}'.");
             }
             else
             {
@@ -158,9 +160,10 @@ namespace GitHub.Authentication
 
             Credential credentials = null;
 
-            if ((credentials = PersonalAccessTokenStore.ReadCredentials(targetUri)) != null)
+            var normalizedTargetUri = NormalizeUri(targetUri);
+            if ((credentials = PersonalAccessTokenStore.ReadCredentials(normalizedTargetUri)) != null)
             {
-                Git.Trace.WriteLine($"credentials for '{targetUri}' found.");
+                Git.Trace.WriteLine($"credentials for '{normalizedTargetUri}' found.");
             }
 
             return credentials;
@@ -181,19 +184,20 @@ namespace GitHub.Authentication
             string username;
             string password;
 
-            if (AcquireCredentialsCallback(targetUri, out username, out password))
+            var normalizedTargetUri = NormalizeUri(targetUri);
+            if (AcquireCredentialsCallback(normalizedTargetUri, out username, out password))
             {
                 AuthenticationResult result;
 
-                if (result = await Authority.AcquireToken(targetUri, username, password, null, TokenScope))
+                if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, null, TokenScope))
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
+                    Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded");
 
                     credentials = (Credential)result.Token;
-                    PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
+                    PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
 
                     // if a result callback was registered, call it
-                    AuthenticationResultCallback?.Invoke(targetUri, result);
+                    AuthenticationResultCallback?.Invoke(normalizedTargetUri, result);
 
                     return credentials;
                 }
@@ -201,17 +205,17 @@ namespace GitHub.Authentication
                         || result == GitHubAuthenticationResultType.TwoFactorSms)
                 {
                     string authenticationCode;
-                    if (AcquireAuthenticationCodeCallback(targetUri, result, username, out authenticationCode))
+                    if (AcquireAuthenticationCodeCallback(normalizedTargetUri, result, username, out authenticationCode))
                     {
-                        if (result = await Authority.AcquireToken(targetUri, username, password, authenticationCode, TokenScope))
+                        if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, authenticationCode, TokenScope))
                         {
-                            Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
+                            Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
 
                             credentials = (Credential)result.Token;
-                            PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
+                            PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
 
                             // if a result callback was registered, call it
-                            AuthenticationResultCallback?.Invoke(targetUri, result);
+                            AuthenticationResultCallback?.Invoke(normalizedTargetUri, result);
 
                             return credentials;
                         }
@@ -221,11 +225,11 @@ namespace GitHub.Authentication
                 // if a result callback was registered, call it
                 if (AuthenticationResultCallback != null)
                 {
-                    AuthenticationResultCallback(targetUri, result);
+                    AuthenticationResultCallback(normalizedTargetUri, result);
                 }
             }
 
-            Git.Trace.WriteLine($"interactive logon for '{targetUri}' failed.");
+            Git.Trace.WriteLine($"interactive logon for '{normalizedTargetUri}' failed.");
             return credentials;
         }
 
@@ -251,19 +255,19 @@ namespace GitHub.Authentication
                 throw new ArgumentNullException("username", "The `password` parameter is null or invalid.");
 
             Credential credentials = null;
-
+            var normalizedTargetUri = NormalizeUri(targetUri);
             AuthenticationResult result;
-            if (result = await Authority.AcquireToken(targetUri, username, password, authenticationCode, TokenScope))
+            if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, authenticationCode, TokenScope))
             {
-                Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
+                Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
 
                 credentials = (Credential)result.Token;
-                PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
+                PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
 
                 return credentials;
             }
 
-            Git.Trace.WriteLine($"non-interactive logon for '{targetUri}' failed.");
+            Git.Trace.WriteLine($"non-interactive logon for '{normalizedTargetUri}' failed.");
             return credentials;
         }
 
@@ -282,7 +286,7 @@ namespace GitHub.Authentication
             BaseSecureStore.ValidateTargetUri(targetUri);
             BaseSecureStore.ValidateCredential(credentials);
 
-            PersonalAccessTokenStore.WriteCredentials(targetUri, credentials);
+            PersonalAccessTokenStore.WriteCredentials(NormalizeUri(targetUri), credentials);
         }
 
         /// <summary>
@@ -336,5 +340,15 @@ namespace GitHub.Authentication
         /// </param>
         /// <param name="result">The result of the interactive authentication attempt.</param>
         public delegate void AuthenticationResultDelegate(TargetUri targetUri, GitHubAuthenticationResultType result);
+
+        static Uri NormalizeUri(Uri targetUri)
+        {
+            // Special case for gist.github.com which are git backed repositories under the hood.
+            // Credentials for these repos are the same as the one stored with "github.com"
+            if (targetUri.DnsSafeHost.StartsWith("gist.", StringComparison.OrdinalIgnoreCase) && targetUri.DnsSafeHost.EndsWith(".github.com", StringComparison.OrdinalIgnoreCase))
+                return new Uri("https://" + GitHubBaseUrlHost);
+
+            return targetUri;
+        }
     }
 }


### PR DESCRIPTION
Gists are backed by git repositories hosted on GitHub.com, but the host name for these repos are "gist.github.com" and not "github.com".

This confuses the GCM as it tries to retrieve credentials for gist.github.com in this case. This change normalizes such URLs so that any operation against "gist.github.com" goes against "github.com".

This is special cased against gist.github.com rather than global because you never know if GitHub might use subdomains for other purposes in the future.

Fixes #495