### PR TITLE
Allow personal access tokens

### DIFF
--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -57,22 +57,16 @@ namespace GitHub.Authentication
             AcquireAuthenticationCodeDelegate acquireAuthenticationCodeCallback,
             AuthenticationResultDelegate authenticationResultCallback)
         {
-            if (tokenScope == null)
-                throw new ArgumentNullException("tokenScope", "The parameter `tokenScope` is null or invalid.");
-            if (personalAccessTokenStore == null)
-                throw new ArgumentNullException("personalAccessTokenStore", "The parameter `personalAccessTokenStore` is null or invalid.");
-            if (acquireCredentialsCallback == null)
-                throw new ArgumentNullException("acquireCredentialsCallback", "The parameter `acquireCredentialsCallback` is null or invalid.");
-            if (acquireAuthenticationCodeCallback == null)
-                throw new ArgumentNullException("acquireAuthenticationCodeCallback", "The parameter `acquireAuthenticationCodeCallback` is null or invalid.");
+            TokenScope = tokenScope
+                ?? throw new ArgumentNullException("tokenScope", "The parameter `tokenScope` is null or invalid.");
+            PersonalAccessTokenStore = personalAccessTokenStore
+                ?? throw new ArgumentNullException("personalAccessTokenStore", "The parameter `personalAccessTokenStore` is null or invalid.");
+            AcquireCredentialsCallback = acquireCredentialsCallback
+                ?? throw new ArgumentNullException("acquireCredentialsCallback", "The parameter `acquireCredentialsCallback` is null or invalid.");
+            AcquireAuthenticationCodeCallback = acquireAuthenticationCodeCallback
+                ?? throw new ArgumentNullException("acquireAuthenticationCodeCallback", "The parameter `acquireAuthenticationCodeCallback` is null or invalid.");
 
-            TokenScope = tokenScope;
-
-            PersonalAccessTokenStore = personalAccessTokenStore;
             Authority = new Authority(NormalizeUri(targetUri));
-
-            AcquireCredentialsCallback = acquireCredentialsCallback;
-            AcquireAuthenticationCodeCallback = acquireAuthenticationCodeCallback;
             AuthenticationResultCallback = authenticationResultCallback;
         }
 
@@ -224,11 +218,7 @@ namespace GitHub.Authentication
                     }
                 }
 
-                // if a result callback was registered, call it
-                if (AuthenticationResultCallback != null)
-                {
-                    AuthenticationResultCallback(normalizedTargetUri, result);
-                }
+                AuthenticationResultCallback?.Invoke(normalizedTargetUri, result);
             }
 
             Git.Trace.WriteLine($"interactive logon for '{normalizedTargetUri}' failed.");

--- a/GitHub.Authentication/Authority.cs
+++ b/GitHub.Authentication/Authority.cs
@@ -50,7 +50,7 @@ namespace GitHub.Authentication
         public Authority(TargetUri targetUri)
         {
             // The GitHub proper API endpoints
-            if (targetUri.Host == "github.com")
+            if (targetUri.DnsSafeHost.Equals("github.com", StringComparison.OrdinalIgnoreCase))
             {
                 _authorityUrl = "https://api.github.com/authorizations";
                 _validationUrl = "https://api.github.com/user/subscriptions";

--- a/GitHub.Authentication/TokenScope.cs
+++ b/GitHub.Authentication/TokenScope.cs
@@ -169,54 +169,54 @@ namespace GitHub.Authentication
         }
 
         public override bool Equals(object obj)
-            => Microsoft.Alm.Authentication.TokenScope.Equals(this as Microsoft.Alm.Authentication.TokenScope, obj);
+            => Equals(this as Microsoft.Alm.Authentication.TokenScope, obj);
 
         public bool Equals(TokenScope other)
-            => Microsoft.Alm.Authentication.TokenScope.Equals(this as Microsoft.Alm.Authentication.TokenScope, other as Microsoft.Alm.Authentication.TokenScope);
+            => Equals(this as Microsoft.Alm.Authentication.TokenScope, other as Microsoft.Alm.Authentication.TokenScope);
 
         public override int GetHashCode()
-            => Microsoft.Alm.Authentication.TokenScope.GetHashCode(this as Microsoft.Alm.Authentication.TokenScope);
+            => GetHashCode(this as Microsoft.Alm.Authentication.TokenScope);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(TokenScope left, TokenScope right)
-            => Microsoft.Alm.Authentication.TokenScope.Equals(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
+            => Equals(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(TokenScope left, TokenScope right)
-            => !Microsoft.Alm.Authentication.TokenScope.Equals(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
+            => !Equals(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TokenScope operator +(TokenScope left, TokenScope right)
         {
-            var set = Microsoft.Alm.Authentication.TokenScope.UnionWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
+            var set = UnionWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
             return new TokenScope(set);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TokenScope operator -(TokenScope left, TokenScope right)
         {
-            var set = Microsoft.Alm.Authentication.TokenScope.ExceptWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
+            var set = ExceptWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
             return new TokenScope(set);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TokenScope operator |(TokenScope left, TokenScope right)
         {
-            var set = Microsoft.Alm.Authentication.TokenScope.UnionWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
+            var set = UnionWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
             return new TokenScope(set);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TokenScope operator &(TokenScope left, TokenScope right)
         {
-            var set = Microsoft.Alm.Authentication.TokenScope.IntersectWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
+            var set = IntersectWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
             return new TokenScope(set);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TokenScope operator ^(TokenScope left, TokenScope right)
         {
-            var set = Microsoft.Alm.Authentication.TokenScope.SymmetricExceptWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
+            var set = SymmetricExceptWith(left as Microsoft.Alm.Authentication.TokenScope, right as Microsoft.Alm.Authentication.TokenScope);
             return new TokenScope(set);
         }
     }


### PR DESCRIPTION
Prior to this fix, if a user supplies an OAuth Personal Access Token (PAT) instead of a password, the GCM would reject it.

This is because the GCM called an API that only allows basic authentication. So even though the token was valid, the response code returned back was `HTTP 403 Forbidden`. However, if an invalid password or Oauth token is supplied, the API returns an `HTTP 401 Unauthorized`. 

This code takes advantage of that behavior to go ahead and store the user supplied token only when the response is 403 Forbidden and we check the content to make sure it's forbidden for the reason we think it is.

Fixes #496