### PR TITLE
Add TLS 1.2 as an available protocol ahead of TLS 1.0 retirement

### DIFF
--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
@@ -67,6 +68,8 @@ namespace Microsoft.Alm.Cli
                     : new Github.Authentication.AcquireAuthenticationCodeDelegate(program.GitHubAuthCodePrompt);
 
             NtlmSupport basicNtlmSupport = NtlmSupport.Auto;
+
+            ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
 
             switch (operationArguments.Authority)
             {


### PR DESCRIPTION
The industry is in the process of upgrading to TLS 1.2 following [announcements](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls) from Payment Card Industry (PCI) that certification would no longer be accepted for solutions using TLS 1.0 after June 2018.

Because GCM targets less than .NET 4.7 (for broad client compatibility), it does not use TLS 1.2 by default. This change adds it as an enabled protocol, so that it can be used where supported.

Tested on Win 10 1709 and Windows 7 SP1 with only .NET4.5.1 installed, against VSTS
