### PR TITLE
Fix ArgumentNullException in askpass when username is not set in prompt URL

### DIFF
--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Alm.Cli
                         Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
                         OperationArguments operationArguments = new OperationArguments.Impl(targetUri);
-                        operationArguments.SetCredentials(username, password);
+                        operationArguments.SetCredentials(username ?? string.Empty, password ?? string.Empty);
 
                         // load up the operation arguments, enable tracing, and query for credentials
                         LoadOperationArguments(operationArguments);

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -151,6 +151,10 @@ namespace Microsoft.Alm.Cli
                 string seeking = match.Groups[1].Value;
                 string targetUrl = match.Groups[2].Value;
 
+                string username = string.Empty;
+                string password = string.Empty;
+                Uri targetUri = null;
+
                 // Since we're looking for HTTP(s) credentials, we can use NetFx `Uri` class.
                 if (Uri.TryCreate(targetUrl, UriKind.Absolute, out Uri targetUri))
                 {

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -156,11 +156,11 @@ namespace Microsoft.Alm.Cli
                 Uri targetUri = null;
 
                 // Since we're looking for HTTP(s) credentials, we can use NetFx `Uri` class.
-                if (Uri.TryCreate(targetUrl, UriKind.Absolute, out Uri targetUri))
+                if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                 {
                     Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
-                    if (TryParseUrlCredentials(targetUrl, out string username, out string password))
+                    if (TryParseUrlCredentials(targetUrl, out username, out password))
                     {
                         if (password != null
                             && seeking.Equals("Password", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Fix #518.