### PR TITLE
Re-enable tests in automation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,6 @@ before_build:
 build_script:
   - msbuild "GitCredentialManager.sln" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /consoleloggerparameters:Verbosity=normal /nodeReuse:false /target:"Build" /property:Configuration="%configuration%";Platform="%platform%"
 
-test:
-  assemblies:
-    - '*.Test\bin\$(configuration)\*.Test.dll'
-
 cache:
   - packages -> **\packages.config
 


### PR DESCRIPTION
Move test properties from test.props into *.Test.csproj files, so that automation detects the test assemblies correctly.