### PR TITLE
cli-manager: add dump variables verb.

### DIFF
--- a/Cli-CredentialHelper.Test/ProgramTests.cs
+++ b/Cli-CredentialHelper.Test/ProgramTests.cs
@@ -35,11 +35,12 @@ namespace Microsoft.Alm.Cli.Test
         [Fact]
         public void LoadOperationArgumentsTest()
         {
-            var program = new Program();
-
-            program._dieException = (Program caller, Exception e, string path, int line, string name) => Assert.False(true, $"Error: {e.ToString()}");
-            program._dieMessage = (Program caller, string m, string path, int line, string name) => Assert.False(true, $"Error: {m}");
-            program._exit = (Program caller, int e, string m, string path, int line, string name) => Assert.False(true, $"Error: {e} {m}");
+            var program = new Program
+            {
+                _dieException = (Program caller, Exception e, string path, int line, string name) => Assert.False(true, $"Error: {e.ToString()}"),
+                _dieMessage = (Program caller, string m, string path, int line, string name) => Assert.False(true, $"Error: {m}"),
+                _exit = (Program caller, int e, string m, string path, int line, string name) => Assert.False(true, $"Error: {e} {m}")
+            };
 
             var configs = new Dictionary<Git.ConfigurationLevel, Dictionary<string, string>>
             {

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -201,13 +201,13 @@ namespace Microsoft.Alm.Cli
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
                     Git.Trace.WriteLine($"deleting VSTS credentials for '{operationArguments.TargetUri}'.");
-                    BaseVstsAuthentication vstsAuth = authentication as BaseVstsAuthentication;
+                    var vstsAuth = authentication as BaseVstsAuthentication;
                     vstsAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
                 case AuthorityType.GitHub:
                     Git.Trace.WriteLine($"deleting GitHub credentials for '{operationArguments.TargetUri}'.");
-                    Github.Authentication ghAuth = authentication as Github.Authentication;
+                    var ghAuth = authentication as Github.Authentication;
                     ghAuth.DeleteCredentials(operationArguments.TargetUri);
                     break;
 
@@ -307,7 +307,7 @@ namespace Microsoft.Alm.Cli
 
             string logFileName = Path.Combine(logFilePath, Path.ChangeExtension(Program.ConfigPrefix, ".log"));
 
-            FileInfo logFileInfo = new FileInfo(logFileName);
+            var logFileInfo = new FileInfo(logFileName);
             if (logFileInfo.Exists && logFileInfo.Length > LogFileMaxLength)
             {
                 for (int i = 1; i < int.MaxValue; i++)
@@ -591,7 +591,7 @@ namespace Microsoft.Alm.Cli
                 default:
                 case AuthorityType.Basic:
                     {
-                        BasicAuthentication basicAuth = authentication as BasicAuthentication;
+                        var basicAuth = authentication as BasicAuthentication;
 
                         Task.Run(async () =>
                         {
@@ -616,8 +616,8 @@ namespace Microsoft.Alm.Cli
 
                 case AuthorityType.AzureDirectory:
                     {
-                        VstsAadAuthentication aadAuth = authentication as VstsAadAuthentication;
-                        PersonalAccessTokenOptions patOptions = new PersonalAccessTokenOptions()
+                        var aadAuth = authentication as VstsAadAuthentication;
+                        var patOptions = new PersonalAccessTokenOptions()
                         {
                             RequireCompactToken = true,
                             TokenDuration = operationArguments.TokenDuration,
@@ -655,8 +655,8 @@ namespace Microsoft.Alm.Cli
 
                 case AuthorityType.MicrosoftAccount:
                     {
-                        VstsMsaAuthentication msaAuth = authentication as VstsMsaAuthentication;
-                        PersonalAccessTokenOptions patOptions = new PersonalAccessTokenOptions()
+                        var msaAuth = authentication as VstsMsaAuthentication;
+                        var patOptions = new PersonalAccessTokenOptions()
                         {
                             RequireCompactToken = true,
                             TokenDuration = operationArguments.TokenDuration,
@@ -690,7 +690,7 @@ namespace Microsoft.Alm.Cli
 
                 case AuthorityType.GitHub:
                     {
-                        Github.Authentication ghAuth = authentication as Github.Authentication;
+                        var ghAuth = authentication as Github.Authentication;
 
                         Task.Run(async () =>
                         {
@@ -765,7 +765,7 @@ namespace Microsoft.Alm.Cli
 
         public static bool TryReadBoolean(Program program, OperationArguments operationArguments, string configKey, string environKey, out bool? value)
         {
-            if (ReferenceEquals(operationArguments, null))
+            if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
             var envars = operationArguments.EnvironmentVariables;
@@ -825,7 +825,7 @@ namespace Microsoft.Alm.Cli
 
         public static bool TryReadString(Program program, OperationArguments operationArguments, string configKey, string environKey, out string value)
         {
-            if (ReferenceEquals(operationArguments, null))
+            if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
             var envars = operationArguments.EnvironmentVariables;
@@ -840,7 +840,7 @@ namespace Microsoft.Alm.Cli
                 return true;
             }
 
-            var config = operationArguments.GitConfiguration;
+            Configuration config = operationArguments.GitConfiguration;
 
             // Look for an entry in the git config.
             Configuration.Entry entry;

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -208,10 +208,10 @@ namespace Microsoft.Alm.Cli
                 {
                     read += r;
 
-                    // if we've filled the buffer, make it larger this could hit an out of memory
+                    // If we've filled the buffer, make it larger this could hit an out of memory
                     // condition, but that'd require the called to be attempting to do so, since
-                    // that's not a secyity threat we can safely ignore that and allow NetFx to
-                    // handle it
+                    // that's not a security threat we can safely ignore that and allow NetFx to
+                    // handle it.
                     if (read == buffer.Length)
                     {
                         Array.Resize(ref buffer, buffer.Length * 2);
@@ -222,8 +222,8 @@ namespace Microsoft.Alm.Cli
                         throw new InvalidDataException("Invalid input, please see 'https://www.kernel.org/pub/software/scm/git/docs/git-credential.html'.");
                     }
 
-                    // the input ends with LFLF, check for that and break the read loop unless
-                    // input is coming from CLRF system, in which case it'll be CLRFCLRF
+                    // The input ends with LFLF, check for that and break the read loop unless
+                    // input is coming from CLRF system, in which case it'll be CLRFCLRF.
                     if ((buffer[read - 2] == '\n'
                             && buffer[read - 1] == '\n')
                         || (buffer[read - 4] == '\r'
@@ -234,10 +234,10 @@ namespace Microsoft.Alm.Cli
                 }
 
                 // Git uses UTF-8 for string, don't let the OS decide how to decode it instead
-                // we'll actively decode the UTF-8 block ourselves
+                // we'll actively decode the UTF-8 block ourselves.
                 string input = Encoding.UTF8.GetString(buffer, 0, read);
 
-                // the `StringReader` is just useful
+                // The `StringReader` is just useful.
                 using (StringReader reader = new StringReader(input))
                 {
                     string line;


### PR DESCRIPTION
Adds a new verb ("config") which instructs the git-credential-manager to dump all variables to the console. Including environment variables, Git configuration, and GCM specific values.

This will help with gathering debugging information.