### PR TITLE
Use Nuget Command Line nupkg

### DIFF
--- a/Cli-CredentialHelper/Cli-CredentialHelper.csproj
+++ b/Cli-CredentialHelper/Cli-CredentialHelper.csproj
@@ -67,7 +67,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\Cli-Shared\Cli-Shared.projitems" Label="Shared" />
   <Import Project="..\build.targets" />
-  <Target Name="AfterBuild"><Message Text="BinariesDirectory = $(BinariesDirectory)" /></Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/Cli-CredentialHelper/packages.config
+++ b/Cli-CredentialHelper/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Net.Compilers" version="2.4.0" targetFramework="net452" developmentDependency="true" />
-  <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net452" developmentDependency="true" />
   <package id="Pandoc.Windows" version="2.1.0" developmentDependency="true" />
   <package id="Tools.InnoSetup" version="5.5.9" targetFramework="net452" />
   <package id="Tools.InnoSetup.Download" version="1.5.1" targetFramework="net452" />

--- a/Microsoft.Vsts.Authentication/Microsoft.Vsts.Authentication.csproj
+++ b/Microsoft.Vsts.Authentication/Microsoft.Vsts.Authentication.csproj
@@ -73,7 +73,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\build.targets" />
   <Target Name="BuildNupkg" AfterTargets="CopyFilesToOutputDirectory;SignFiles">
-    <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
     <!-- Read the nupkg meta data from the AssemblyInfo.cs file copied from Microsoft.Vsts.Authentication -->
     <PropertyGroup>
       <In>$([System.IO.File]::ReadAllText('$(ProjectDir)\Properties\AssemblyInfo.cs'))</In>
@@ -98,9 +97,8 @@
       <NugetWorkDir>$(OutputPath.TrimEnd('\'))</NugetWorkDir>
     </PropertyGroup>
     <PropertyGroup Condition="!Exists($(NugetPath))">
-      <NugetPath>$(IntermediateOutputPath)nuget.exe</NugetPath>
+      <NugetPath>..\packages\NuGet.CommandLine.4.4.1\tools\NuGet.exe</NugetPath>
     </PropertyGroup>
-    <WebDownload Condition="!Exists($(NugetPath))" Filename="$(NugetPath)" FileUri="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" />
     <Exec Command="&quot;$(NugetPath)&quot; pack &quot;$(ProjectDir)\Microsoft.Alm.Authentication.nuspec&quot; -BasePath &quot;$(NugetWorkDir)&quot; -IncludeReferencedProjects -Properties Configuration=&quot;$(Configuration)&quot;;Version=&quot;$(AssemblyVersion)$(IsSigned)&quot;;Id=&quot;Microsoft.Alm.Authentication&quot;;Title=&quot;$(AssemblyTitle)&quot;;Owners=&quot;$(AssemblyCompany)&quot;;Copyright=&quot;$(AssemblyCopyright)&quot;;Description=&quot;$(AssemblyDescription)&quot; -OutputDirectory &quot;$(NugetWorkDir)&quot;" />
     <Exec Command="&quot;$(NugetPath)&quot; pack &quot;$(ProjectDir)\Microsoft.Alm.Authentication.symbols.nuspec&quot; -BasePath &quot;$(NugetWorkDir)&quot; -IncludeReferencedProjects -Properties Configuration=&quot;$(Configuration)&quot;;Version=&quot;$(AssemblyVersion)$(IsSigned)&quot;;Id=&quot;Microsoft.Alm.Authentication.symbols&quot;;Title=&quot;$(AssemblyTitle)&quot;;Owners=&quot;$(AssemblyCompany)&quot;;Copyright=&quot;$(AssemblyCopyright)&quot;;Description=&quot;$(AssemblyDescription)&quot; -OutputDirectory &quot;$(NugetWorkDir)&quot;" />
   </Target>
@@ -117,6 +115,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.4.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.4.0\build\Microsoft.Net.Compilers.props'))" />
     <Error Condition="!Exists('..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\NuGet.CommandLine.4.4.1\tools\NuGet.exe')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGet.CommandLine.4.4.1\tools\NuGet.exe'))" />
   </Target>
   <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
   <Import Project="..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />

--- a/Microsoft.Vsts.Authentication/packages.config
+++ b/Microsoft.Vsts.Authentication/packages.config
@@ -3,4 +3,5 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net451" developmentDependency="true" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net451" />
   <package id="Microsoft.Net.Compilers" version="2.4.0" targetFramework="net451" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="4.4.1" targetFramework="net451" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Instead of relying on MSbuildTools nupkg to download nuget.exe and then create the Microsoft.Alm.Authentication.nupkg output, add a dependency on Nuget.CommandLine nupkg to create it directly.