### PR TITLE
Does not support the Git Proxy with default credentials "http://:@myproxy.com:8080"

### DIFF
--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -205,31 +205,27 @@ namespace Microsoft.Alm.Authentication
             {
                 if (ProxyUri != null)
                 {
-                    WebProxy proxy = new WebProxy(ProxyUri);
-
-                    int tokenIndex = ProxyUri.UserInfo.IndexOf(':');
-                    bool hasUserNameAndPassword = tokenIndex != -1;
-                    bool hasAuthenticationSpecified = !string.IsNullOrWhiteSpace(ProxyUri.UserInfo);
+                    WebProxy proxy = new WebProxy(ProxyUri) { UseDefaultCredentials = true };
 
                     // check if the user has specified authentications (comes as UserInfo)
-                    if (hasAuthenticationSpecified && hasUserNameAndPassword)
+                    if (!string.IsNullOrWhiteSpace(ProxyUri.UserInfo) && ProxyUri.UserInfo.Length > 1)
                     {
-                        string userName = ProxyUri.UserInfo.Substring(0, tokenIndex);
-                        string password = ProxyUri.UserInfo.Substring(tokenIndex + 1);
+                        int tokenIndex = ProxyUri.UserInfo.IndexOf(':');
+                        bool hasUserNameAndPassword = tokenIndex != -1;
 
-                        NetworkCredential proxyCreds = new NetworkCredential(
-                            userName,
-                            password
-                        );
+                        if (hasUserNameAndPassword)
+                        {
+                            string userName = ProxyUri.UserInfo.Substring(0, tokenIndex);
+                            string password = ProxyUri.UserInfo.Substring(tokenIndex + 1);
 
-                        proxy.UseDefaultCredentials = false;
-                        proxy.Credentials = proxyCreds;
-                    }
-                    else
-                    {
-                        // if no explicit proxy authentication, set to use default (Credentials will
-                        // be set to DefaultCredentials automatically)
-                        proxy.UseDefaultCredentials = true;
+                            NetworkCredential proxyCreds = new NetworkCredential(
+                                userName,
+                                password
+                            );
+
+                            proxy.UseDefaultCredentials = false;
+                            proxy.Credentials = proxyCreds;
+                        }
                     }
 
                     return proxy;


### PR DESCRIPTION
So we are getting an error when we set the git http.proxy to be our proxy server with git's notation of using default credentials.

Error is:
[GeneratePersonalAccessToken] ! an error occurred: An error occurred while sending the request.

After debugging the code and seeing how bad the HttpHandler and WebProxy code is we discovered that the code is treating ":@" in the proxy to mean it has an empty string username and password. Git says you need this notation to tell it to use the default credentials instead.