### PR TITLE
cli-shared: Support `HTTP_PROXY` envronment variables.

### DIFF
--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -486,9 +486,19 @@ namespace Microsoft.Alm.Cli
 
                 operationArguments.SetProxy(value);
             }
+            // Check environment variables just-in-case.
+            else if ((operationArguments.EnvironmentVariables.TryGetValue(Program.EnvironGitHttpsProxyKey, out value)
+                    && !string.IsNullOrWhiteSpace(value))
+                || (operationArguments.EnvironmentVariables.TryGetValue(Program.EnvironGitHttpProxyKey, out value)
+                    && !string.IsNullOrWhiteSpace(value)))
+            {
+                Git.Trace.WriteLine($"http.proxy = '{value}'.");
+
+                operationArguments.SetProxy(value);
+            }
+            // Check the git-config http.proxy setting just-in-case.
             else
             {
-                // Check the git-config http.proxy setting just-in-case.
                 Configuration.Entry entry;
                 if (operationArguments.GitConfiguration.TryGetEntry("http", operationArguments.QueryUri, "proxy", out entry)
                     && !string.IsNullOrWhiteSpace(entry.Value))

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -67,6 +67,8 @@ namespace Microsoft.Alm.Cli
         internal const string EnvironPreserveCredentialsKey = "GCM_PRESERVE_CREDS";
         internal const string EnvironValidateKey = "GCM_VALIDATE";
         internal const string EnvironWritelogKey = "GCM_WRITELOG";
+        internal const string EnvironGitHttpProxyKey = "HTTP_PROXY";
+        internal const string EnvironGitHttpsProxyKey = "HTTPS_PROXY";
 
         internal const string EnvironConfigTraceKey = Git.Trace.EnvironmentVariableKey;
 


### PR DESCRIPTION
Add a check for `HTTP_PROXY` and `HTTPS_PROXY` when loading operation arguments. Use of these environment variables is a comon enough way to inform Git of proxies that the GCM ought to suppor them.

Resolves #506