### PR TITLE
 Ms.Vsts.Auth: Improve credential deletion logic.

### DIFF
--- a/Microsoft.Vsts.Authentication.Test/AuthorityFake.cs
+++ b/Microsoft.Vsts.Authentication.Test/AuthorityFake.cs
@@ -9,9 +9,13 @@ namespace Microsoft.Alm.Authentication.Test
         public AuthorityFake(string expectedQueryParameters)
         {
             ExpectedQueryParameters = expectedQueryParameters;
+
+            CredentialsAreValid = true;
         }
 
         internal readonly string ExpectedQueryParameters;
+
+        public bool CredentialsAreValid { get; set; }
 
         /// <summary>
         /// Generates a personal access token for use with Visual Studio Team Services.
@@ -77,7 +81,7 @@ namespace Microsoft.Alm.Authentication.Test
                 try
                 {
                     BaseSecureStore.ValidateCredential(credentials);
-                    return true;
+                    return CredentialsAreValid;
                 }
                 catch { }
                 return false;

--- a/Microsoft.Vsts.Authentication.Test/VstsAadTests.cs
+++ b/Microsoft.Vsts.Authentication.Test/VstsAadTests.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Alm.Authentication.Test
             TargetUri targetUri = DefaultTargetUri;
             VstsAadAuthentication aadAuthentication = GetVstsAadAuthentication("aad-delete");
 
+            if (aadAuthentication.VstsAuthority is AuthorityFake fake)
+            {
+                fake.CredentialsAreValid = false;
+            }
+
             aadAuthentication.PersonalAccessTokenStore.WriteCredentials(targetUri, DefaultPersonalAccessToken);
 
             aadAuthentication.DeleteCredentials(targetUri);

--- a/Microsoft.Vsts.Authentication.Test/VstsMsaTests.cs
+++ b/Microsoft.Vsts.Authentication.Test/VstsMsaTests.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Alm.Authentication.Test
             TargetUri targetUri = DefaultTargetUri;
             VstsMsaAuthentication msaAuthority = GetVstsMsaAuthentication("msa-delete");
 
+            if (msaAuthority.VstsAuthority is AuthorityFake fake)
+            {
+                fake.CredentialsAreValid = false;
+            }
+
             msaAuthority.PersonalAccessTokenStore.WriteCredentials(targetUri, DefaultPersonalAccessToken);
 
             msaAuthority.DeleteCredentials(targetUri);


### PR DESCRIPTION
When Git asks for a VSTS PAT to be erased, it is not always because the credentials are actually invalid. Often it is due to network issues (flakiness, WI-FI disconnected, etc.). Therefore is better to validate that the credentials have gone invalid before deleting them.

Validation before deletion is a good idea for the reason that authentication is often a laborious task; often requiring multi-factor steps such as answering a phone or getting a code from email. A flaky network should not cause a user to waste so much time re-authenticating.

When credentials are invalidated, there's no good way to know if it is because they have expired or another reason. A recently common reason is accounts migrating between Azure tenants. When this happens the tenant cache become a nuance because the user cannot authenticate correctly because the cause points them at the wrong authority.

Therefore, when credentials are purged the related authority ought to be as well.