### PR TITLE
cli-shared: Add VSTS Token Scope Support

### DIFF
--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Alm.Cli
                     {
                         Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
-                        OperationArguments operationArguments = new OperationArguments.Impl(targetUri);
+                        OperationArguments operationArguments = new OperationArguments(targetUri);
                         operationArguments.SetCredentials(username ?? string.Empty, password ?? string.Empty);
 
                         // load up the operation arguments, enable tracing, and query for credentials

--- a/Cli-CredentialHelper.Test/Cli-CredentialHelper.Test.csproj
+++ b/Cli-CredentialHelper.Test/Cli-CredentialHelper.Test.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Microsoft.Alm.CredentialHelper.Test</RootNamespace>
     <AssemblyName>Microsoft.Alm.CredentialHelper.Test</AssemblyName>
     <IsCodedUITest>False</IsCodedUITest>
-    <NuGetPackageImportStamp/>
+    <NuGetPackageImportStamp />
   </PropertyGroup>
   <Import Project="..\test.props" />
   <ItemGroup>
@@ -46,6 +46,10 @@
     <ProjectReference Include="..\Microsoft.Alm.Git\Microsoft.Alm.Git.csproj">
       <Project>{19770407-5c58-406d-ab3f-3700bb0d06fe}</Project>
       <Name>Microsoft.Alm.Git</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.Vsts.Authentication\Microsoft.Vsts.Authentication.csproj">
+      <Project>{19770407-d7d8-4a37-914c-f552ff4b90d4}</Project>
+      <Name>Microsoft.Vsts.Authentication</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                cut = new OperationArguments.Impl(memory);
+                cut = new OperationArguments(memory);
             }
 
             Assert.Equal("https", cut.QueryProtocol);
@@ -60,7 +60,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                cut = new OperationArguments.Impl(memory);
+                cut = new OperationArguments(memory);
             }
 
             Assert.Equal("https", cut.QueryProtocol);
@@ -201,7 +201,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                var oparg = new OperationArguments.Impl(memory);
+                var oparg = new OperationArguments(memory);
 
                 Assert.NotNull(oparg);
                 Assert.Equal(input.Protocol ?? string.Empty, oparg.QueryProtocol);
@@ -228,7 +228,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                var oparg = new OperationArguments.Impl(memory);
+                var oparg = new OperationArguments(memory);
                 oparg.UseHttpPath = false;
 
                 Assert.NotNull(oparg);
@@ -256,7 +256,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                var oparg = new OperationArguments.Impl(memory);
+                var oparg = new OperationArguments(memory);
                 oparg.UseHttpPath = true;
 
                 Assert.NotNull(oparg);

--- a/Cli-CredentialHelper.Test/ProgramTests.cs
+++ b/Cli-CredentialHelper.Test/ProgramTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Alm.Cli.Test
                     new Dictionary<string, string>(Program.ConfigKeyComparer)
                     {
                         { "credential.validate", "false" },
+                        { "credential.vstsScope", "vso.build,vso.code_write" },
                     }
                 },
                 {
@@ -81,16 +82,17 @@ namespace Microsoft.Alm.Cli.Test
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();
-            opargsMock.Setup(r => r.EnvironmentVariables)
+            opargsMock.Setup(o => o.EnvironmentVariables)
                       .Returns(envvars);
-            opargsMock.Setup(r => r.GitConfiguration)
+            opargsMock.Setup(o => o.GitConfiguration)
                       .Returns(gitconfig);
-            opargsMock.Setup(r => r.TargetUri)
+            opargsMock.Setup(o => o.TargetUri)
                       .Returns(targetUri);
-            opargsMock.Setup(r => r.QueryUri)
+            opargsMock.Setup(o => o.QueryUri)
                       .Returns(targetUri);
             opargsMock.SetupProperty(o => o.UseHttpPath);
             opargsMock.SetupProperty(o => o.ValidateCredentials);
+            opargsMock.SetupProperty(o => o.VstsTokenScope);
 
             var opargs = opargsMock.Object;
 
@@ -99,6 +101,11 @@ namespace Microsoft.Alm.Cli.Test
             Assert.NotNull(opargs);
             Assert.True(opargs.ValidateCredentials, "credential.validate");
             Assert.True(opargs.UseHttpPath, "credential.useHttpPath");
+
+            Assert.NotNull(opargs.VstsTokenScope);
+
+            var expectedScope = Authentication.VstsTokenScope.BuildAccess | Authentication.VstsTokenScope.CodeWrite;
+            Assert.Equal(expectedScope, opargs.VstsTokenScope);
         }
 
         public static object[][] TryReadBooleanData
@@ -211,6 +218,100 @@ namespace Microsoft.Alm.Cli.Test
             {
                 Assert.False(CommonFunctions.TryReadBoolean(program, opargsMock.Object, key, out yesno));
                 Assert.False(yesno.HasValue);
+            }
+        }
+
+        public static object[][] TryReadStringData
+        {
+            get
+            {
+                var data = new List<object[]>();
+
+                foreach (KeyType key in Enum.GetValues(typeof(KeyType)))
+                {
+                    var value = "a value";
+                    var upper = value.ToUpper();
+
+                    data.Add(new object[] { (int)key, value, null, value });
+                    data.Add(new object[] { (int)key, null, value, value });
+
+                    if (StringComparer.Ordinal.Equals(upper, value))
+                    {
+                        data.Add(new object[] { (int)key, upper, null, upper });
+                        data.Add(new object[] { (int)key, null, upper, upper });
+                    }
+                }
+
+                return data.ToArray();
+            }
+        }
+
+        [Theory, MemberData(nameof(TryReadStringData), DisableDiscoveryEnumeration = true)]
+        public void TryReadStringTest(int keyValue, string configValue, string environValue, string expectedValue)
+        {
+            KeyType key = (KeyType)keyValue;
+
+            var program = new Program
+            {
+                _dieException = (Program caller, Exception e, string path, int line, string name) => Assert.False(true, $"Error: {e.ToString()}"),
+                _dieMessage = (Program caller, string m, string path, int line, string name) => Assert.False(true, $"Error: {m}"),
+                _exit = (Program caller, int e, string m, string path, int line, string name) => Assert.False(true, $"Error: {e} {m}")
+            };
+
+            Assert.True(program.EnvironmentKeys.ContainsKey(key));
+
+            var configs = new Dictionary<Git.ConfigurationLevel, Dictionary<string, string>>
+            {
+                { Git.ConfigurationLevel.Local,    new Dictionary<string, string>(Program.ConfigKeyComparer) },
+                { Git.ConfigurationLevel.Global,   new Dictionary<string, string>(Program.ConfigKeyComparer) },
+                { Git.ConfigurationLevel.Xdg,      new Dictionary<string, string>(Program.ConfigKeyComparer) },
+                { Git.ConfigurationLevel.System,   new Dictionary<string, string>(Program.ConfigKeyComparer) },
+                { Git.ConfigurationLevel.Portable, new Dictionary<string, string>(Program.ConfigKeyComparer) },
+            };
+            var envvars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "HOME", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
+            };
+
+            bool setupComplete = false;
+
+            if (!string.IsNullOrEmpty(configValue) && program.ConfigurationKeys.TryGetValue(key, out string configKey))
+            {
+                configs[Git.ConfigurationLevel.Local].Add($"credential.{configKey}", configValue);
+                setupComplete = true;
+            }
+
+            if (!string.IsNullOrEmpty(environValue) && program.EnvironmentKeys.TryGetValue(key, out string environKey))
+            {
+                envvars.Add(environKey, environValue);
+                setupComplete = true;
+            }
+
+            if (!setupComplete)
+                return;
+
+            var gitconfig = new Git.Configuration(configs);
+            var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
+
+            var opargsMock = new Mock<OperationArguments>();
+            opargsMock.Setup(v => v.EnvironmentVariables)
+                      .Returns(envvars);
+            opargsMock.Setup(v => v.GitConfiguration)
+                      .Returns(gitconfig);
+            opargsMock.Setup(v => v.TargetUri)
+                      .Returns(targetUri);
+            opargsMock.Setup(v => v.QueryUri)
+                      .Returns(targetUri);
+
+            if (expectedValue != null)
+            {
+                Assert.True(CommonFunctions.TryReadString(program, opargsMock.Object, key, out string actualValue));
+                Assert.Equal(expectedValue, actualValue);
+            }
+            else
+            {
+                Assert.False(CommonFunctions.TryReadString(program, opargsMock.Object, key, out string actualValue));
+                Assert.Null(actualValue);
             }
         }
     }

--- a/Cli-CredentialHelper.Test/ProgramTests.cs
+++ b/Cli-CredentialHelper.Test/ProgramTests.cs
@@ -107,10 +107,12 @@ namespace Microsoft.Alm.Cli.Test
         {
             bool? yesno;
 
+            var program = new Program();
+
             var envvars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "HOME", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
-                { Program.EnvironPreserveCredentialsKey, "no" },
+                { program.EnvironmentKeys[KeyType.PreserveCredentials], "no" },
             };
             var gitconfig = new Git.Configuration.Impl();
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
@@ -126,36 +128,35 @@ namespace Microsoft.Alm.Cli.Test
             opargsMock.Setup(v => v.QueryUri)
                       .Returns(targetUri);
 
-            var program = new Program();
 
-            Assert.False(CommonFunctions.TryReadBoolean(program, opargsMock.Object, "notFound", "notFound", out yesno));
+            Assert.False(CommonFunctions.TryReadBoolean(program, opargsMock.Object, KeyType.HttpPath, out yesno));
             Assert.False(yesno.HasValue);
 
-            Assert.True(CommonFunctions.TryReadBoolean(program, opargsMock.Object, Program.ConfigPreserveCredentialsKey, Program.EnvironPreserveCredentialsKey, out yesno));
+            Assert.True(CommonFunctions.TryReadBoolean(program, opargsMock.Object, KeyType.PreserveCredentials, out yesno));
             Assert.True(yesno.HasValue);
             Assert.False(yesno.Value);
 
             envvars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "HOME", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
-                { Program.EnvironPreserveCredentialsKey, "yes" },
+                { program.EnvironmentKeys[KeyType.PreserveCredentials], "yes" },
             };
             opargsMock.Setup(r => r.EnvironmentVariables)
                       .Returns(envvars);
 
-            Assert.True(CommonFunctions.TryReadBoolean(program, opargsMock.Object, Program.ConfigPreserveCredentialsKey, Program.EnvironPreserveCredentialsKey, out yesno));
+            Assert.True(CommonFunctions.TryReadBoolean(program, opargsMock.Object, KeyType.PreserveCredentials, out yesno));
             Assert.True(yesno.HasValue);
             Assert.True(yesno.Value);
 
             envvars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "HOME", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
-                { Program.EnvironPreserveCredentialsKey, string.Empty },
+                { program.EnvironmentKeys[KeyType.PreserveCredentials], string.Empty },
             };
             opargsMock.Setup(r => r.EnvironmentVariables)
                       .Returns(envvars);
 
-            Assert.False(CommonFunctions.TryReadBoolean(program, opargsMock.Object, Program.ConfigPreserveCredentialsKey, Program.EnvironPreserveCredentialsKey, out yesno));
+            Assert.False(CommonFunctions.TryReadBoolean(program, opargsMock.Object, KeyType.PreserveCredentials, out yesno));
             Assert.False(yesno.HasValue);
         }
     }

--- a/Cli-CredentialHelper.Test/ProgramTests.cs
+++ b/Cli-CredentialHelper.Test/ProgramTests.cs
@@ -77,21 +77,20 @@ namespace Microsoft.Alm.Cli.Test
             {
                 { "HOME", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
             };
-            var gitconfig = new Git.Configuration.Impl(configs);
+            var gitconfig = new Git.Configuration(configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
-            var opargsMock = new Mock<OperationArguments>(MockBehavior.Strict);
+            var opargsMock = new Mock<OperationArguments>();
             opargsMock.Setup(r => r.EnvironmentVariables)
                       .Returns(envvars);
             opargsMock.Setup(r => r.GitConfiguration)
                       .Returns(gitconfig);
-            opargsMock.Setup(r => r.LoadConfiguration());
             opargsMock.Setup(r => r.TargetUri)
                       .Returns(targetUri);
             opargsMock.Setup(r => r.QueryUri)
                       .Returns(targetUri);
-            opargsMock.SetupProperty(r => r.UseHttpPath);
-            opargsMock.SetupProperty(r => r.ValidateCredentials);
+            opargsMock.SetupProperty(o => o.UseHttpPath);
+            opargsMock.SetupProperty(o => o.ValidateCredentials);
 
             var opargs = opargsMock.Object;
 
@@ -190,7 +189,7 @@ namespace Microsoft.Alm.Cli.Test
             if (!setupComplete)
                 return;
 
-            var gitconfig = new Git.Configuration.Impl(configs);
+            var gitconfig = new Git.Configuration(configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();
@@ -198,7 +197,6 @@ namespace Microsoft.Alm.Cli.Test
                       .Returns(envvars);
             opargsMock.Setup(v => v.GitConfiguration)
                       .Returns(gitconfig);
-            opargsMock.Setup(v => v.LoadConfiguration());
             opargsMock.Setup(v => v.TargetUri)
                       .Returns(targetUri);
             opargsMock.Setup(v => v.QueryUri)

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Alm.Cli
             {
                 Git.Trace.WriteLine($"converted '{url}' to '{uri.AbsoluteUri}'.");
 
-                OperationArguments operationArguments = new OperationArguments.Impl(uri);
+                OperationArguments operationArguments = new OperationArguments(uri);
 
                 LoadOperationArguments(operationArguments);
                 EnableTraceLogging(operationArguments);
@@ -159,7 +159,7 @@ namespace Microsoft.Alm.Cli
             }
 
             // Create operation arguments, and load configuration data.
-            OperationArguments operationArguments = new OperationArguments.Impl(targetUri);
+            OperationArguments operationArguments = new OperationArguments(targetUri);
 
             LoadOperationArguments(operationArguments);
             EnableTraceLogging(operationArguments);
@@ -232,7 +232,7 @@ namespace Microsoft.Alm.Cli
 
             using (var stdin = Console.OpenStandardInput())
             {
-                OperationArguments operationArguments = new OperationArguments.Impl(stdin)
+                OperationArguments operationArguments = new OperationArguments(stdin)
                 {
                     QueryUri = uri
                 };
@@ -293,7 +293,7 @@ namespace Microsoft.Alm.Cli
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
             using (var stdin = Console.OpenStandardInput())
             {
-                OperationArguments operationArguments = new OperationArguments.Impl(stdin);
+                OperationArguments operationArguments = new OperationArguments(stdin);
 
                 Debug.Assert(operationArguments != null, "The operationArguments is null");
                 Debug.Assert(operationArguments.TargetUri != null, "The operationArgument.TargetUri is null");
@@ -318,7 +318,7 @@ namespace Microsoft.Alm.Cli
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
             using (var stdin = Console.OpenStandardInput())
             {
-                OperationArguments operationArguments = new OperationArguments.Impl(stdin);
+                OperationArguments operationArguments = new OperationArguments(stdin);
 
                 LoadOperationArguments(operationArguments);
                 EnableTraceLogging(operationArguments);
@@ -386,7 +386,7 @@ namespace Microsoft.Alm.Cli
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
             using (var stdin = Console.OpenStandardInput())
             {
-                OperationArguments operationArguments = new OperationArguments.Impl(stdin);
+                OperationArguments operationArguments = new OperationArguments(stdin);
 
                 Debug.Assert(operationArguments != null, "The operationArguments is null");
                 Debug.Assert(operationArguments.CredUsername != null, "The operaionArgument.Username is null");

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Alm.Cli
 
                 if (operationArguments.PreserveCredentials)
                 {
-                    Git.Trace.WriteLine($"{ConfigPreserveCredentialsKey} = true, canceling erase request.");
+                    Git.Trace.WriteLine($"{KeyTypeName(KeyType.PreserveCredentials)} = true, canceling erase request.");
                     return;
                 }
 

--- a/Cli-Shared/AuthorityType.cs
+++ b/Cli-Shared/AuthorityType.cs
@@ -31,33 +31,33 @@ namespace Microsoft.Alm.Cli
     internal enum AuthorityType
     {
         /// <summary>
-        /// Attempt to detect the authority automatically, fallback to <see cref="Basic"/> if unable
+        /// Attempt to detect the authority automatically, fallback to `<see cref="Basic"/>` if unable
         /// to detect an authority.
         /// </summary>
         Auto,
 
         /// <summary>
-        /// Basic username and password scheme
+        /// Basic username and password scheme.
         /// </summary>
         Basic,
 
         /// <summary>
-        /// Username and password scheme using Microsoft's Live system
+        /// Username and password scheme using Microsoft's Live system.
         /// </summary>
         MicrosoftAccount,
 
         /// <summary>
-        /// Azure Directory Authentication based, including support for ADFS
+        /// Azure Directory Authentication based, including support for ADFS.
         /// </summary>
         AzureDirectory,
 
         /// <summary>
-        /// GitHub authentication
+        /// GitHub authentication.
         /// </summary>
         GitHub,
 
         /// <summary>
-        /// Bitbucket authentication
+        /// Bitbucket authentication.
         /// </summary>
         Bitbucket,
 

--- a/Cli-Shared/Delegates.cs
+++ b/Cli-Shared/Delegates.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Alm.Cli
 
         internal delegate bool StandardHandleIsTtyDelegate(Program program, NativeMethods.StandardHandleType handleType);
 
-        internal delegate bool TryReadBooleanDelegate(Program program, OperationArguments operationArguments, string configKey, string environKey, out bool? value);
+        internal delegate bool TryReadBooleanDelegate(Program program, OperationArguments operationArguments, KeyType key, out bool? value);
 
-        internal delegate bool TryReadStringDelegate(Program program, OperationArguments operationArguments, string configKey, string environKey, out string value);
+        internal delegate bool TryReadStringDelegate(Program program, OperationArguments operationArguments, KeyType key, out string value);
 
         internal delegate void WriteDelegate(Program program, string message);
 

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -352,16 +352,16 @@ namespace Microsoft.Alm.Cli
             string value;
             bool? yesno;
 
-            if (program.TryReadBoolean(operationArguments, null, Program.EnvironConfigNoLocalKey, out yesno))
+            if (program.TryReadBoolean(operationArguments, KeyType.ConfigNoLocal, out yesno))
             {
-                Git.Trace.WriteLine($"{Program.EnvironConfigNoLocalKey} = '{yesno}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoLocal)} = '{yesno}'.");
 
                 operationArguments.UseConfigLocal = yesno.Value;
             }
 
-            if (program.TryReadBoolean(operationArguments, null, Program.EnvironConfigNoSystemKey, out yesno))
+            if (program.TryReadBoolean(operationArguments, KeyType.ConfigNoSystem, out yesno))
             {
-                Git.Trace.WriteLine($"{Program.EnvironConfigNoSystemKey} = '{yesno}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoSystem)} = '{yesno}'.");
 
                 operationArguments.UseConfigSystem = yesno.Value;
             }
@@ -370,17 +370,17 @@ namespace Microsoft.Alm.Cli
             operationArguments.LoadConfiguration();
 
             // If a user-agent has been specified in the environment, set it globally.
-            if (program.TryReadString(operationArguments, null, Program.EnvironHttpUserAgent, out value))
+            if (program.TryReadString(operationArguments, KeyType.HttpUserAgent, out value))
             {
-                Git.Trace.WriteLine($"{Program.EnvironHttpUserAgent} = '{value}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpUserAgent)} = '{value}'.");
 
                 Global.UserAgent = value;
             }
 
             // Look for authority settings.
-            if (program.TryReadString(operationArguments, Program.ConfigAuthorityKey, Program.EnvironAuthorityKey, out value))
+            if (program.TryReadString(operationArguments, KeyType.Authority, out value))
             {
-                Git.Trace.WriteLine($"{Program.ConfigAuthorityKey} = '{value}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Authority)} = '{value}'.");
 
                 if (Program.ConfigKeyComparer.Equals(value, "MSA")
                     || Program.ConfigKeyComparer.Equals(value, "Microsoft")
@@ -422,9 +422,9 @@ namespace Microsoft.Alm.Cli
             }
 
             // Look for interactivity config settings.
-            if (program.TryReadString(operationArguments, Program.ConfigInteractiveKey, Program.EnvironInteractiveKey, out value))
+            if (program.TryReadString(operationArguments, KeyType.Interactive, out value))
             {
-                Git.Trace.WriteLine($"{Program.EnvironInteractiveKey} = '{value}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Interactive)} = '{value}'.");
 
                 if (Program.ConfigKeyComparer.Equals(value, "always")
                     || Program.ConfigKeyComparer.Equals(value, "true")
@@ -440,59 +440,67 @@ namespace Microsoft.Alm.Cli
             }
 
             // Look for credential validation config settings.
-            if (program.TryReadBoolean(operationArguments, Program.ConfigValidateKey, Program.EnvironValidateKey, out yesno))
+            if (program.TryReadBoolean(operationArguments, KeyType.Validate, out yesno))
             {
-                Git.Trace.WriteLine($"{Program.ConfigValidateKey} = '{yesno}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Validate)} = '{yesno}'.");
 
                 operationArguments.ValidateCredentials = yesno.Value;
             }
 
             // Look for write log config settings.
-            if (program.TryReadBoolean(operationArguments, Program.ConfigWritelogKey, Program.EnvironWritelogKey, out yesno))
+            if (program.TryReadBoolean(operationArguments, KeyType.Writelog, out yesno))
             {
-                Git.Trace.WriteLine($"{Program.ConfigWritelogKey} = '{yesno}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Writelog)} = '{yesno}'.");
 
                 operationArguments.WriteLog = yesno.Value;
             }
 
             // Look for modal prompt config settings.
-            if (program.TryReadBoolean(operationArguments, Program.ConfigUseModalPromptKey, Program.EnvironModalPromptKey, out yesno))
+            if (program.TryReadBoolean(operationArguments, KeyType.ModalPrompt, out yesno))
             {
-                Git.Trace.WriteLine($"{Program.ConfigUseModalPromptKey} = '{yesno}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ModalPrompt)} = '{yesno}'.");
 
                 operationArguments.UseModalUi = yesno.Value;
             }
 
             // Look for credential preservation config settings.
-            if (program.TryReadBoolean(operationArguments, Program.ConfigPreserveCredentialsKey, Program.EnvironPreserveCredentialsKey, out yesno))
+            if (program.TryReadBoolean(operationArguments, KeyType.PreserveCredentials, out yesno))
             {
-                Git.Trace.WriteLine($"{Program.ConfigPreserveCredentialsKey} = '{yesno}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.PreserveCredentials)} = '{yesno}'.");
 
                 operationArguments.PreserveCredentials = yesno.Value;
             }
 
             // Look for HTTP path usage config settings.
-            if (program.TryReadBoolean(operationArguments, Program.ConfigUseHttpPathKey, null, out yesno))
+            if (program.TryReadBoolean(operationArguments, KeyType.HttpPath, out yesno))
             {
-                Git.Trace.WriteLine($"{Program.ConfigUseHttpPathKey} = '{value}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpPath)} = '{value}'.");
 
                 operationArguments.UseHttpPath = yesno.Value;
             }
 
             // Look for HTTP proxy config settings.
-            if (program.TryReadString(operationArguments, Program.ConfigHttpProxyKey, Program.EnvironHttpProxyKey, out value))
+            if ((operationArguments.TargetUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                    && program.TryReadString(operationArguments, KeyType.HttpsProxy, out value))
+                || program.TryReadString(operationArguments, KeyType.HttpProxy, out value))
             {
-                Git.Trace.WriteLine($"{Program.ConfigHttpProxyKey} = '{value}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpProxy)} = '{value}'.");
 
                 operationArguments.SetProxy(value);
             }
             // Check environment variables just-in-case.
-            else if ((operationArguments.EnvironmentVariables.TryGetValue(Program.EnvironGitHttpsProxyKey, out value)
-                    && !string.IsNullOrWhiteSpace(value))
-                || (operationArguments.EnvironmentVariables.TryGetValue(Program.EnvironGitHttpProxyKey, out value)
+            else if ((operationArguments.EnvironmentVariables.TryGetValue("GCM_HTTP_PROXY", out value)
                     && !string.IsNullOrWhiteSpace(value)))
             {
-                Git.Trace.WriteLine($"http.proxy = '{value}'.");
+                Git.Trace.WriteLine($"GCM_HTTP_PROXY = '{value}'.");
+
+                var keyName = (operationArguments.TargetUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                    ? "HTTPS_PROXY"
+                    : "HTTP_PROXY";
+                var warning = $"WARNING: the 'GCM_HTTP_PROXY' variable has been deprecated, use '{ keyName }' instead.";
+
+                Git.Trace.WriteLine(warning);
+                program.WriteLine(warning);
 
                 operationArguments.SetProxy(value);
             }
@@ -510,17 +518,17 @@ namespace Microsoft.Alm.Cli
             }
 
             // Look for custom namespace config settings.
-            if (program.TryReadString(operationArguments, Program.ConfigNamespaceKey, Program.EnvironNamespaceKey, out value))
+            if (program.TryReadString(operationArguments, KeyType.Namespace, out value))
             {
-                Git.Trace.WriteLine($"{Program.ConfigNamespaceKey} = '{value}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Namespace)} = '{value}'.");
 
                 operationArguments.CustomNamespace = value;
             }
 
             // Look for custom token duration settings.
-            if (program.TryReadString(operationArguments, Program.ConfigTokenDuration, Program.EnvironTokenDuration, out value))
+            if (program.TryReadString(operationArguments, KeyType.TokenDuration, out value))
             {
-                Git.Trace.WriteLine($"{Program.ConfigTokenDuration} = '{value}'.");
+                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.TokenDuration)} = '{value}'.");
 
                 int hours;
                 if (int.TryParse(value, out hours))
@@ -773,93 +781,101 @@ namespace Microsoft.Alm.Cli
             return credentials;
         }
 
-        public static bool TryReadBoolean(Program program, OperationArguments operationArguments, string configKey, string environKey, out bool? value)
+        public static bool TryReadBoolean(Program program, OperationArguments operationArguments, KeyType key, out bool? value)
         {
             if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
-            var envars = operationArguments.EnvironmentVariables;
-
-            // Look for an entry in the environment variables.
-            string localVal = null;
-            if (!string.IsNullOrWhiteSpace(environKey)
-                && envars.TryGetValue(environKey, out localVal))
+            if (program.ConfigurationKeys.TryGetValue(key, out string configKey)
+                | program.ConfigurationKeys.TryGetValue(key, out string environKey))
             {
-                goto parse_localval;
-            }
+                var envars = operationArguments.EnvironmentVariables;
 
-            var config = operationArguments.GitConfiguration;
+                // Look for an entry in the environment variables.
+                string localVal = null;
+                if (!string.IsNullOrWhiteSpace(environKey)
+                    && envars.TryGetValue(environKey, out localVal))
+                {
+                    goto parse_localval;
+                }
 
-            // Look for an entry in the git config.
-            Configuration.Entry entry;
-            if (!string.IsNullOrWhiteSpace(configKey)
-                && config.TryGetEntry(Program.ConfigPrefix, operationArguments.QueryUri, configKey, out entry))
-            {
-                localVal = entry.Value;
-                goto parse_localval;
-            }
+                var config = operationArguments.GitConfiguration;
 
-            // Parse the value into a bool.
-            parse_localval:
+                // Look for an entry in the git config.
+                Configuration.Entry entry;
+                if (!string.IsNullOrWhiteSpace(configKey)
+                    && config.TryGetEntry(Program.ConfigPrefix, operationArguments.QueryUri, configKey, out entry))
+                {
+                    localVal = entry.Value;
+                    goto parse_localval;
+                }
 
-            // An empty value is unset / should not be there, so treat it as if it isn't.
-            if (string.IsNullOrWhiteSpace(localVal))
-            {
-                value = null;
-                return false;
-            }
+                // Parse the value into a bool.
+                parse_localval:
 
-            // Test `localValue` for a Git 'true' equivalent value.
-            if (Program.ConfigValueComparer.Equals(localVal, "yes")
-                || Program.ConfigValueComparer.Equals(localVal, "true")
-                || Program.ConfigValueComparer.Equals(localVal, "1")
-                || Program.ConfigValueComparer.Equals(localVal, "on"))
-            {
-                value = true;
-                return true;
-            }
+                // An empty value is unset / should not be there, so treat it as if it isn't.
+                if (string.IsNullOrWhiteSpace(localVal))
+                {
+                    value = null;
+                    return false;
+                }
 
-            // Test `localValue` for a Git 'false' equivalent value.
-            if (Program.ConfigValueComparer.Equals(localVal, "no")
-                || Program.ConfigValueComparer.Equals(localVal, "false")
-                || Program.ConfigValueComparer.Equals(localVal, "0")
-                || Program.ConfigValueComparer.Equals(localVal, "off"))
-            {
-                value = false;
-                return true;
+                // Test `localValue` for a Git 'true' equivalent value.
+                if (Program.ConfigValueComparer.Equals(localVal, "yes")
+                    || Program.ConfigValueComparer.Equals(localVal, "true")
+                    || Program.ConfigValueComparer.Equals(localVal, "1")
+                    || Program.ConfigValueComparer.Equals(localVal, "on"))
+                {
+                    value = true;
+                    return true;
+                }
+
+                // Test `localValue` for a Git 'false' equivalent value.
+                if (Program.ConfigValueComparer.Equals(localVal, "no")
+                    || Program.ConfigValueComparer.Equals(localVal, "false")
+                    || Program.ConfigValueComparer.Equals(localVal, "0")
+                    || Program.ConfigValueComparer.Equals(localVal, "off"))
+                {
+                    value = false;
+                    return true;
+                }
             }
 
             value = null;
             return false;
         }
 
-        public static bool TryReadString(Program program, OperationArguments operationArguments, string configKey, string environKey, out string value)
+        public static bool TryReadString(Program program, OperationArguments operationArguments, KeyType key, out string value)
         {
             if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
-            var envars = operationArguments.EnvironmentVariables;
-
-            // Look for an entry in the environment variables.
-            string localVal;
-            if (!string.IsNullOrWhiteSpace(environKey)
-                && envars.TryGetValue(environKey, out localVal)
-                && !string.IsNullOrWhiteSpace(localVal))
+            if (program.ConfigurationKeys.TryGetValue(key, out string configKey)
+                | program.ConfigurationKeys.TryGetValue(key, out string environKey))
             {
-                value = localVal;
-                return true;
-            }
+                var envars = operationArguments.EnvironmentVariables;
 
-            Configuration config = operationArguments.GitConfiguration;
+                // Look for an entry in the environment variables.
+                string localVal;
+                if (!string.IsNullOrWhiteSpace(environKey)
+                    && envars.TryGetValue(environKey, out localVal)
+                    && !string.IsNullOrWhiteSpace(localVal))
+                {
+                    value = localVal;
+                    return true;
+                }
 
-            // Look for an entry in the git config.
-            Configuration.Entry entry;
-            if (!string.IsNullOrWhiteSpace(configKey)
-                && config.TryGetEntry(Program.ConfigPrefix, operationArguments.QueryUri, configKey, out entry)
-                && !string.IsNullOrWhiteSpace(entry.Value))
-            {
-                value = entry.Value;
-                return true;
+                Configuration config = operationArguments.GitConfiguration;
+
+                // Look for an entry in the git config.
+                Configuration.Entry entry;
+                if (!string.IsNullOrWhiteSpace(configKey)
+                    && config.TryGetEntry(Program.ConfigPrefix, operationArguments.QueryUri, configKey, out entry)
+                    && !string.IsNullOrWhiteSpace(entry.Value))
+                {
+                    value = entry.Value;
+                    return true;
+                }
             }
 
             value = null;

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -787,7 +787,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentNullException(nameof(operationArguments));
 
             if (program.ConfigurationKeys.TryGetValue(key, out string configKey)
-                | program.ConfigurationKeys.TryGetValue(key, out string environKey))
+                | program.EnvironmentKeys.TryGetValue(key, out string environKey))
             {
                 var envars = operationArguments.EnvironmentVariables;
 

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -878,7 +878,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentNullException(nameof(operationArguments));
 
             if (program.ConfigurationKeys.TryGetValue(key, out string configKey)
-                | program.ConfigurationKeys.TryGetValue(key, out string environKey))
+                | program.EnvironmentKeys.TryGetValue(key, out string environKey))
             {
                 var envars = operationArguments.EnvironmentVariables;
 

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -31,28 +31,163 @@ using Microsoft.Alm.Authentication;
 
 namespace Microsoft.Alm.Cli
 {
-    internal abstract class OperationArguments
+    internal class OperationArguments
     {
+        private static readonly char[] SeperatorCharacters = { '/', '\\' };
+
+        public OperationArguments(Stream readableStream)
+                : this()
+        {
+            if (ReferenceEquals(readableStream, null))
+                throw new ArgumentNullException(nameof(readableStream));
+
+            if (readableStream == Stream.Null || !readableStream.CanRead)
+                throw new InvalidOperationException("Unable to read input.");
+
+            byte[] buffer = new byte[4096];
+            int read = 0;
+
+            int r;
+            while ((r = readableStream.Read(buffer, read, buffer.Length - read)) > 0)
+            {
+                read += r;
+
+                // If we've filled the buffer, make it larger this could hit an out of memory
+                // condition, but that'd require the called to be attempting to do so, since
+                // that's not a security threat we can safely ignore that and allow NetFx to
+                // handle it.
+                if (read == buffer.Length)
+                {
+                    Array.Resize(ref buffer, buffer.Length * 2);
+                }
+
+                if ((read > 0 && read < 3 && buffer[read - 1] == '\n'))
+                {
+                    throw new InvalidDataException("Invalid input, please see 'https://www.kernel.org/pub/software/scm/git/docs/git-credential.html'.");
+                }
+
+                // The input ends with LFLF, check for that and break the read loop unless
+                // input is coming from CLRF system, in which case it'll be CLRFCLRF.
+                if ((buffer[read - 2] == '\n'
+                        && buffer[read - 1] == '\n')
+                    || (buffer[read - 4] == '\r'
+                        && buffer[read - 3] == '\n'
+                        && buffer[read - 2] == '\r'
+                        && buffer[read - 1] == '\n'))
+                    break;
+            }
+
+            // Git uses UTF-8 for string, don't let the OS decide how to decode it instead
+            // we'll actively decode the UTF-8 block ourselves.
+            string input = Encoding.UTF8.GetString(buffer, 0, read);
+
+            // The `StringReader` is just useful.
+            using (StringReader reader = new StringReader(input))
+            {
+                string line;
+                while (!string.IsNullOrWhiteSpace((line = reader.ReadLine())))
+                {
+                    string[] pair = line.Split(new[] { '=' }, 2);
+
+                    if (pair.Length == 2)
+                    {
+                        switch (pair[0])
+                        {
+                            case "protocol":
+                                _queryProtocol = pair[1];
+                                break;
+
+                            case "host":
+                                _queryHost = pair[1];
+                                break;
+
+                            case "path":
+                                _queryPath = pair[1];
+                                break;
+
+                            case "username":
+                                _username = pair[1];
+                                break;
+
+                            case "password":
+                                _password = pair[1];
+                                break;
+                        }
+                    }
+                }
+            }
+
+            CreateTargetUri();
+        }
+
+        public OperationArguments(Uri targetUri)
+            : this()
+        {
+            if (ReferenceEquals(targetUri, null))
+                throw new ArgumentNullException("targetUri");
+
+            _queryProtocol = targetUri.Scheme;
+            _queryHost = (targetUri.IsDefaultPort)
+                ? targetUri.Host
+                : string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}:{1}", targetUri.Host, targetUri.Port);
+            _queryPath = targetUri.AbsolutePath;
+
+            CreateTargetUri();
+        }
+
+        public OperationArguments()
+        {
+            _authorityType = AuthorityType.Auto;
+            _interactivity = Interactivity.Auto;
+            _useLocalConfig = true;
+            _useModalUi = true;
+            _useSystemConfig = true;
+            _validateCredentials = true;
+            _vstsTokenScope = Program.VstsCredentialScope;
+        }
+
+        private AuthorityType _authorityType;
+        private Git.Configuration _configuration;
+        private string _customNamespace;
+        private Dictionary<string, string> _environmentVariables;
+        private Interactivity _interactivity;
+        private string _password;
+        private bool _preserveCredentials;
+        private Uri _proxyUri;
+        private string _queryHost;
+        private string _queryPath;
+        private string _queryProtocol;
+        private TargetUri _targetUri;
+        private TimeSpan? _tokenDuration;
+        private bool _useHttpPath;
+        private bool _useLocalConfig;
+        private bool _useModalUi;
+        private string _username;
+        private bool _useSystemConfig;
+        private bool _validateCredentials;
+        private VstsTokenScope _vstsTokenScope;
+        private bool _writeLog;
+
         public virtual AuthorityType Authority
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _authorityType; }
+            set { _authorityType = value; }
         }
 
         public virtual string CredPassword
         {
-            get => throw new NotImplementedException();
+            get { return _password; }
         }
 
         public virtual string CredUsername
         {
-            get => throw new NotImplementedException();
+            get { return _username; }
         }
 
         public virtual string CustomNamespace
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _customNamespace; }
+            set { _customNamespace = value; }
         }
 
         /// <summary>
@@ -60,7 +195,19 @@ namespace Microsoft.Alm.Cli
         /// </summary>
         public virtual IReadOnlyDictionary<string, string> EnvironmentVariables
         {
-            get => throw new NotImplementedException();
+            get
+            {
+                if (_environmentVariables == null)
+                {
+                    _environmentVariables = new Dictionary<string, string>(Program.EnvironKeyComparer);
+                    var iter = Environment.GetEnvironmentVariables().GetEnumerator();
+                    while (iter.MoveNext())
+                    {
+                        _environmentVariables[iter.Key as string] = iter.Value as string;
+                    }
+                }
+                return _environmentVariables;
+            }
         }
 
         /// <summary>
@@ -69,103 +216,170 @@ namespace Microsoft.Alm.Cli
         /// </summary>
         public virtual Git.Configuration GitConfiguration
         {
-            get => throw new NotImplementedException();
+            get
+            {
+                if (_configuration == null)
+                {
+                    LoadConfiguration();
+                }
+                return _configuration;
+            }
         }
 
         public virtual Interactivity Interactivity
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _interactivity; }
+            set { _interactivity = value; }
         }
 
         public virtual bool PreserveCredentials
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _preserveCredentials; }
+            set { _preserveCredentials = value; }
         }
 
         public virtual Uri ProxyUri
         {
-            get => throw new NotImplementedException();
-            internal set => throw new NotImplementedException();
+            get { return _targetUri.ProxyUri; }
+            internal set
+            {
+                _proxyUri = value;
+                CreateTargetUri();
+            }
         }
 
         public virtual string QueryHost
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _queryHost; }
+            set
+            {
+                _queryHost = value;
+                CreateTargetUri();
+            }
         }
 
         public virtual string QueryPath
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _queryPath; }
+            set
+            {
+                _queryPath = value;
+                CreateTargetUri();
+            }
         }
 
         public virtual string QueryProtocol
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _queryProtocol; }
+            set
+            {
+                _queryProtocol = value;
+                CreateTargetUri();
+            }
         }
 
         public virtual Uri QueryUri
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _targetUri.QueryUri; }
+            set
+            {
+                if (value == null)
+                {
+                    _queryHost = null;
+                    _queryPath = null;
+                    _queryProtocol = null;
+                }
+                else
+                {
+                    _queryHost = value.DnsSafeHost;
+                    _queryPath = value.AbsolutePath;
+                    _queryProtocol = value.Scheme;
+
+                    // If there's a non-default port value, retain it.
+                    if (!value.IsDefaultPort)
+                    {
+                        _queryHost = $"{_queryHost}:{value.Port}";
+                    }
+
+                    // If there's a query segment, retain it.
+                    if (!string.IsNullOrWhiteSpace(value.Query))
+                    {
+                        _queryHost = $"{_queryHost}?{value.Query}";
+                    }
+                }
+                CreateTargetUri();
+            }
         }
 
         public virtual bool UseConfigLocal
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _useLocalConfig; }
+            set { _useLocalConfig = value; }
         }
 
         public virtual bool UseConfigSystem
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _useSystemConfig; }
+            set { _useSystemConfig = value; }
         }
 
         public virtual TargetUri TargetUri
         {
-            get => throw new NotImplementedException();
+            get { return _targetUri; }
         }
 
         public virtual TimeSpan? TokenDuration
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _tokenDuration; }
+            set { _tokenDuration = value; }
         }
 
         public virtual bool UseHttpPath
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _useHttpPath; }
+            set
+            {
+                _useHttpPath = value;
+                CreateTargetUri();
+            }
         }
 
         public virtual bool UseModalUi
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _useModalUi; }
+            set { _useModalUi = value; }
         }
 
         public virtual bool ValidateCredentials
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _validateCredentials; }
+            set { _validateCredentials = value; }
+        }
+
+        public virtual VstsTokenScope VstsTokenScope
+        {
+            get { return _vstsTokenScope; }
+            set { _vstsTokenScope = value; }
         }
 
         public virtual bool WriteLog
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get { return _writeLog; }
+            set { _writeLog = true; }
         }
 
         public virtual void LoadConfiguration()
-            => throw new NotImplementedException();
+        {
+            _configuration = Git.Configuration.ReadConfiuration(Environment.CurrentDirectory, UseConfigLocal, UseConfigSystem);
+        }
 
         public virtual void SetCredentials(Credential credentials)
-            => throw new NotImplementedException();
+        {
+            _username = credentials.Username;
+            _password = credentials.Password;
+
+            CreateTargetUri();
+        }
 
         public virtual void SetCredentials(string username, string password)
         {
@@ -175,537 +389,160 @@ namespace Microsoft.Alm.Cli
         }
 
         public virtual void SetProxy(string url)
-            => throw new NotImplementedException();
+        {
+            Uri tmp = null;
+            if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
+            {
+                Git.Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(url))
+                {
+                    Git.Trace.WriteLine($"failed to parse '{url}'.");
+                }
+
+                Git.Trace.WriteLine("proxy cleared.");
+            }
+            ProxyUri = tmp;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder builder = new StringBuilder();
+
+            builder.Append("protocol=")
+                   .Append(_queryProtocol ?? string.Empty)
+                   .Append("\n");
+            builder.Append("host=")
+                   .Append(_queryHost ?? string.Empty)
+                   .Append("\n");
+            builder.Append("path=")
+                   .Append(_queryPath ?? string.Empty)
+                   .Append("\n");
+
+            // Only write out username if we know it.
+            if (_username != null)
+            {
+                builder.Append("username=")
+                       .Append(_username)
+                       .Append("\n");
+            }
+
+            // Only write out password if we know it.
+            if (_password != null)
+            {
+                builder.Append("password=")
+                       .Append(_password)
+                       .Append("\n");
+            }
+
+            return builder.ToString();
+        }
 
         /// <summary>
         /// Writes the UTF-8 encoded value of <see cref="ToString"/> directly to a <see cref="Stream"/>.
         /// </summary>
         /// <param name="writableStream">The <see cref="Stream"/> to write to.</param>
         public virtual void WriteToStream(Stream writableStream)
-            => throw new NotImplementedException();
+        {
+            if (ReferenceEquals(writableStream, null))
+                throw new ArgumentNullException(nameof(writableStream));
+            if (!writableStream.CanWrite)
+                throw new ArgumentException("CanWrite property returned false.", nameof(writableStream));
+
+            // Git reads/writes UTF-8, we'll explicitly encode to Utf-8 to avoid NetFx or the
+            // operating system making the wrong encoding decisions.
+            string output = ToString();
+            byte[] bytes = Encoding.UTF8.GetBytes(output);
+
+            // write the bytes.
+            writableStream.Write(bytes, 0, bytes.Length);
+        }
 
         internal virtual void CreateTargetUri()
-            => throw new NotImplementedException();
-
-        internal sealed class Impl : OperationArguments
         {
-            private static readonly char[] SeperatorCharacters = { '/', '\\' };
+            string actualUrl = null;
+            string queryUrl = null;
+            string proxyUrl = _proxyUri?.OriginalString;
 
-            internal Impl(Stream readableStream)
-                : this()
+            // When the target requests a path...
+            if (UseHttpPath)
             {
-                if (ReferenceEquals(readableStream, null))
-                    throw new ArgumentNullException(nameof(readableStream));
-
-                if (readableStream == Stream.Null || !readableStream.CanRead)
-                    throw new InvalidOperationException("Unable to read input.");
-
-                byte[] buffer = new byte[4096];
-                int read = 0;
-
-                int r;
-                while ((r = readableStream.Read(buffer, read, buffer.Length - read)) > 0)
+                // and lacks a protocol...
+                if (string.IsNullOrWhiteSpace(_queryProtocol))
                 {
-                    read += r;
-
-                    // If we've filled the buffer, make it larger this could hit an out of memory
-                    // condition, but that'd require the called to be attempting to do so, since
-                    // that's not a security threat we can safely ignore that and allow NetFx to
-                    // handle it.
-                    if (read == buffer.Length)
+                    // and the target lacks a path: use just the host.
+                    if ((string.IsNullOrWhiteSpace(_queryPath)))
                     {
-                        Array.Resize(ref buffer, buffer.Length * 2);
-                    }
+                        queryUrl = $"{_queryHost}/";
 
-                    if ((read > 0 && read < 3 && buffer[read - 1] == '\n'))
-                    {
-                        throw new InvalidDataException("Invalid input, please see 'https://www.kernel.org/pub/software/scm/git/docs/git-credential.html'.");
-                    }
-
-                    // The input ends with LFLF, check for that and break the read loop unless
-                    // input is coming from CLRF system, in which case it'll be CLRFCLRF.
-                    if ((buffer[read - 2] == '\n'
-                            && buffer[read - 1] == '\n')
-                        || (buffer[read - 4] == '\r'
-                            && buffer[read - 3] == '\n'
-                            && buffer[read - 2] == '\r'
-                            && buffer[read - 1] == '\n'))
-                        break;
-                }
-
-                // Git uses UTF-8 for string, don't let the OS decide how to decode it instead
-                // we'll actively decode the UTF-8 block ourselves.
-                string input = Encoding.UTF8.GetString(buffer, 0, read);
-
-                // The `StringReader` is just useful.
-                using (StringReader reader = new StringReader(input))
-                {
-                    string line;
-                    while (!string.IsNullOrWhiteSpace((line = reader.ReadLine())))
-                    {
-                        string[] pair = line.Split(new[] { '=' }, 2);
-
-                        if (pair.Length == 2)
+                        // If the username is known, include it in the actual URL.
+                        if (!string.IsNullOrEmpty(_username))
                         {
-                            switch (pair[0])
-                            {
-                                case "protocol":
-                                    _queryProtocol = pair[1];
-                                    break;
-
-                                case "host":
-                                    _queryHost = pair[1];
-                                    break;
-
-                                case "path":
-                                    _queryPath = pair[1];
-                                    break;
-
-                                case "username":
-                                    _username = pair[1];
-                                    break;
-
-                                case "password":
-                                    _password = pair[1];
-                                    break;
-                            }
+                            var escapedUsername = Uri.EscapeDataString(_username);
+                            actualUrl = $"{escapedUsername}@{_queryHost}/";
                         }
                     }
-                }
-
-                CreateTargetUri();
-            }
-
-            internal Impl(Uri targetUri)
-                : this()
-            {
-                if (ReferenceEquals(targetUri, null))
-                    throw new ArgumentNullException("targetUri");
-
-                _queryProtocol = targetUri.Scheme;
-                _queryHost = (targetUri.IsDefaultPort)
-                    ? targetUri.Host
-                    : string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}:{1}", targetUri.Host, targetUri.Port);
-                _queryPath = targetUri.AbsolutePath;
-
-                CreateTargetUri();
-            }
-
-            private Impl()
-            {
-                _preserveCredentials = false;
-                _useHttpPath = false;
-                _useLocalConfig = true;
-                _useSystemConfig = true;
-                Authority = AuthorityType.Auto;
-                Interactivity = Interactivity.Auto;
-                UseModalUi = true;
-                ValidateCredentials = true;
-                WriteLog = false;
-            }
-
-            private AuthorityType _authorityType;
-            private Git.Configuration _configuration;
-            private string _customNamespace;
-            private Dictionary<string, string> _environmentVariables;
-            private Interactivity _interactivity;
-            private string _password;
-            private bool _preserveCredentials;
-            private Uri _proxyUri;
-            private string _queryHost;
-            private string _queryPath;
-            private string _queryProtocol;
-            private TargetUri _targetUri;
-            private TimeSpan? _tokenDuration;
-            private bool _useHttpPath;
-            private bool _useLocalConfig;
-            private string _username;
-            private bool _useSystemConfig;
-
-            public sealed override AuthorityType Authority
-            {
-                get { return _authorityType; }
-                set { _authorityType = value; }
-            }
-
-            public sealed override string CredPassword
-            {
-                get { return _password; }
-            }
-
-            public sealed override string CredUsername
-            {
-                get { return _username; }
-            }
-
-            public sealed override string CustomNamespace
-            {
-                get { return _customNamespace; }
-                set { _customNamespace = value; }
-            }
-
-            public sealed override IReadOnlyDictionary<string, string> EnvironmentVariables
-            {
-                get
-                {
-                    if (_environmentVariables == null)
-                    {
-                        _environmentVariables = new Dictionary<string, string>(Program.EnvironKeyComparer);
-                        var iter = Environment.GetEnvironmentVariables().GetEnumerator();
-                        while (iter.MoveNext())
-                        {
-                            _environmentVariables[iter.Key as string] = iter.Value as string;
-                        }
-                    }
-                    return _environmentVariables;
-                }
-            }
-
-            public sealed override Git.Configuration GitConfiguration
-            {
-                get
-                {
-                    if (_configuration == null)
-                    {
-                        LoadConfiguration();
-                    }
-                    return _configuration;
-                }
-            }
-
-            public sealed override Interactivity Interactivity
-            {
-                get { return _interactivity; }
-                set { _interactivity = value; }
-            }
-
-            public sealed override bool PreserveCredentials
-            {
-                get { return _preserveCredentials; }
-                set { _preserveCredentials = value; }
-            }
-
-            public sealed override Uri ProxyUri
-            {
-                get { return _targetUri.ProxyUri; }
-                internal set
-                {
-                    _proxyUri = value;
-                    CreateTargetUri();
-                }
-            }
-
-            public sealed override string QueryHost
-            {
-                get { return _queryHost; }
-                set
-                {
-                    _queryHost = value;
-                    CreateTargetUri();
-                }
-            }
-
-            public sealed override string QueryPath
-            {
-                get { return _queryPath; }
-                set
-                {
-                    _queryPath = value;
-                    CreateTargetUri();
-                }
-            }
-
-            public sealed override string QueryProtocol
-            {
-                get { return _queryProtocol; }
-                set
-                {
-                    _queryProtocol = value;
-                    CreateTargetUri();
-                }
-            }
-
-            public sealed override Uri QueryUri
-            {
-                get { return _targetUri.QueryUri; }
-                set
-                {
-                    if (value == null)
-                    {
-                        _queryHost = null;
-                        _queryPath = null;
-                        _queryProtocol = null;
-                    }
+                    // Combine the host + path.
                     else
                     {
-                        _queryHost = value.DnsSafeHost;
-                        _queryPath = value.AbsolutePath;
-                        _queryProtocol = value.Scheme;
+                        queryUrl = $"{_queryHost}/{_queryPath}";
 
-                        // if there's a non-default port value, retain it
-                        if (!value.IsDefaultPort)
+                        // If the username is known, include it in the actual URL.
+                        if (!string.IsNullOrEmpty(_username))
                         {
-                            _queryHost = $"{_queryHost}:{value.Port}";
-                        }
-
-                        // if there's a query segment, retain it
-                        if (!string.IsNullOrWhiteSpace(value.Query))
-                        {
-                            _queryHost = $"{_queryHost}?{value.Query}";
+                            var escapedUsername = Uri.EscapeDataString(_username);
+                            actualUrl = $"{escapedUsername}@{_queryHost}/{_queryPath}";
                         }
                     }
-                    CreateTargetUri();
                 }
-            }
-
-            public sealed override TargetUri TargetUri
-            {
-                get { return _targetUri; }
-            }
-
-            public sealed override TimeSpan? TokenDuration
-            {
-                get { return _tokenDuration; }
-                set { _tokenDuration = value; }
-            }
-
-            public sealed override bool UseConfigLocal
-            {
-                get { return _useLocalConfig; }
-                set { _useLocalConfig = value; }
-            }
-
-            public sealed override bool UseConfigSystem
-            {
-                get { return _useSystemConfig; }
-                set { _useSystemConfig = value; }
-            }
-
-            public sealed override bool UseHttpPath
-            {
-                get { return _useHttpPath; }
-                set
-                {
-                    _useHttpPath = value;
-                    CreateTargetUri();
-                }
-            }
-
-            public sealed override bool UseModalUi { get; set; }
-
-            public sealed override bool ValidateCredentials { get; set; }
-
-            public sealed override bool WriteLog { get; set; }
-
-            public sealed override void LoadConfiguration()
-            {
-                _configuration = Git.Configuration.ReadConfiuration(Environment.CurrentDirectory, UseConfigLocal, UseConfigSystem);
-            }
-
-            public sealed override void SetCredentials(Credential credentials)
-            {
-                _username = credentials.Username;
-                _password = credentials.Password;
-
-                CreateTargetUri();
-            }
-
-            public sealed override void SetProxy(string url)
-            {
-                Uri tmp = null;
-                if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
-                {
-                    Git.Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
-                }
+                // and has a protocol...
                 else
                 {
-                    if (!string.IsNullOrWhiteSpace(url))
+                    // and the target lacks a path, combine protocol + host
+                    if (string.IsNullOrWhiteSpace(_queryPath))
                     {
-                        Git.Trace.WriteLine($"failed to parse '{url}'.");
-                    }
+                        queryUrl = $"{_queryProtocol}://{_queryHost}/";
 
-                    Git.Trace.WriteLine("proxy cleared.");
-                }
-                ProxyUri = tmp;
-            }
-
-            public sealed override string ToString()
-            {
-                StringBuilder builder = new StringBuilder();
-
-                builder.Append("protocol=")
-                       .Append(_queryProtocol ?? string.Empty)
-                       .Append("\n");
-                builder.Append("host=")
-                       .Append(_queryHost ?? string.Empty)
-                       .Append("\n");
-                builder.Append("path=")
-                       .Append(_queryPath ?? string.Empty)
-                       .Append("\n");
-                // only write out username if we know it
-                if (_username != null)
-                {
-                    builder.Append("username=")
-                           .Append(_username)
-                           .Append("\n");
-                }
-                // only write out password if we know it
-                if (_password != null)
-                {
-                    builder.Append("password=")
-                           .Append(_password)
-                           .Append("\n");
-                }
-
-                return builder.ToString();
-            }
-
-            public sealed override void WriteToStream(Stream writableStream)
-            {
-                if (ReferenceEquals(writableStream, null))
-                    throw new ArgumentNullException(nameof(writableStream));
-                if (!writableStream.CanWrite)
-                    throw new ArgumentException("CanWrite property returned false.", nameof(writableStream));
-
-                // Git reads/writes UTF-8, we'll explicitly encode to Utf-8 to avoid NetFx or the
-                // operating system making the wrong encoding decisions.
-                string output = ToString();
-                byte[] bytes = Encoding.UTF8.GetBytes(output);
-
-                // write the bytes.
-                writableStream.Write(bytes, 0, bytes.Length);
-            }
-
-            internal sealed override void CreateTargetUri()
-            {
-                string actualUrl = null;
-                string queryUrl = null;
-                string proxyUrl = _proxyUri?.OriginalString;
-
-                // when the target requests a path...
-                if (UseHttpPath)
-                {
-                    // and lacks a protocol...
-                    if (string.IsNullOrWhiteSpace(_queryProtocol))
-                    {
-                        // and the target lacks a path: use just the host
-                        if ((string.IsNullOrWhiteSpace(_queryPath)))
+                        // If the username is known, include it in the actual URL.
+                        if (!string.IsNullOrEmpty(_username))
                         {
-                            queryUrl = $"{_queryHost}/";
-
-                            // if the username is known, include it in the actual url
-                            if (!string.IsNullOrEmpty(_username))
-                            {
-                                var escapedUsername = Uri.EscapeDataString(_username);
-                                actualUrl = $"{escapedUsername}@{_queryHost}/";
-                            }
-                        }
-                        // combine the host + path
-                        else
-                        {
-                            queryUrl = $"{_queryHost}/{_queryPath}";
-
-                            // if the username is known, include it in the actual url
-                            if (!string.IsNullOrEmpty(_username))
-                            {
-                                var escapedUsername = Uri.EscapeDataString(_username);
-                                actualUrl = $"{escapedUsername}@{_queryHost}/{_queryPath}";
-                            }
+                            var escapedUsername = Uri.EscapeDataString(_username);
+                            actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
                         }
                     }
-                    // and has a protocol...
+                    // Combine protocol + host + path.
                     else
                     {
-                        // and the target lacks a path, combine protocol + host
-                        if (string.IsNullOrWhiteSpace(_queryPath))
-                        {
-                            queryUrl = $"{_queryProtocol}://{_queryHost}/";
+                        queryUrl = $"{_queryProtocol}://{_queryHost}/{_queryPath}";
 
-                            // if the username is known, include it in the actual url
-                            if (!string.IsNullOrEmpty(_username))
-                            {
-                                var escapedUsername = Uri.EscapeDataString(_username);
-                                actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
-                            }
-                        }
-                        // combine protocol + host + path
-                        else
+                        // If the username is known, include it in the actual URL.
+                        if (!string.IsNullOrEmpty(_username))
                         {
-                            queryUrl = $"{_queryProtocol}://{_queryHost}/{_queryPath}";
-
-                            // if the username is known, include it in the actual url
-                            if (!string.IsNullOrEmpty(_username))
-                            {
-                                var escapedUsername = Uri.EscapeDataString(_username);
-                                actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/{_queryPath}";
-                            }
+                            var escapedUsername = Uri.EscapeDataString(_username);
+                            actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/{_queryPath}";
                         }
                     }
                 }
-                // when the target ignores paths...
-                else
+            }
+            // When the target ignores paths...
+            else
+            {
+                // and lacks a protocol...
+                if (string.IsNullOrWhiteSpace(_queryProtocol))
                 {
-                    // and lacks a protocol...
-                    if (string.IsNullOrWhiteSpace(_queryProtocol))
+                    // and the host starts with "\\", strip the path...
+                    if (_queryHost.StartsWith(@"\\", StringComparison.Ordinal))
                     {
-                        // and the host starts with "\\", strip the path...
-                        if (_queryHost.StartsWith(@"\\", StringComparison.Ordinal))
-                        {
-                            int idx = _queryHost.IndexOfAny(SeperatorCharacters, 2);
-                            queryUrl = (idx > 0)
-                                ? _queryHost.Substring(0, idx)
-                                : _queryHost;
-
-                            queryUrl += '/';
-
-                            // if the username is known, include it in the actual url
-                            if (string.IsNullOrEmpty(_username))
-                            {
-                                actualUrl = queryUrl;
-                            }
-                            else
-                            {
-                                var escapedUsername = Uri.EscapeDataString(_username);
-                                actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
-                            }
-                        }
-                        // use just the host
-                        else
-                        {
-                            queryUrl = $"{_queryHost}/";
-
-                            // if the username is known, include it in the actual url
-                            if (string.IsNullOrEmpty(_username))
-                            {
-                                actualUrl = queryUrl;
-                            }
-                            else
-                            {
-                                var escapedUsername = Uri.EscapeDataString(_username);
-                                actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
-                            }
-                        }
-
-                        // append path information in the actual url, but avoid empty paths
-                        if (!string.IsNullOrWhiteSpace(_queryPath) && _queryPath.Length > 1)
-                        {
-                            actualUrl += _queryPath;
-                        }
-                    }
-                    // and the protocol is "file://" strip any path
-                    else if (_queryProtocol.StartsWith(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-                    {
-                        int idx = _queryHost.IndexOfAny(SeperatorCharacters);
-
-                        // strip the host as neccisary
+                        int idx = _queryHost.IndexOfAny(SeperatorCharacters, 2);
                         queryUrl = (idx > 0)
                             ? _queryHost.Substring(0, idx)
                             : _queryHost;
 
-                        // combine with protocol
-                        queryUrl = $"{_queryProtocol}://{queryUrl}/";
+                        queryUrl += '/';
 
-                        // if the username is known, include it in the actual url
+                        // If the username is known, include it in the actual URL.
                         if (string.IsNullOrEmpty(_username))
                         {
                             actualUrl = queryUrl;
@@ -715,19 +552,13 @@ namespace Microsoft.Alm.Cli
                             var escapedUsername = Uri.EscapeDataString(_username);
                             actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
                         }
-
-                        // append path information in the actual url, but avoid empty paths
-                        if (!string.IsNullOrWhiteSpace(_queryPath) && _queryPath.Length > 1)
-                        {
-                            actualUrl += _queryPath;
-                        }
                     }
-                    // combine the protocol + host
+                    // Use just the host.
                     else
                     {
-                        queryUrl = $"{_queryProtocol}://{_queryHost}/";
+                        queryUrl = $"{_queryHost}/";
 
-                        // if the username is known, include it in the actual url
+                        // If the username is known, include it in the actual URL.
                         if (string.IsNullOrEmpty(_username))
                         {
                             actualUrl = queryUrl;
@@ -737,21 +568,73 @@ namespace Microsoft.Alm.Cli
                             var escapedUsername = Uri.EscapeDataString(_username);
                             actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
                         }
+                    }
 
-                        // append path information in the actual url, but avoid empty paths
-                        if (!string.IsNullOrWhiteSpace(_queryPath) && _queryPath.Length > 1)
-                        {
-                            actualUrl += _queryPath;
-                        }
+                    // Append path information in the actual URL, but avoid empty paths.
+                    if (!string.IsNullOrWhiteSpace(_queryPath) && _queryPath.Length > 1)
+                    {
+                        actualUrl += _queryPath;
                     }
                 }
+                // and the protocol is "file://" strip any path.
+                else if (_queryProtocol.StartsWith(Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+                {
+                    int idx = _queryHost.IndexOfAny(SeperatorCharacters);
 
-                // take the query url if the actual url is still unset
-                actualUrl = actualUrl ?? queryUrl;
+                    // Strip the host as necessary.
+                    queryUrl = (idx > 0)
+                        ? _queryHost.Substring(0, idx)
+                        : _queryHost;
 
-                // Create the target uri object
-                _targetUri = new TargetUri(actualUrl, queryUrl, proxyUrl);
+                    // Combine with protocol.
+                    queryUrl = $"{_queryProtocol}://{queryUrl}/";
+
+                    // If the username is known, include it in the actual URL.
+                    if (string.IsNullOrEmpty(_username))
+                    {
+                        actualUrl = queryUrl;
+                    }
+                    else
+                    {
+                        var escapedUsername = Uri.EscapeDataString(_username);
+                        actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
+                    }
+
+                    // Append path information in the actual URL, but avoid empty paths.
+                    if (!string.IsNullOrWhiteSpace(_queryPath) && _queryPath.Length > 1)
+                    {
+                        actualUrl += _queryPath;
+                    }
+                }
+                // Combine the protocol + host.
+                else
+                {
+                    queryUrl = $"{_queryProtocol}://{_queryHost}/";
+
+                    // If the username is known, include it in the actual URL.
+                    if (string.IsNullOrEmpty(_username))
+                    {
+                        actualUrl = queryUrl;
+                    }
+                    else
+                    {
+                        var escapedUsername = Uri.EscapeDataString(_username);
+                        actualUrl = $"{_queryProtocol}://{escapedUsername}@{_queryHost}/";
+                    }
+
+                    // Append path information in the actual URL, but avoid empty paths.
+                    if (!string.IsNullOrWhiteSpace(_queryPath) && _queryPath.Length > 1)
+                    {
+                        actualUrl += _queryPath;
+                    }
+                }
             }
+
+            // Take the query URL if the actual URL is still unset.
+            actualUrl = actualUrl ?? queryUrl;
+
+            // Create the target URI object.
+            _targetUri = new TargetUri(actualUrl, queryUrl, proxyUrl);
         }
     }
 }

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -24,6 +24,7 @@
 **/
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -34,41 +35,33 @@ using Github = GitHub.Authentication;
 
 namespace Microsoft.Alm.Cli
 {
+    enum KeyType
+    {
+        Authority,
+        ConfigNoLocal,
+        ConfigNoSystem,
+        GcmProxy,
+        HttpPath,
+        HttpProxy,
+        HttpsProxy,
+        HttpUserAgent,
+        Interactive,
+        LoginHint,
+        ModalPrompt,
+        Namespace,
+        PreserveCredentials,
+        TokenDuration,
+        Validate,
+        Writelog,
+    }
+
     partial class Program
     {
         public const string SourceUrl = "https://github.com/Microsoft/Git-Credential-Manager-for-Windows";
         public const string EventSource = "Git Credential Manager";
 
-        internal const string ConfigAuthorityKey = "authority";
-        internal const string ConfigHttpProxyKey = "httpProxy";
-        internal const string ConfigInteractiveKey = "interactive";
-        internal const string ConfigLoginHintKey = "loginhint";
-        internal const string ConfigNamespaceKey = "namespace";
-        internal const string ConfigPreserveCredentialsKey = "preserve";
-        internal const string ConfigTokenDuration = "tokenDuration";
-        internal const string ConfigUseHttpPathKey = "useHttpPath";
-        internal const string ConfigUseModalPromptKey = "modalPrompt";
-        internal const string ConfigValidateKey = "validate";
-        internal const string ConfigWritelogKey = "writelog";
-
         internal static readonly StringComparer ConfigKeyComparer = StringComparer.OrdinalIgnoreCase;
         internal static readonly StringComparer ConfigValueComparer = StringComparer.OrdinalIgnoreCase;
-
-        internal const string EnvironAuthorityKey = "GCM_AUTHORITY";
-        internal const string EnvironConfigNoLocalKey = "GCM_CONFIG_NOLOCAL";
-        internal const string EnvironConfigNoSystemKey = "GCM_CONFIG_NOSYSTEM";
-        internal const string EnvironHttpProxyKey = "GCM_HTTP_PROXY";
-        internal const string EnvironHttpUserAgent = "GCM_HTTP_USER_AGENT";
-        internal const string EnvironInteractiveKey = "GCM_INTERACTIVE";
-        internal const string EnvironLoginHintKey = "GCM_LOGINHINT";
-        internal const string EnvironModalPromptKey = "GCM_MODAL_PROMPT";
-        internal const string EnvironNamespaceKey = "GCM_NAMESPACE";
-        internal const string EnvironTokenDuration = "GCM_TOKEN_DURATION";
-        internal const string EnvironPreserveCredentialsKey = "GCM_PRESERVE_CREDS";
-        internal const string EnvironValidateKey = "GCM_VALIDATE";
-        internal const string EnvironWritelogKey = "GCM_WRITELOG";
-        internal const string EnvironGitHttpProxyKey = "HTTP_PROXY";
-        internal const string EnvironGitHttpsProxyKey = "HTTPS_PROXY";
 
         internal const string EnvironConfigTraceKey = Git.Trace.EnvironmentVariableKey;
 
@@ -108,11 +101,52 @@ namespace Microsoft.Alm.Cli
         internal WriteDelegate _write = ConsoleFunctions.Write;
         internal WriteLineDelegate _writeLine = ConsoleFunctions.WriteLine;
 
+        internal readonly Dictionary<KeyType, string> _configurationKeys = new Dictionary<KeyType, string>()
+        {
+            { KeyType.Authority,  "authority" },
+            { KeyType.HttpPath,  "useHttpPath" },
+            { KeyType.HttpProxy,  "httpProxy" },
+            { KeyType.HttpsProxy,  "httpsProxy" },
+            { KeyType.Interactive,  "interactive" },
+            { KeyType.LoginHint,  "loginhint" },
+            { KeyType.ModalPrompt,  "modalPrompt" },
+            { KeyType.Namespace,  "namespace" },
+            { KeyType.PreserveCredentials,  "preserve" },
+            { KeyType.TokenDuration,  "tokenDuration" },
+            { KeyType.Validate,  "validate" },
+            { KeyType.Writelog,  "writelog" },
+        };
+        internal readonly Dictionary<KeyType, string> _environmentKeys = new Dictionary<KeyType, string>()
+        {
+            { KeyType.Authority, "GCM_AUTHORITY" },
+            { KeyType.ConfigNoLocal, "GCM_CONFIG_NOLOCAL" },
+            { KeyType.ConfigNoSystem, "GCM_CONFIG_NOSYSTEM" },
+            { KeyType.GcmProxy, "GCM_HTTP_PROXY" },
+            { KeyType.HttpPath, "GCM_USE_HTTP_PATH" },
+            { KeyType.HttpProxy, "HTTP_PROXY" },
+            { KeyType.HttpsProxy, "HTTPS_PROXY" },
+            { KeyType.HttpUserAgent, "GCM_HTTP_USER_AGENT" },
+            { KeyType.Interactive, "GCM_INTERACTIVE" },
+            { KeyType.LoginHint, "GCM_LOGINHINT" },
+            { KeyType.ModalPrompt, "GCM_MODAL_PROMPT" },
+            { KeyType.Namespace, "GCM_NAMESPACE" },
+            { KeyType.PreserveCredentials, "GCM_PRESERVE_CREDS" },
+            { KeyType.TokenDuration, "GCM_TOKEN_DURATION" },
+            { KeyType.Validate, "GCM_VALIDATE" },
+            { KeyType.Writelog, "GCM_WRITELOG" },
+        };
+
         private string _executablePath;
         private string _location;
         private string _name;
         private string _title;
         private Version _version;
+
+        public IReadOnlyDictionary<KeyType, string> ConfigurationKeys
+            => _configurationKeys;
+
+        public IReadOnlyDictionary<KeyType, string> EnvironmentKeys
+            => _environmentKeys;
 
         /// <summary>
         /// Gets the path to the executable.
@@ -291,6 +325,19 @@ namespace Microsoft.Alm.Cli
         internal bool BitbucketOAuthPrompt(string title, TargetUri targetUri, Bitbucket.AuthenticationResultType resultType, string username)
             => _bitbucketOauthPrompt(this, title, targetUri, resultType, username);
 
+        internal string KeyTypeName(KeyType type)
+        {
+            string value = "UNKNOWN";
+
+            if (!_configurationKeys.TryGetValue(type, out value)
+                && !_environmentKeys.TryGetValue(type, out value))
+            {
+                Git.Trace.WriteLine($"BUG: unknown {nameof(KeyType)}: '{type}' encountered.");
+            }
+
+            return value;
+        }
+
         internal bool GitHubAuthCodePrompt(TargetUri targetUri, Github.GitHubAuthenticationResultType resultType, string username, out string authenticationCode)
             => _gitHubAuthCodePrompt(this, targetUri, resultType, username, out authenticationCode);
 
@@ -367,10 +414,10 @@ namespace Microsoft.Alm.Cli
         private bool StandardHandleIsTty(NativeMethods.StandardHandleType handleType)
             => _standardHandleIsTty(this, handleType);
 
-        internal bool TryReadBoolean(OperationArguments operationArguments, string configKey, string environKey, out bool? value)
-            => _tryReadBoolean(this, operationArguments, configKey, environKey, out value);
+        internal bool TryReadBoolean(OperationArguments operationArguments, KeyType key, out bool? value)
+            => _tryReadBoolean(this, operationArguments, key, out value);
 
-        internal bool TryReadString(OperationArguments operationArguments, string configKey, string environKey, out string value)
-            => _tryReadString(this, operationArguments, configKey, environKey, out value);
+        internal bool TryReadString(OperationArguments operationArguments, KeyType key, out string value)
+            => _tryReadString(this, operationArguments, key, out value);
     }
 }

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Alm.Cli
         PreserveCredentials,
         TokenDuration,
         Validate,
+        VstsScope,
         Writelog,
     }
 
@@ -114,6 +115,7 @@ namespace Microsoft.Alm.Cli
             { KeyType.PreserveCredentials,  "preserve" },
             { KeyType.TokenDuration,  "tokenDuration" },
             { KeyType.Validate,  "validate" },
+            { KeyType.VstsScope, "vstsScope" },
             { KeyType.Writelog,  "writelog" },
         };
         internal readonly Dictionary<KeyType, string> _environmentKeys = new Dictionary<KeyType, string>()
@@ -133,6 +135,7 @@ namespace Microsoft.Alm.Cli
             { KeyType.PreserveCredentials, "GCM_PRESERVE_CREDS" },
             { KeyType.TokenDuration, "GCM_TOKEN_DURATION" },
             { KeyType.Validate, "GCM_VALIDATE" },
+            { KeyType.VstsScope, "GCM_VSTS_SCOPE" },
             { KeyType.Writelog, "GCM_WRITELOG" },
         };
 

--- a/Microsoft.Alm.Authentication.Test/CredentialTests.cs
+++ b/Microsoft.Alm.Authentication.Test/CredentialTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Alm.Authentication.Test
                     new object[] { false, "http://dummy.url/for/testing", "", "blank_usernames_are_legal", false },
                     new object[] { false, "http://dummy.url/for/testing", "null_passwords_are_legal", null, false },
                     new object[] { false, "http://dummy.url/for/testing", "blank_passwords_are_legal", "", false },
-                    new object[] { false, "http://dummy.url/for/testing", "username", "password", false },
                     new object[] { false, "http://dummy.url:999/for/testing", "username", "password", false },
 
                     new object[] { true, "http://dummy.url/for/testing", "username", "password", false },
@@ -31,7 +30,6 @@ namespace Microsoft.Alm.Authentication.Test
                     new object[] { true, "http://dummy.url/for/testing", "", "blank_usernames_are_legal", false },
                     new object[] { true, "http://dummy.url/for/testing", "null_passwords_are_legal", null, false },
                     new object[] { true, "http://dummy.url/for/testing", "blank_passwords_are_legal", "", false },
-                    new object[] { true, "http://dummy.url/for/testing", "username", "password", false },
                     new object[] { true, "http://dummy.url:999/for/testing", "username", "password", false },
                 };
 

--- a/Microsoft.Alm.Authentication.Test/CredentialTests.cs
+++ b/Microsoft.Alm.Authentication.Test/CredentialTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Alm.Authentication.Test
         }
 
         [Theory]
-        [MemberData(nameof(CredentialData))]
+        [MemberData(nameof(CredentialData), DisableDiscoveryEnumeration = true)]
         public void Credential_WriteDelete(bool useCache, string url, string username, string password, bool throws)
         {
             Action action = () =>
@@ -94,7 +94,7 @@ namespace Microsoft.Alm.Authentication.Test
         }
 
         [Theory]
-        [MemberData(nameof(UriToNameData))]
+        [MemberData(nameof(UriToNameData), DisableDiscoveryEnumeration = true)]
         public void UriToName(string original, string expected)
         {
             var uri = new Uri(original);

--- a/Microsoft.Alm.Authentication.Test/TargetUriTests.cs
+++ b/Microsoft.Alm.Authentication.Test/TargetUriTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Alm.Authentication.Test
         }
 
         [Theory]
-        [MemberData(nameof(UrlData))]
+        [MemberData(nameof(UrlData), DisableDiscoveryEnumeration = true)]
         public void TargetUri_Basics(string actualUrl, string queryUrl, string proxyUrl)
         {
             TargetUri targetUri;
@@ -89,7 +89,7 @@ namespace Microsoft.Alm.Authentication.Test
         }
 
         [Theory]
-        [MemberData(nameof(UrlData))]
+        [MemberData(nameof(UrlData), DisableDiscoveryEnumeration = true)]
         public void TargetUri_WebProxy(string actualUrl, string queryUrl, string proxyUrl)
         {
             var targetUri = new TargetUri(actualUrl, queryUrl, proxyUrl);
@@ -108,7 +108,7 @@ namespace Microsoft.Alm.Authentication.Test
         }
 
         [Theory]
-        [MemberData(nameof(UrlData))]
+        [MemberData(nameof(UrlData), DisableDiscoveryEnumeration = true)]
         public void TargetUri_HttpClientHandler(string actualUrl, string queryUrl, string proxyUrl)
         {
             var targetUri = new TargetUri(actualUrl, queryUrl, proxyUrl);

--- a/Microsoft.Alm.Authentication.Test/TokenTests.cs
+++ b/Microsoft.Alm.Authentication.Test/TokenTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Alm.Authentication.Test
         }
 
         [Theory]
-        [MemberData(nameof(TokenStoreData))]
+        [MemberData(nameof(TokenStoreData), DisableDiscoveryEnumeration = true)]
         public void Token_WriteDelete(bool useCache, string secretName, string url, string token)
         {
             var tokenStore = useCache

--- a/Microsoft.Alm.Git.Test/ConfigurationTests.cs
+++ b/Microsoft.Alm.Git.Test/ConfigurationTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Alm.Git.Test
                     values[level] = dict;
                 }
 
-                cut = new Configuration.Impl(values);
+                cut = new Configuration(values);
             }
 
             Assert.True(cut.ContainsKey("CoRe.AuToCrLf"));

--- a/Microsoft.Alm.Git.Test/ConfigurationTests.cs
+++ b/Microsoft.Alm.Git.Test/ConfigurationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Alm.Git.Test
         }
 
         [Theory]
-        [MemberData(nameof(ParseData))]
+        [MemberData(nameof(ParseData), DisableDiscoveryEnumeration = true)]
         public void GitConfif_Parse(string input, string expectedName, string expected, bool ignoreCase)
         {
             var values = TestParseGitConfig(input);

--- a/Microsoft.Alm.Git.Test/WhereTests.cs
+++ b/Microsoft.Alm.Git.Test/WhereTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Alm.Git.Test
         }
 
         [Theory]
-        [MemberData(nameof(FindAppData))]
+        [MemberData(nameof(FindAppData), DisableDiscoveryEnumeration = true)]
         public void Where_FindApp(string app)
         {
             string path1;

--- a/Microsoft.Vsts.Authentication/VstsTokenScope.cs
+++ b/Microsoft.Vsts.Authentication/VstsTokenScope.cs
@@ -23,7 +23,9 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using ScopeSet = System.Collections.Generic.HashSet<string>;
 
@@ -61,14 +63,14 @@ namespace Microsoft.Alm.Authentication
 
         /// <summary>
         /// Grants the ability to read, update, and delete source code, access metadata about
-        /// commits, changesets, branches, and other version control artifacts. Also grants the
+        /// commits, change-sets, branches, and other version control artifacts. Also grants the
         /// ability to create and manage code repositories, create and manage pull requests and code
         /// reviews, and to receive notifications about version control events via service hooks.
         /// </summary>
         public static readonly VstsTokenScope CodeManage = new VstsTokenScope("vso.code_manage");
 
         /// <summary>
-        /// Grants the ability to read source code and metadata about commits, changesets, branches,
+        /// Grants the ability to read source code and metadata about commits, change-sets, branches,
         /// and other version control artifacts. Also grants the ability to get notified about
         /// version control events via service hooks.
         /// </summary>
@@ -76,7 +78,7 @@ namespace Microsoft.Alm.Authentication
 
         /// <summary>
         /// Grants the ability to read, update, and delete source code, access metadata about
-        /// commits, changesets, branches, and other version control artifacts. Also grants the
+        /// commits, change-sets, branches, and other version control artifacts. Also grants the
         /// ability to create and manage pull requests and code reviews and to receive notifications
         /// about version control events via service hooks.
         /// </summary>
@@ -175,6 +177,13 @@ namespace Microsoft.Alm.Authentication
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public bool Equals(VstsTokenScope other)
             => TokenScope.Equals(this as TokenScope, other as TokenScope);
+
+        public static bool Find(string value, out VstsTokenScope vstsScope)
+        {
+            vstsScope = EnumerateValues().FirstOrDefault(v => StringComparer.OrdinalIgnoreCase.Equals(v.Value, value));
+
+            return vstsScope != null;
+        }
 
         public override int GetHashCode()
             => TokenScope.GetHashCode(this as TokenScope);


### PR DESCRIPTION
Instead of keeping each configuration key and each environment key as a separately declared global constant, define a set of possible keys as an enumeration. Then define a look up of type -> key for configuration keys, and for environment keys.

Update the `LoadOperationArguments` and related functions to use the new schema. This is code clean up and 'correctness' change.