### PR TITLE
Connect Config Set Token Scopes and PAT Generation.

### DIFF
--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Alm.Cli
                     }
 
                     // Return the allocated authority or a generic AAD backed VSTS authentication object.
-                    return authority ?? new VstsAadAuthentication(tenantId, Program.VstsCredentialScope, secrets);
+                    return authority ?? new VstsAadAuthentication(tenantId, operationArguments.VstsTokenScope, secrets);
 
                 case AuthorityType.Basic:
                     // Enforce basic authentication only.

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Alm.Cli
         public OperationArguments(Stream readableStream)
                 : this()
         {
-            if (ReferenceEquals(readableStream, null))
+            if (readableStream is null)
                 throw new ArgumentNullException(nameof(readableStream));
 
             if (readableStream == Stream.Null || !readableStream.CanRead)
@@ -123,7 +123,7 @@ namespace Microsoft.Alm.Cli
         public OperationArguments(Uri targetUri)
             : this()
         {
-            if (ReferenceEquals(targetUri, null))
+            if (targetUri is null)
                 throw new ArgumentNullException("targetUri");
 
             _queryProtocol = targetUri.Scheme;
@@ -446,7 +446,7 @@ namespace Microsoft.Alm.Cli
         /// <param name="writableStream">The <see cref="Stream"/> to write to.</param>
         public virtual void WriteToStream(Stream writableStream)
         {
-            if (ReferenceEquals(writableStream, null))
+            if (writableStream is null)
                 throw new ArgumentNullException(nameof(writableStream));
             if (!writableStream.CanWrite)
                 throw new ArgumentException("CanWrite property returned false.", nameof(writableStream));

--- a/Microsoft.Vsts.Authentication/BaseVstsAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/BaseVstsAuthentication.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Alm.Authentication
 
         protected BaseVstsAuthentication(VstsTokenScope tokenScope, ICredentialStore personalAccessTokenStore)
         {
-            if (ReferenceEquals(tokenScope, null))
+            if (tokenScope is null)
                 throw new ArgumentNullException(nameof(tokenScope));
-            if (ReferenceEquals(personalAccessTokenStore, null))
+            if (personalAccessTokenStore is null)
                 throw new ArgumentNullException(nameof(personalAccessTokenStore));
 
             ClientId = DefaultClientId;
@@ -65,9 +65,9 @@ namespace Microsoft.Alm.Authentication
             IVstsAuthority vstsAuthority)
             : this(VstsTokenScope.ProfileRead, personalAccessTokenStore)
         {
-            if (ReferenceEquals(vstsIdeTokenCache, null))
+            if (vstsIdeTokenCache is null)
                 throw new ArgumentNullException(nameof(vstsIdeTokenCache));
-            if (ReferenceEquals(vstsAuthority, null))
+            if (vstsAuthority is null)
                 throw new ArgumentNullException(nameof(vstsAuthority));
 
             VstsIdeTokenCache = vstsIdeTokenCache;
@@ -90,8 +90,8 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         public readonly VstsTokenScope TokenScope;
 
-        internal readonly TokenCache VstsAdalTokenCache;
-        internal readonly ITokenStore VstsIdeTokenCache;
+        internal TokenCache VstsAdalTokenCache { get; private set; }
+        internal ITokenStore VstsIdeTokenCache{ get; private set; }
 
         internal ICredentialStore PersonalAccessTokenStore { get; set; }
         internal IVstsAuthority VstsAuthority { get; set; }
@@ -370,7 +370,7 @@ namespace Microsoft.Alm.Authentication
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
-            if (ReferenceEquals(accessToken, null))
+            if (accessToken is null)
                 throw new ArgumentNullException(nameof(accessToken));
 
             Credential credential = null;


### PR DESCRIPTION
Turns out passing unit tests doesn't actually help end-users unless the product code works too. Fixing that.

A few minor code cleanup changes inspired by Visual Studio nag messages.