### PR TITLE
Add missing break; in retry logic

### DIFF
--- a/Microsoft.Vsts.Authentication/BaseVstsAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/BaseVstsAuthentication.cs
@@ -423,6 +423,7 @@ namespace Microsoft.Alm.Authentication
                     using (var reader = new StreamReader(inflate, encoding))
                     {
                         data = await reader.ReadToEndAsync();
+                        break;
                     }
                 }
                 catch when (i < 5)
@@ -524,6 +525,7 @@ namespace Microsoft.Alm.Authentication
                     using (var writer = new StreamWriter(deflate, encoding))
                     {
                         await writer.WriteAsync(data);
+                        break;
                     }
                 }
                 catch when (i < 5)


### PR DESCRIPTION
I was debugging something and while stepping through this code saw that it is missing a `break;` in the case of success.  Right now it reads and writes 5 times.