### PR TITLE
docs: Add ServicePointManager vs .NET Framework issue to FAQ.

### DIFF
--- a/Docs/Faq.md
+++ b/Docs/Faq.md
@@ -109,3 +109,9 @@ Error: cannot spawn askpass: No such file or directory
 Error encountered while pushing to the remote repository: Git failed with a fatal error.
 could not read Username for ‘https://******.********.***’: terminal prompts disabled
 ```
+
+## Q: Why doesn’t the GCM work with ServicePointManager?
+
+When you have `git config http.proxy` or `HTTPS_PROXY` configured to use [`ServicePointManager`](https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager?view=netframework-4.7.1) proxy, and the URL doesn’t begin with "http://" the GCM will be unable to negotiate with the proxy. This is due the way the .NET Framework [`WebProxy`](https://docs.microsoft.com/en-us/dotnet/api/system.net.webproxy?view=netframework-4.7.1) and `ServicePointManager` interact. You can read "[ServicePointManager does not support proxies of https scheme](https://blogs.msdn.microsoft.com/jpsanders/2007/04/25/the-servicepointmanager-does-not-support-proxies-of-https-scheme-net-1-1-sp1/)" for additional information about this issue.
+
+The work around is to use a proxy URL which starts with "http://", or discontinue use of `ServicePointManager`.


### PR DESCRIPTION
## Q: Why doesn’t the GCM work with ServicePointManager?

When you have `git config http.proxy` or `HTTPS_PROXY` configured to use [`ServicePointManager`](https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager?view=netframework-4.7.1) proxy, and the URL doesn’t begin with "http://" the GCM will be unable to negotiate with the proxy. This is due the way the .NET Framework [`WebProxy`](https://docs.microsoft.com/en-us/dotnet/api/system.net.webproxy?view=netframework-4.7.1) and `ServicePointManager` interact. You can read "[ServicePointManager does not support proxies of https scheme](https://blogs.msdn.microsoft.com/jpsanders/2007/04/25/the-servicepointmanager-does-not-support-proxies-of-https-scheme-net-1-1-sp1/)" for additional information about this issue.

The work around is to use a proxy URL which starts with "http://", or discontinue use of `ServicePointManager`.

Resolves #551