### PR TITLE
Fix console prompt for credentials.

### DIFF
--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Alm.Cli
         internal static readonly StringComparer ConfigKeyComparer = StringComparer.OrdinalIgnoreCase;
         internal static readonly StringComparer ConfigValueComparer = StringComparer.OrdinalIgnoreCase;
 
+        internal const string EnvironConfigDebugKey = "GCM_DEBUG";
         internal const string EnvironConfigTraceKey = Git.Trace.EnvironmentVariableKey;
 
         internal static readonly StringComparer EnvironKeyComparer = StringComparer.OrdinalIgnoreCase;
@@ -148,6 +149,8 @@ namespace Microsoft.Alm.Cli
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static Program()
         {
+            DebuggerLaunch();
+
             ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
         }
 
@@ -365,6 +368,23 @@ namespace Microsoft.Alm.Cli
 
                     return _stdOutStream;
                 }
+            }
+        }
+
+        internal static void DebuggerLaunch()
+        {
+            if (Debugger.IsAttached)
+                return;
+
+            string debug = Environment.GetEnvironmentVariable(EnvironConfigDebugKey);
+            if (debug != null
+                && (StringComparer.OrdinalIgnoreCase.Equals(debug, "true")
+                    || StringComparer.OrdinalIgnoreCase.Equals(debug, "1")
+                    || StringComparer.OrdinalIgnoreCase.Equals(debug, "debug")))
+            {
+                Git.Trace.WriteLine($"'{EnvironConfigDebugKey}': '{debug}', launching debugger...");
+
+                Debugger.Launch();
             }
         }
 


### PR DESCRIPTION
When prompting users for credentials via the console, the normal `IsTty` isn't useful as standard input is almost never a TTY handle. Instead, the handles borrowed from the console directly should be investigated.

Thanks to @dhirschfeld for originally reporting the issue, and special thanks to @dscho for creating a minimum viable reproduction of the issue which lead to a immediate root cause and bug-fix.

Resolves #455