### PR TITLE
Trace-as-a-Service

### DIFF
--- a/Bitbucket.Authentication/Authentication.cs
+++ b/Bitbucket.Authentication/Authentication.cs
@@ -27,8 +27,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
 
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
-
 namespace Atlassian.Bitbucket.Authentication
 {
     /// <summary>
@@ -301,7 +299,7 @@ namespace Atlassian.Bitbucket.Authentication
             if (targetUri.QueryUri.DnsSafeHost.EndsWith(BitbucketBaseUrlHost, StringComparison.OrdinalIgnoreCase))
             {
                 authentication = new Authentication(context, personalAccessTokenStore, acquireCredentialsCallback, acquireAuthenticationOAuthCallback);
-                Trace.WriteLine("authentication for Bitbucket created");
+                context.Trace.WriteLine("authentication for Bitbucket created");
             }
             else
             {

--- a/Bitbucket.Authentication/AuthenticationPrompts.cs
+++ b/Bitbucket.Authentication/AuthenticationPrompts.cs
@@ -35,7 +35,6 @@ using Atlassian.Bitbucket.Authentication.Views;
 using GitHub.Shared.Controls;
 using GitHub.Shared.ViewModels;
 using Microsoft.Alm.Authentication;
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
 
 namespace Atlassian.Bitbucket.Authentication
 {

--- a/Bitbucket.Authentication/Authority.cs
+++ b/Bitbucket.Authentication/Authority.cs
@@ -30,7 +30,6 @@ using System.Threading.Tasks;
 using Atlassian.Bitbucket.Authentication.BasicAuth;
 using Atlassian.Bitbucket.Authentication.Rest;
 using Microsoft.Alm.Authentication;
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
 
 namespace Atlassian.Bitbucket.Authentication
 {

--- a/Bitbucket.Authentication/OAuth/OAuthAuthenticator.cs
+++ b/Bitbucket.Authentication/OAuth/OAuthAuthenticator.cs
@@ -34,8 +34,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
 
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
-
 namespace Atlassian.Bitbucket.Authentication.OAuth
 {
     /// <summary>

--- a/Bitbucket.Authentication/Rest/RestClient.cs
+++ b/Bitbucket.Authentication/Rest/RestClient.cs
@@ -72,7 +72,7 @@ namespace Atlassian.Bitbucket.Authentication.Rest
             }
         }
 
-        private static string FindUsername(string responseText)
+        private string FindUsername(string responseText)
         {
             Match usernameMatch;
             if ((usernameMatch = UsernameRegex.Match(responseText)).Success

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Alm.Cli
             _context = context;
 
             Title = AssemblyTitle;
+
+            DebuggerLaunch(this);
         }
 
         internal static bool TryParseUrlCredentials(string targetUrl, out string username, out string password)
@@ -122,7 +124,7 @@ namespace Microsoft.Alm.Cli
 
             if (match.Success)
             {
-                Git.Trace.WriteLine("querying for passphrase key.");
+                _context.Trace.WriteLine("querying for passphrase key.");
 
                 if (match.Groups.Count < 2)
                     throw new ArgumentException("Unable to understand command.");
@@ -130,7 +132,7 @@ namespace Microsoft.Alm.Cli
                 // string request = match.Groups[0].Value;
                 string resource = match.Groups[1].Value;
 
-                Git.Trace.WriteLine($"open dialog for '{resource}'.");
+                _context.Trace.WriteLine($"open dialog for '{resource}'.");
 
                 System.Windows.Application application = new System.Windows.Application();
                 Gui.UserPromptDialog prompt = new Gui.UserPromptDialog(promptKind, resource);
@@ -140,7 +142,7 @@ namespace Microsoft.Alm.Cli
                 {
                     string passphase = prompt.Response;
 
-                    Git.Trace.WriteLine("passphase acquired.");
+                    _context.Trace.WriteLine("passphase acquired.");
 
                     Out.Write(passphase + "\n");
                     return;
@@ -151,7 +153,7 @@ namespace Microsoft.Alm.Cli
 
             if ((match = AskCredentialRegex.Match(args[0])).Success)
             {
-                Git.Trace.WriteLine("querying for basic credentials.");
+                _context.Trace.WriteLine("querying for basic credentials.");
 
                 if (match.Groups.Count < 3)
                     throw new ArgumentException("Unable to understand command.");
@@ -166,7 +168,7 @@ namespace Microsoft.Alm.Cli
                 // Since we're looking for HTTP(s) credentials, we can use NetFx `Uri` class.
                 if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                 {
-                    Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
+                    _context.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
                     if (TryParseUrlCredentials(targetUrl, out username, out password))
                     {
@@ -213,9 +215,9 @@ namespace Microsoft.Alm.Cli
 
                     if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                     {
-                        Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
+                        _context.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
-                        OperationArguments operationArguments = new OperationArguments(targetUri);
+                        OperationArguments operationArguments = new OperationArguments(_context, targetUri);
                         operationArguments.SetCredentials(username ?? string.Empty, password ?? string.Empty);
 
                         // Load up the operation arguments, enable tracing, and query for credentials.
@@ -229,7 +231,7 @@ namespace Microsoft.Alm.Cli
                             {
                                 if (seeking.Equals("Username", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    Git.Trace.WriteLine($"username for '{targetUrl}' asked for and found.");
+                                    _context.Trace.WriteLine($"username for '{targetUrl}' asked for and found.");
 
                                     Out.Write(credentials.Username + '\n');
                                     return;
@@ -237,7 +239,7 @@ namespace Microsoft.Alm.Cli
 
                                 if (seeking.Equals("Password", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    Git.Trace.WriteLine($"password for '{targetUrl}' asked for and found.");
+                                    _context.Trace.WriteLine($"password for '{targetUrl}' asked for and found.");
 
                                     Out.Write(credentials.Password + '\n');
                                     return;
@@ -245,19 +247,19 @@ namespace Microsoft.Alm.Cli
                             }
                             else
                             {
-                                Git.Trace.WriteLine($"user cancelled credential dialog.");
+                                _context.Trace.WriteLine($"user cancelled credential dialog.");
                                 return;
                             }
                         }).Wait();
                     }
                     else
                     {
-                        Git.Trace.WriteLine("error: unable to parse target URL.");
+                        _context.Trace.WriteLine("error: unable to parse target URL.");
                     }
                 }
                 else
                 {
-                    Git.Trace.WriteLine("error: unable to parse supplied URL.");
+                    _context.Trace.WriteLine("error: unable to parse supplied URL.");
                 }
 
                 Die($"failed to detect {seeking} in target URL.");
@@ -268,7 +270,7 @@ namespace Microsoft.Alm.Cli
                 string host = match.Groups[1].Value;
                 string fingerprint = match.Groups[2].Value;
 
-                Git.Trace.WriteLine($"requesting authorization to add {host} ({fingerprint}) to known hosts.");
+                _context.Trace.WriteLine($"requesting authorization to add {host} ({fingerprint}) to known hosts.");
 
                 System.Windows.Application application = new System.Windows.Application();
                 Gui.UserPromptDialog prompt = new Gui.UserPromptDialog(host, fingerprint);
@@ -276,12 +278,12 @@ namespace Microsoft.Alm.Cli
 
                 if (prompt.Failed)
                 {
-                    Git.Trace.WriteLine("denied authorization of host.");
+                    _context.Trace.WriteLine("denied authorization of host.");
                     Out.Write("no\n");
                 }
                 else
                 {
-                    Git.Trace.WriteLine("approved authorization of host.");
+                    _context.Trace.WriteLine("approved authorization of host.");
                     Out.Write("yes\n");
                 }
 
@@ -309,7 +311,7 @@ namespace Microsoft.Alm.Cli
                         // if the help file exists, send it to the operating system to display to the user
                         if (File.Exists(doc))
                         {
-                            Git.Trace.WriteLine($"opening help documentation '{doc}'.");
+                            _context.Trace.WriteLine($"opening help documentation '{doc}'.");
 
                             Process.Start(doc);
 

--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Microsoft.Alm.Authentication;
 using Xunit;
 
 namespace Microsoft.Alm.Cli.Test
@@ -30,7 +31,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                cut = new OperationArguments(memory);
+                cut = new OperationArguments(RuntimeContext.Default, memory);
             }
 
             Assert.Equal(input.Protocol, cut.QueryProtocol);
@@ -68,7 +69,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                cut = new OperationArguments(memory);
+                cut = new OperationArguments(RuntimeContext.Default, memory);
             }
 
             Assert.Equal(input.Protocol, cut.QueryProtocol, StringComparer.Ordinal);
@@ -194,7 +195,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                var oparg = new OperationArguments(memory);
+                var oparg = new OperationArguments(RuntimeContext.Default, memory);
 
                 Assert.NotNull(oparg);
                 Assert.Equal(input.Protocol ?? string.Empty, oparg.QueryProtocol, StringComparer.Ordinal);

--- a/Cli-CredentialHelper.Test/ProgramTests.cs
+++ b/Cli-CredentialHelper.Test/ProgramTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Alm.Cli.Test
             {
                 { "HOME", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
             };
-            var gitconfig = new Git.Configuration(configs);
+            var gitconfig = new Git.Configuration(RuntimeContext.Default, configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();
@@ -200,7 +200,7 @@ namespace Microsoft.Alm.Cli.Test
             if (!setupComplete)
                 return;
 
-            var gitconfig = new Git.Configuration(configs);
+            var gitconfig = new Git.Configuration(RuntimeContext.Default, configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();
@@ -294,7 +294,7 @@ namespace Microsoft.Alm.Cli.Test
             if (!setupComplete)
                 return;
 
-            var gitconfig = new Git.Configuration(configs);
+            var gitconfig = new Git.Configuration(RuntimeContext.Default, configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentException(innerException.Message, nameof(operationArguments), innerException);
             }
 
+            var trace = program.Context.Trace;
             var secretsNamespace = operationArguments.CustomNamespace ?? Program.SecretsNamespace;
             BaseAuthentication authority = null;
 
@@ -81,7 +82,7 @@ namespace Microsoft.Alm.Cli
             switch (operationArguments.Authority)
             {
                 case AuthorityType.Auto:
-                    Git.Trace.WriteLine($"detecting authority type for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"detecting authority type for '{operationArguments.TargetUri}'.");
 
                     // Detect the authority.
                     authority = await BaseVstsAuthentication.GetAuthentication(program.Context,
@@ -128,12 +129,12 @@ namespace Microsoft.Alm.Cli
                     goto default;
 
                 case AuthorityType.AzureDirectory:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Azure Directory.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Azure Directory.");
 
                     Guid tenantId = Guid.Empty;
 
                     // Get the identity of the tenant.
-                    var result = await BaseVstsAuthentication.DetectAuthority(operationArguments.TargetUri);
+                    var result = await BaseVstsAuthentication.DetectAuthority(program.Context, operationArguments.TargetUri);
 
                     if (result.Key)
                     {
@@ -152,7 +153,7 @@ namespace Microsoft.Alm.Cli
                     goto default;
 
                 case AuthorityType.GitHub:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is GitHub.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is GitHub.");
 
                     // Return a GitHub authentication object.
                     return authority ?? new Github.Authentication(program.Context,
@@ -164,7 +165,7 @@ namespace Microsoft.Alm.Cli
                                                                   null);
 
                 case AuthorityType.Bitbucket:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}'  is Bitbucket");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}'  is Bitbucket");
 
                     // Return a Bitbucket authentication object.
                     return authority ?? new Bitbucket.Authentication(program.Context,
@@ -173,7 +174,7 @@ namespace Microsoft.Alm.Cli
                                                                      bitbucketOauthCallback);
 
                 case AuthorityType.MicrosoftAccount:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Microsoft Live.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Microsoft Live.");
 
                     // Return the allocated authority or a generic MSA backed VSTS authentication object.
                     return authority ?? new VstsMsaAuthentication(program.Context,
@@ -186,7 +187,7 @@ namespace Microsoft.Alm.Cli
                     goto default;
 
                 default:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is basic with NTLM={basicNtlmSupport}.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is basic with NTLM={basicNtlmSupport}.");
 
                     // Return a generic username + password authentication object.
                     return authority ?? new BasicAuthentication(program.Context, 
@@ -204,28 +205,29 @@ namespace Microsoft.Alm.Cli
             if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
+            var trace = program.Context.Trace;
             BaseAuthentication authentication = await program.CreateAuthentication(operationArguments);
 
             switch (operationArguments.Authority)
             {
                 default:
                 case AuthorityType.Basic:
-                    Git.Trace.WriteLine($"deleting basic credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting basic credentials for '{operationArguments.TargetUri}'.");
                     return await authentication.DeleteCredentials(operationArguments.TargetUri);
 
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
-                    Git.Trace.WriteLine($"deleting VSTS credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting VSTS credentials for '{operationArguments.TargetUri}'.");
                     var vstsAuth = authentication as BaseVstsAuthentication;
                     return await vstsAuth.DeleteCredentials(operationArguments.TargetUri);
 
                 case AuthorityType.GitHub:
-                    Git.Trace.WriteLine($"deleting GitHub credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting GitHub credentials for '{operationArguments.TargetUri}'.");
                     var ghAuth = authentication as Github.Authentication;
                     return await ghAuth.DeleteCredentials(operationArguments.TargetUri);
 
                 case AuthorityType.Bitbucket:
-                    Git.Trace.WriteLine($"deleting Bitbucket credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting Bitbucket credentials for '{operationArguments.TargetUri}'.");
                     var bbAuth = authentication as Bitbucket.Authentication;
                     return await bbAuth.DeleteCredentials(operationArguments.TargetUri, operationArguments.Username);
             }
@@ -238,7 +240,7 @@ namespace Microsoft.Alm.Cli
             if (exception is null)
                 throw new ArgumentNullException(nameof(exception));
 
-            Git.Trace.WriteLine(exception.ToString(), path, line, name);
+            program.Context.Trace.WriteLine(exception.ToString(), path, line, name);
             program.LogEvent(exception.ToString(), EventLogEntryType.Error);
 
             string message;
@@ -273,14 +275,16 @@ namespace Microsoft.Alm.Cli
             if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
+            var trace = program.Context.Trace;
+
             if (operationArguments.WriteLog)
             {
-                Git.Trace.WriteLine("trace logging enabled.");
+                trace.WriteLine("trace logging enabled.");
 
                 string gitConfigPath;
                 if (Git.Where.GitLocalConfig(out gitConfigPath))
                 {
-                    Git.Trace.WriteLine($"git local config found at '{gitConfigPath}'.");
+                    trace.WriteLine($"git local config found at '{gitConfigPath}'.");
 
                     string gitDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -291,7 +295,7 @@ namespace Microsoft.Alm.Cli
                 }
                 else if (Git.Where.GitGlobalConfig(out gitConfigPath))
                 {
-                    Git.Trace.WriteLine($"git global config found at '{gitConfigPath}'.");
+                    trace.WriteLine($"git global config found at '{gitConfigPath}'.");
 
                     string homeDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -302,7 +306,7 @@ namespace Microsoft.Alm.Cli
                 }
             }
 #if DEBUG
-            Git.Trace.WriteLine($"GCM arguments:{Environment.NewLine}{operationArguments}");
+            trace.WriteLine($"GCM arguments:{Environment.NewLine}{operationArguments}");
 #endif
         }
 
@@ -317,6 +321,7 @@ namespace Microsoft.Alm.Cli
             if (logFilePath is null)
                 throw new ArgumentNullException(nameof(logFilePath));
 
+            var trace = program.Context.Trace;
             string logFileName = Path.Combine(logFilePath, Path.ChangeExtension(Program.ConfigPrefix, ".log"));
 
             var logFileInfo = new FileInfo(logFileName);
@@ -335,12 +340,12 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Git.Trace.WriteLine($"trace log destination is '{logFilePath}'.");
+            trace.WriteLine($"trace log destination is '{logFilePath}'.");
 
             using (var fileStream = File.Open(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
             {
                 var listener = new StreamWriter(fileStream, Encoding.UTF8);
-                Git.Trace.AddListener(listener);
+                trace.AddListener(listener);
 
                 // write a small header to help with identifying new log entries
                 listener.Write('\n');
@@ -361,19 +366,21 @@ namespace Microsoft.Alm.Cli
                 program.Die("No host information, unable to continue.");
             }
 
+            var trace = program.Context.Trace;
+
             string value;
             bool? yesno;
 
             if (program.TryReadBoolean(operationArguments, KeyType.ConfigNoLocal, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoLocal)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoLocal)} = '{yesno}'.");
 
                 operationArguments.UseConfigLocal = yesno.Value;
             }
 
             if (program.TryReadBoolean(operationArguments, KeyType.ConfigNoSystem, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoSystem)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoSystem)} = '{yesno}'.");
 
                 operationArguments.UseConfigSystem = yesno.Value;
             }
@@ -384,7 +391,7 @@ namespace Microsoft.Alm.Cli
             // If a user-agent has been specified in the environment, set it globally.
             if (program.TryReadString(operationArguments, KeyType.HttpUserAgent, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpUserAgent)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.HttpUserAgent)} = '{value}'.");
 
                 Global.UserAgent = value;
             }
@@ -392,7 +399,7 @@ namespace Microsoft.Alm.Cli
             // Look for authority settings.
             if (program.TryReadString(operationArguments, KeyType.Authority, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Authority)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Authority)} = '{value}'.");
 
                 if (Program.ConfigKeyComparer.Equals(value, "MSA")
                     || Program.ConfigKeyComparer.Equals(value, "Microsoft")
@@ -436,7 +443,7 @@ namespace Microsoft.Alm.Cli
             // Look for interactivity config settings.
             if (program.TryReadString(operationArguments, KeyType.Interactive, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Interactive)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Interactive)} = '{value}'.");
 
                 if (Program.ConfigKeyComparer.Equals(value, "always")
                     || Program.ConfigKeyComparer.Equals(value, "true")
@@ -454,7 +461,7 @@ namespace Microsoft.Alm.Cli
             // Look for credential validation config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.Validate, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Validate)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Validate)} = '{yesno}'.");
 
                 operationArguments.ValidateCredentials = yesno.Value;
             }
@@ -462,7 +469,7 @@ namespace Microsoft.Alm.Cli
             // Look for write log config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.Writelog, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Writelog)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Writelog)} = '{yesno}'.");
 
                 operationArguments.WriteLog = yesno.Value;
             }
@@ -470,7 +477,7 @@ namespace Microsoft.Alm.Cli
             // Look for modal prompt config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.ModalPrompt, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ModalPrompt)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.ModalPrompt)} = '{yesno}'.");
 
                 operationArguments.UseModalUi = yesno.Value;
             }
@@ -478,7 +485,7 @@ namespace Microsoft.Alm.Cli
             // Look for credential preservation config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.PreserveCredentials, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.PreserveCredentials)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.PreserveCredentials)} = '{yesno}'.");
 
                 operationArguments.PreserveCredentials = yesno.Value;
             }
@@ -489,18 +496,18 @@ namespace Microsoft.Alm.Cli
                     || StringComparer.OrdinalIgnoreCase.Equals(value, "1")
                     || StringComparer.OrdinalIgnoreCase.Equals(value, "on"))
                 {
-                    Git.Trace.WriteLine($"GCM_PRESERVE_CREDS = '{yesno}'.");
+                    trace.WriteLine($"GCM_PRESERVE_CREDS = '{yesno}'.");
 
                     operationArguments.PreserveCredentials = true;
 
-                    Git.Trace.WriteLine($"WARNING: the 'GCM_PRESERVE_CREDS' variable has been deprecated, use '{ program.KeyTypeName(KeyType.PreserveCredentials) }' instead.");
+                    trace.WriteLine($"WARNING: the 'GCM_PRESERVE_CREDS' variable has been deprecated, use '{ program.KeyTypeName(KeyType.PreserveCredentials) }' instead.");
                 }
             }
 
             // Look for HTTP path usage config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.HttpPath, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpPath)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.HttpPath)} = '{value}'.");
 
                 operationArguments.UseHttpPath = yesno.Value;
             }
@@ -510,7 +517,7 @@ namespace Microsoft.Alm.Cli
                     && program.TryReadString(operationArguments, KeyType.HttpsProxy, out value))
                 || program.TryReadString(operationArguments, KeyType.HttpProxy, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpProxy)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.HttpProxy)} = '{value}'.");
 
                 operationArguments.SetProxy(value);
             }
@@ -518,14 +525,14 @@ namespace Microsoft.Alm.Cli
             else if ((operationArguments.EnvironmentVariables.TryGetValue("GCM_HTTP_PROXY", out value)
                     && !string.IsNullOrWhiteSpace(value)))
             {
-                Git.Trace.WriteLine($"GCM_HTTP_PROXY = '{value}'.");
+                trace.WriteLine($"GCM_HTTP_PROXY = '{value}'.");
 
                 var keyName = (operationArguments.TargetUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                     ? "HTTPS_PROXY"
                     : "HTTP_PROXY";
                 var warning = $"WARNING: the 'GCM_HTTP_PROXY' variable has been deprecated, use '{ keyName }' instead.";
 
-                Git.Trace.WriteLine(warning);
+                trace.WriteLine(warning);
                 program.WriteLine(warning);
 
                 operationArguments.SetProxy(value);
@@ -537,7 +544,7 @@ namespace Microsoft.Alm.Cli
                 if (operationArguments.GitConfiguration.TryGetEntry("http", operationArguments.QueryUri, "proxy", out entry)
                     && !string.IsNullOrWhiteSpace(entry.Value))
                 {
-                    Git.Trace.WriteLine($"http.proxy = '{entry.Value}'.");
+                    trace.WriteLine($"http.proxy = '{entry.Value}'.");
 
                     operationArguments.SetProxy(entry.Value);
                 }
@@ -546,7 +553,7 @@ namespace Microsoft.Alm.Cli
             // Look for custom namespace config settings.
             if (program.TryReadString(operationArguments, KeyType.Namespace, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Namespace)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Namespace)} = '{value}'.");
 
                 operationArguments.CustomNamespace = value;
             }
@@ -554,7 +561,7 @@ namespace Microsoft.Alm.Cli
             // Look for custom token duration settings.
             if (program.TryReadString(operationArguments, KeyType.TokenDuration, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.TokenDuration)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.TokenDuration)} = '{value}'.");
 
                 int hours;
                 if (int.TryParse(value, out hours))
@@ -566,7 +573,7 @@ namespace Microsoft.Alm.Cli
             // Look for custom VSTS scope settings.
             if (program.TryReadString(operationArguments, KeyType.VstsScope, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.VstsScope)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.VstsScope)} = '{value}'.");
 
                 VstsTokenScope vstsTokenScope = VstsTokenScope.None;
 
@@ -581,7 +588,7 @@ namespace Microsoft.Alm.Cli
                     }
                     else
                     {
-                        Git.Trace.WriteLine($"Unknown VSTS Token scope: '{scopes[i]}'.");
+                        trace.WriteLine($"Unknown VSTS Token scope: '{scopes[i]}'.");
                     }
                 }
 
@@ -591,7 +598,7 @@ namespace Microsoft.Alm.Cli
             // Check for configuration supplied user-info.
             if (program.TryReadString(operationArguments, KeyType.Username, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Username)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Username)} = '{value}'.");
 
                 operationArguments.Username = value;
             }
@@ -606,7 +613,7 @@ namespace Microsoft.Alm.Cli
 
             /*** try-squelch due to UAC issues which require a proper installer to work around ***/
 
-            Git.Trace.WriteLine(message);
+            program.Context.Trace.WriteLine(message);
 
             try
             {
@@ -641,7 +648,7 @@ namespace Microsoft.Alm.Cli
             }
 
             // Fake being part of the Main method for clarity.
-            Git.Trace.WriteLine(builder.ToString(), memberName: "Main");
+            program.Context.Trace.WriteLine(builder.ToString(), memberName: "Main");
             builder = null;
         }
 
@@ -659,6 +666,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentException(innerException.Message, nameof(operationArguments), innerException);
             }
 
+            var trace = program.Context.Trace;
             BaseAuthentication authentication = await program.CreateAuthentication(operationArguments);
             Credential credentials = null;
 
@@ -675,13 +683,13 @@ namespace Microsoft.Alm.Cli
                             || (operationArguments.Interactivity != Interactivity.Never
                                 && (credentials = await basicAuth.AcquireCredentials(operationArguments.TargetUri)) != null))
                         {
-                            Git.Trace.WriteLine("credentials found.");
+                            trace.WriteLine("credentials found.");
                             // No need to save the credentials explicitly, as Git will call back
                             // with a store command if the credentials are valid.
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -712,12 +720,12 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await aadAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             program.LogEvent($"Azure Directory credentials  for '{operationArguments.TargetUri}' successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve Azure Directory credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -744,12 +752,12 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await msaAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             program.LogEvent($"Microsoft Live credentials for '{operationArguments.TargetUri}' successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve Microsoft Live credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -768,12 +776,12 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await ghAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             program.LogEvent($"GitHub credentials for '{operationArguments.TargetUri}' successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve GitHub credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -792,7 +800,7 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || ((credentials = await bbcAuth.ValidateCredentials(operationArguments.TargetUri, operationArguments.Username, credentials)) != null))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             // Bitbucket relies on a username + secret, so make sure there is a
                             // username to return.
                             if (operationArguments.Username != null)
@@ -810,7 +818,7 @@ namespace Microsoft.Alm.Cli
 
                 case AuthorityType.Ntlm:
                     {
-                        Git.Trace.WriteLine($"'{operationArguments.TargetUri}' is NTLM.");
+                        trace.WriteLine($"'{operationArguments.TargetUri}' is NTLM.");
                         credentials = BasicAuthentication.NtlmCredentials;
                     }
                     break;

--- a/Cli-Shared/Functions/Console.cs
+++ b/Cli-Shared/Functions/Console.cs
@@ -43,7 +43,12 @@ namespace Microsoft.Alm.Cli
             // ReadConsole 32768 fail, 32767 OK @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
             const int BufferReadSize = 16 * 1024;
 
-            Debug.Assert(targetUri != null);
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            var trace = program.Context.Trace;
 
             titleMessage = titleMessage ?? "Please enter your credentials for ";
 
@@ -64,7 +69,7 @@ namespace Microsoft.Alm.Cli
                 // Read the current console mode.
                 if (stdin.IsInvalid || stdout.IsInvalid)
                 {
-                    Git.Trace.WriteLine("not a tty detected, abandoning prompt.");
+                    trace.WriteLine("not a tty detected, abandoning prompt.");
                     return null;
                 }
                 else if (!NativeMethods.GetConsoleMode(stdin, out consoleMode))
@@ -73,7 +78,7 @@ namespace Microsoft.Alm.Cli
                     throw new Win32Exception(error, "Unable to determine console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                 }
 
-                Git.Trace.WriteLine($"console mode = '{consoleMode}'.");
+                trace.WriteLine($"console mode = '{consoleMode}'.");
 
                 string username = null;
                 string password = null;
@@ -127,7 +132,7 @@ namespace Microsoft.Alm.Cli
                         throw new Win32Exception(error, "Unable to set console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                     }
 
-                    Git.Trace.WriteLine($"console mode = '{consoleMode2}'.");
+                    trace.WriteLine($"console mode = '{consoleMode2}'.");
 
                     // Prompt the user for password.
                     buffer.Append("password: ");
@@ -156,7 +161,7 @@ namespace Microsoft.Alm.Cli
                     // Restore the console mode to its original value.
                     NativeMethods.SetConsoleMode(stdin, consoleMode);
 
-                    Git.Trace.WriteLine($"console mode = '{consoleMode}'.");
+                    trace.WriteLine($"console mode = '{consoleMode}'.");
                 }
 
                 if (username != null && password != null)
@@ -168,13 +173,18 @@ namespace Microsoft.Alm.Cli
 
         public static void Exit(Program program, int exitcode, string message, string path, int line, string name)
         {
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+
+            var trace = program.Context.Trace;
+
             if (!string.IsNullOrWhiteSpace(message))
             {
-                Git.Trace.WriteLine(message, path, line, name);
+                trace.WriteLine(message, path, line, name);
                 program.WriteLine(message);
             }
 
-            Git.Trace.Flush();
+            trace.Flush();
 
             Environment.Exit(exitcode);
         }

--- a/Cli-Shared/Functions/Dialog.cs
+++ b/Cli-Shared/Functions/Dialog.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Alm.Cli
             if (program is null)
                 throw new ArgumentNullException(nameof(program));
 
+            var trace = program.Context.Trace;
+
             int error;
 
             try
@@ -64,7 +66,7 @@ namespace Microsoft.Alm.Cli
                                                                              saveCredentials: ref saveCredentials,
                                                                              flags: flags)) != NativeMethods.Win32Error.Success)
                 {
-                    Git.Trace.WriteLine($"credential prompt failed ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"credential prompt failed ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     username = null;
                     password = null;
@@ -95,12 +97,12 @@ namespace Microsoft.Alm.Cli
                     password = null;
 
                     error = Marshal.GetLastWin32Error();
-                    Git.Trace.WriteLine($"failed to unpack buffer ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"failed to unpack buffer ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     return false;
                 }
 
-                Git.Trace.WriteLine("successfully acquired credentials from user.");
+                trace.WriteLine("successfully acquired credentials from user.");
 
                 username = usernameBuffer.ToString();
                 password = passwordBuffer.ToString();
@@ -188,6 +190,8 @@ namespace Microsoft.Alm.Cli
             int inBufferSize = 0;
             string password = null;
 
+            var trace = program.Context.Trace;
+
             try
             {
                 int error;
@@ -202,7 +206,7 @@ namespace Microsoft.Alm.Cli
                 if (inBufferSize <= 0)
                 {
                     error = Marshal.GetLastWin32Error();
-                    Git.Trace.WriteLine($"unable to determine credential buffer size ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"unable to determine credential buffer size ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     return null;
                 }
@@ -216,7 +220,7 @@ namespace Microsoft.Alm.Cli
                                                                 packedCredentialsSize: ref inBufferSize))
                 {
                     error = Marshal.GetLastWin32Error();
-                    Git.Trace.WriteLine($"unable to write to credential buffer ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"unable to write to credential buffer ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     return null;
                 }

--- a/Cli-Shared/Functions/GitHub.cs
+++ b/Cli-Shared/Functions/GitHub.cs
@@ -42,7 +42,12 @@ namespace Microsoft.Alm.Cli
             // ReadConsole 32768 fail, 32767 ok @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
             const int BufferReadSize = 16 * 1024;
 
-            Debug.Assert(targetUri != null);
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            var trace = program.Context.Trace;
 
             StringBuilder buffer = new StringBuilder(BufferReadSize);
             uint read = 0;
@@ -62,7 +67,7 @@ namespace Microsoft.Alm.Cli
                     ? "app"
                     : "sms";
 
-                Git.Trace.WriteLine($"2fa type = '{type}'.");
+                trace.WriteLine($"2fa type = '{type}'.");
 
                 buffer.AppendLine()
                       .Append("authcode (")

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -34,10 +34,10 @@ using Git = Microsoft.Alm.Authentication.Git;
 
 namespace Microsoft.Alm.Cli
 {
-    internal class OperationArguments
+    internal class OperationArguments : Base
     {
-        public OperationArguments(Stream readableStream)
-                : this()
+        public OperationArguments(RuntimeContext context, Stream readableStream)
+                : this(context)
         {
             if (readableStream is null)
                 throw new ArgumentNullException(nameof(readableStream));
@@ -141,8 +141,8 @@ namespace Microsoft.Alm.Cli
             CreateTargetUri();
         }
 
-        public OperationArguments(Uri targetUri)
-            : this()
+        public OperationArguments(RuntimeContext context, Uri targetUri)
+            : this(context)
         {
             if (targetUri is null)
                 throw new ArgumentNullException("targetUri");
@@ -156,7 +156,8 @@ namespace Microsoft.Alm.Cli
             CreateTargetUri();
         }
 
-        public OperationArguments()
+        public OperationArguments(RuntimeContext context)
+            : base(context)
         {
             _authorityType = AuthorityType.Auto;
             _interactivity = Interactivity.Auto;
@@ -166,6 +167,11 @@ namespace Microsoft.Alm.Cli
             _validateCredentials = true;
             _vstsTokenScope = Program.VstsCredentialScope;
         }
+
+        // Test-only constructor
+        internal OperationArguments()
+            : this(RuntimeContext.Default)
+        { }
 
         private AuthorityType _authorityType;
         private Git.Configuration _configuration;
@@ -403,7 +409,7 @@ namespace Microsoft.Alm.Cli
 
         public virtual async Task LoadConfiguration()
         {
-            _configuration = await Git.Configuration.ReadConfiuration(Environment.CurrentDirectory, UseConfigLocal, UseConfigSystem);
+            _configuration = await Git.Configuration.ReadConfiuration(Context, Environment.CurrentDirectory, UseConfigLocal, UseConfigSystem);
         }
 
         public virtual void SetCredentials(string username, string password)
@@ -417,16 +423,16 @@ namespace Microsoft.Alm.Cli
 
             if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
             {
-                Git.Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
+                Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
             }
             else
             {
                 if (!string.IsNullOrWhiteSpace(url))
                 {
-                    Git.Trace.WriteLine($"failed to parse '{url}'.");
+                    Trace.WriteLine($"failed to parse '{url}'.");
                 }
 
-                Git.Trace.WriteLine("proxy cleared.");
+                Trace.WriteLine("proxy cleared.");
             }
 
             ProxyUri = tmp;

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Alm.Cli
         internal static readonly StringComparer ConfigValueComparer = StringComparer.OrdinalIgnoreCase;
 
         internal const string EnvironConfigDebugKey = "GCM_DEBUG";
-        internal const string EnvironConfigTraceKey = Git.Trace.EnvironmentVariableKey;
+        internal const string EnvironConfigTraceKey = "GCM_TRACE";
 
         internal static readonly StringComparer EnvironKeyComparer = StringComparer.OrdinalIgnoreCase;
 
@@ -150,8 +150,6 @@ namespace Microsoft.Alm.Cli
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static Program()
         {
-            DebuggerLaunch();
-
             ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
         }
 
@@ -376,8 +374,11 @@ namespace Microsoft.Alm.Cli
             }
         }
 
-        internal static void DebuggerLaunch()
+        internal static void DebuggerLaunch(Program program)
         {
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+
             if (Debugger.IsAttached)
                 return;
 
@@ -387,7 +388,7 @@ namespace Microsoft.Alm.Cli
                     || StringComparer.OrdinalIgnoreCase.Equals(debug, "1")
                     || StringComparer.OrdinalIgnoreCase.Equals(debug, "debug")))
             {
-                Git.Trace.WriteLine($"'{EnvironConfigDebugKey}': '{debug}', launching debugger...");
+                program.Context.Trace.WriteLine($"'{EnvironConfigDebugKey}': '{debug}', launching debugger...");
 
                 Debugger.Launch();
             }
@@ -453,7 +454,7 @@ namespace Microsoft.Alm.Cli
         {
             // use the stderr stream for the trace as stdout is used in the cross-process
             // communications protocol
-            Git.Trace.AddListener(Error);
+            _context.Trace.AddListener(Error);
         }
 
         internal void EnableTraceLogging(OperationArguments operationArguments)
@@ -475,7 +476,7 @@ namespace Microsoft.Alm.Cli
             if (!_configurationKeys.TryGetValue(type, out value)
                 && !_environmentKeys.TryGetValue(type, out value))
             {
-                Git.Trace.WriteLine($"BUG: unknown {nameof(KeyType)}: '{type}' encountered.");
+                _context.Trace.WriteLine($"BUG: unknown {nameof(KeyType)}: '{type}' encountered.");
             }
 
             return value;

--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -101,7 +101,7 @@ namespace GitHub.Authentication
             if (await PersonalAccessTokenStore.ReadCredentials(normalizedTargetUri) != null)
             {
                 result = await PersonalAccessTokenStore.DeleteCredentials(normalizedTargetUri);
-                Git.Trace.WriteLine($"credentials for '{normalizedTargetUri}' deleted");
+                Trace.WriteLine($"credentials for '{normalizedTargetUri}' deleted");
             }
 
             return result;
@@ -144,12 +144,12 @@ namespace GitHub.Authentication
                                                     acquireCredentialsCallback,
                                                     acquireAuthenticationCodeCallback,
                                                     authenticationResultCallback);
-                Git.Trace.WriteLine($"created GitHub authentication for '{normalizedTargetUri}'.");
+                context.Trace.WriteLine($"created GitHub authentication for '{normalizedTargetUri}'.");
             }
             else
             {
                 authentication = null;
-                Git.Trace.WriteLine($"not github.com, authentication creation aborted.");
+                context.Trace.WriteLine($"not github.com, authentication creation aborted.");
             }
 
             return authentication;
@@ -170,7 +170,7 @@ namespace GitHub.Authentication
             var normalizedTargetUri = NormalizeUri(targetUri);
             if ((credentials = await PersonalAccessTokenStore.ReadCredentials(normalizedTargetUri)) != null)
             {
-                Git.Trace.WriteLine($"credentials for '{normalizedTargetUri}' found.");
+                Trace.WriteLine($"credentials for '{normalizedTargetUri}' found.");
             }
 
             return credentials;
@@ -198,7 +198,7 @@ namespace GitHub.Authentication
 
                 if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, null, TokenScope))
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded");
+                    Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded");
 
                     credentials = (Credential)result.Token;
                     await PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
@@ -216,7 +216,7 @@ namespace GitHub.Authentication
                     {
                         if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, authenticationCode, TokenScope))
                         {
-                            Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
+                            Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
 
                             credentials = (Credential)result.Token;
                             await PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
@@ -232,7 +232,7 @@ namespace GitHub.Authentication
                 AuthenticationResultCallback?.Invoke(normalizedTargetUri, result);
             }
 
-            Git.Trace.WriteLine($"interactive logon for '{normalizedTargetUri}' failed.");
+            Trace.WriteLine($"interactive logon for '{normalizedTargetUri}' failed.");
             return credentials;
         }
 
@@ -262,7 +262,7 @@ namespace GitHub.Authentication
             AuthenticationResult result;
             if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, authenticationCode, TokenScope))
             {
-                Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
+                Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
 
                 credentials = (Credential)result.Token;
                 await PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
@@ -270,7 +270,7 @@ namespace GitHub.Authentication
                 return credentials;
             }
 
-            Git.Trace.WriteLine($"non-interactive logon for '{normalizedTargetUri}' failed.");
+            Trace.WriteLine($"non-interactive logon for '{normalizedTargetUri}' failed.");
             return credentials;
         }
 

--- a/GitHub.Authentication/AuthenticationPrompts.cs
+++ b/GitHub.Authentication/AuthenticationPrompts.cs
@@ -47,7 +47,7 @@ namespace GitHub.Authentication
         {
             var credentialViewModel = new CredentialsViewModel();
 
-            Git.Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
+            Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
 
             bool credentialValid = ShowViewModel(credentialViewModel, () => new CredentialsWindow());
 
@@ -61,7 +61,7 @@ namespace GitHub.Authentication
         {
             var twoFactorViewModel = new TwoFactorViewModel(resultType == GitHubAuthenticationResultType.TwoFactorSms);
 
-            Git.Trace.WriteLine($"prompting user for authentication code for '{targetUri}'.");
+            Trace.WriteLine($"prompting user for authentication code for '{targetUri}'.");
 
             bool authenticationCodeValid = ShowViewModel(twoFactorViewModel, () => new TwoFactorWindow());
 

--- a/GitHub.Authentication/Authority.cs
+++ b/GitHub.Authentication/Authority.cs
@@ -125,7 +125,7 @@ namespace GitHub.Authentication
                 using (StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType))
                 using (HttpResponseMessage response = await httpClient.PostAsync(_authorityUrl, content))
                 {
-                    Git.Trace.WriteLine($"server responded with {response.StatusCode}.");
+                    Trace.WriteLine($"server responded with {response.StatusCode}.");
 
                     switch (response.StatusCode)
                     {
@@ -144,12 +144,12 @@ namespace GitHub.Authentication
 
                                 if (token == null)
                                 {
-                                    Git.Trace.WriteLine($"authentication for '{targetUri}' failed.");
+                                    Trace.WriteLine($"authentication for '{targetUri}' failed.");
                                     return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                                 else
                                 {
-                                    Git.Trace.WriteLine($"authentication success: new personal access token for '{targetUri}' created.");
+                                    Trace.WriteLine($"authentication success: new personal access token for '{targetUri}' created.");
                                     return new AuthenticationResult(GitHubAuthenticationResultType.Success, token);
                                 }
                             }
@@ -163,18 +163,18 @@ namespace GitHub.Authentication
 
                                     if (mfakvp.Value.First().Contains("app"))
                                     {
-                                        Git.Trace.WriteLine($"two-factor app authentication code required for '{targetUri}'.");
+                                        Trace.WriteLine($"two-factor app authentication code required for '{targetUri}'.");
                                         return new AuthenticationResult(GitHubAuthenticationResultType.TwoFactorApp);
                                     }
                                     else
                                     {
-                                        Git.Trace.WriteLine($"two-factor sms authentication code required for '{targetUri}'.");
+                                        Trace.WriteLine($"two-factor sms authentication code required for '{targetUri}'.");
                                         return new AuthenticationResult(GitHubAuthenticationResultType.TwoFactorSms);
                                     }
                                 }
                                 else
                                 {
-                                    Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
+                                    Trace.WriteLine($"authentication failed for '{targetUri}'.");
                                     return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                             }
@@ -186,15 +186,15 @@ namespace GitHub.Authentication
                             var contentBody = await response.Content.ReadAsStringAsync();
                             if (contentBody.Contains("This API can only be accessed with username and password Basic Auth"))
                             {
-                                Git.Trace.WriteLine($"authentication success: user supplied personal access token for '{targetUri}'.");
+                                Trace.WriteLine($"authentication success: user supplied personal access token for '{targetUri}'.");
 
                                 return new AuthenticationResult(GitHubAuthenticationResultType.Success, new Token(password, TokenType.Personal));
                             }
-                            Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
+                            Trace.WriteLine($"authentication failed for '{targetUri}'.");
                             return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
 
                         default:
-                            Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
+                            Trace.WriteLine($"authentication failed for '{targetUri}'.");
                             return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
                     }
                 }
@@ -225,12 +225,12 @@ namespace GitHub.Authentication
                 {
                     if (response.IsSuccessStatusCode)
                     {
-                        Git.Trace.WriteLine($"credential validation for '{targetUri}' succeeded.");
+                        Trace.WriteLine($"credential validation for '{targetUri}' succeeded.");
                         return true;
                     }
                     else
                     {
-                        Git.Trace.WriteLine($"credential validation for '{targetUri}' failed.");
+                        Trace.WriteLine($"credential validation for '{targetUri}' failed.");
                         return false;
                     }
                 }

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -43,5 +43,8 @@ namespace Microsoft.Alm.Authentication
         {
             get { return _context; }
         }
+
+        protected Git.ITrace Trace
+            => _context.Trace;
     }
 }

--- a/Microsoft.Alm.Authentication/BaseSecureStore.cs
+++ b/Microsoft.Alm.Authentication/BaseSecureStore.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Alm.Authentication
                     {
                         case NativeMethods.Win32Error.NotFound:
                         case NativeMethods.Win32Error.NoSuchLogonSession:
-                            Git.Trace.WriteLine($"credentials not found for '{targetName}'.");
+                            Trace.WriteLine($"credentials not found for '{targetName}'.");
                             break;
 
                         default:
@@ -60,7 +60,7 @@ namespace Microsoft.Alm.Authentication
                 }
                 else
                 {
-                    Git.Trace.WriteLine($"credentials for '{targetName}' deleted from store.");
+                    Trace.WriteLine($"credentials for '{targetName}' deleted from store.");
                 }
             }
             catch (Exception exception)
@@ -101,7 +101,7 @@ namespace Microsoft.Alm.Authentication
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{@namespace}' purged from store.");
+                            Trace.WriteLine($"credentials for '{@namespace}' purged from store.");
                         }
                     }
                 }
@@ -139,14 +139,14 @@ namespace Microsoft.Alm.Authentication
 
                     credentials = new Credential(username, password);
 
-                    Git.Trace.WriteLine($"credentials for '{targetName}' read from store.");
+                    Trace.WriteLine($"credentials for '{targetName}' read from store.");
                 }
             }
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
 
-                Git.Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
+                Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
 
                 return null;
             }
@@ -181,10 +181,10 @@ namespace Microsoft.Alm.Authentication
                         TokenType type;
                         if (Token.GetTypeFromFriendlyName(credStruct.UserName, out type))
                         {
-                            Token.Deserialize(bytes, type, out token);
+                            Token.Deserialize(Context, bytes, type, out token);
                         }
 
-                        Git.Trace.WriteLine($"token for '{targetName}' read from store.");
+                        Trace.WriteLine($"token for '{targetName}' read from store.");
                     }
                 }
             }
@@ -192,7 +192,7 @@ namespace Microsoft.Alm.Authentication
             {
                 Debug.WriteLine(exception);
 
-                Git.Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
+                Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
 
                 return null;
             }
@@ -233,13 +233,13 @@ namespace Microsoft.Alm.Authentication
                     throw new Win32Exception(error, "Failed to write credentials");
                 }
 
-                Git.Trace.WriteLine($"credentials for '{targetName}' written to store.");
+                Trace.WriteLine($"credentials for '{targetName}' written to store.");
             }
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
 
-                Git.Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
+                Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
 
                 return false;
             }
@@ -263,7 +263,7 @@ namespace Microsoft.Alm.Authentication
                 throw new ArgumentNullException(nameof(token));
 
             byte[] bytes = null;
-            if (Token.Serialize(token, out bytes))
+            if (Token.Serialize(Context, token, out bytes))
             {
                 string name;
                 if (Token.GetFriendlyNameFromType(token.Type, out name))
@@ -288,13 +288,13 @@ namespace Microsoft.Alm.Authentication
                             throw new Win32Exception(error, "Failed to write credentials");
                         }
 
-                        Git.Trace.WriteLine($"token for '{targetName}' written to store.");
+                        Trace.WriteLine($"token for '{targetName}' written to store.");
                     }
                     catch (Exception exception)
                     {
                         Debug.WriteLine(exception);
 
-                        Git.Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
+                        Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
 
                         return false;
                     }

--- a/Microsoft.Alm.Authentication/BasicAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BasicAuthentication.cs
@@ -108,13 +108,13 @@ namespace Microsoft.Alm.Authentication
                 // Get the WWW-Authenticate headers (if any).
                 if (_httpAuthenticateOptions == null)
                 {
-                    _httpAuthenticateOptions = await WwwAuthenticateHelper.GetHeaderValues(targetUri);
+                    _httpAuthenticateOptions = await WwwAuthenticateHelper.GetHeaderValues(Context, targetUri);
                 }
 
                 // If the headers contain NTLM as an option, then fall back to NTLM.
                 if (_httpAuthenticateOptions.Any(x => WwwAuthenticateHelper.IsNtlm(x)))
                 {
-                    Git.Trace.WriteLine($"'{targetUri}' supports NTLM, sending NTLM credentials instead");
+                    Trace.WriteLine($"'{targetUri}' supports NTLM, sending NTLM credentials instead");
 
                     return NtlmCredentials;
                 }
@@ -124,7 +124,7 @@ namespace Microsoft.Alm.Authentication
 
             if (_ntlmSupport != NtlmSupport.Always && _acquireCredentials != null)
             {
-                Git.Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
+                Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
 
                 credentials = _acquireCredentials(targetUri);
 

--- a/Microsoft.Alm.Authentication/Git/Trace.cs
+++ b/Microsoft.Alm.Authentication/Git/Trace.cs
@@ -36,15 +36,19 @@ namespace Microsoft.Alm.Authentication.Git
 
         void Flush();
 
-        void WriteLine(string message, string filePath, int lineNumber, string memberName);
+        void WriteLine(
+            string message,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
     }
 
-    public sealed class Trace : ITrace, IDisposable
+    internal class Trace : Base, ITrace, IDisposable
     {
         public const string EnvironmentVariableKey = "GCM_TRACE";
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private Trace()
+        public Trace(RuntimeContext context)
+            : base(context)
         {
             _writers = new List<TextWriter>();
 
@@ -76,32 +80,25 @@ namespace Microsoft.Alm.Authentication.Git
             Dispose(true);
         }
 
-        private static ITrace _instance;
-        private static readonly object _syncpoint = new object();
-        private readonly List<TextWriter> _writers;
+        private readonly object _syncpoint = new object();
+        private List<TextWriter> _writers;
 
-        internal static ITrace Instance
-        {
-            get
-            {
-                lock (_syncpoint)
-                {
-                    if (_instance == null)
-                    {
-                        _instance = new Trace();
-                    }
-                    return _instance;
-                }
-            }
-            set { _instance = value; }
-        }
 
         /// <summary>
         /// Add a listener to the trace writer.
         /// </summary>
         /// <param name="listener">The listener to add.</param>
-        public static void AddListener(TextWriter listener)
-            => Instance.AddListener(listener);
+        public void AddListener(TextWriter listener)
+        {
+            lock (_syncpoint)
+            {
+                // Try not to add the same listener more than once
+                if (_writers.Contains(listener))
+                    return;
+
+                _writers.Add(listener);
+            }
+        }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public void Dispose()
@@ -114,8 +111,21 @@ namespace Microsoft.Alm.Authentication.Git
         /// <summary>
         /// Forces any pending trace messages to be written to any listeners.
         /// </summary>
-        public static void Flush()
-            => Instance.Flush();
+        public void Flush()
+        {
+            lock (_syncpoint)
+            {
+                foreach (var writer in _writers)
+                {
+                    try
+                    {
+                        writer?.Flush();
+                    }
+                    catch
+                    { /* squelch */ }
+                }
+            }
+        }
 
         /// <summary>
         /// Writes a message to the trace writer followed by a line terminator.
@@ -125,11 +135,31 @@ namespace Microsoft.Alm.Authentication.Git
         /// <param name="lineNumber">Line number of file this method is called from.</param>
         /// <param name="memberName">Name of the member in which this method is called.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static void WriteLine(string message,
+        public void WriteLine(
+            string message,
             [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
             [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
             [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
-            => Instance.WriteLine(message, filePath, lineNumber, memberName);
+        {
+            lock (_syncpoint)
+            {
+                if (_writers.Count == 0)
+                    return;
+
+                string text = FormatText(message, filePath, lineNumber, memberName);
+
+                foreach (var writer in _writers)
+                {
+                    try
+                    {
+                        writer?.Write(text);
+                        writer?.Write('\n');
+                        writer?.Flush();
+                    }
+                    catch { /* squelch */ }
+                }
+            }
+        }
 
         private void Dispose(bool finalizing)
         {
@@ -193,56 +223,6 @@ namespace Microsoft.Alm.Authentication.Git
             string text = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:HH:mm:ss.ffffff} {1,-23} trace: [{2}] {3}", DateTime.Now, source, memberName, message);
 
             return text;
-        }
-
-        void ITrace.AddListener(TextWriter listener)
-        {
-            lock (_syncpoint)
-            {
-                // Try not to add the same listener more than once
-                if (_writers.Contains(listener))
-                    return;
-
-                _writers.Add(listener);
-            }
-        }
-
-        void ITrace.Flush()
-        {
-            lock (_syncpoint)
-            {
-                foreach (var writer in _writers)
-                {
-                    try
-                    {
-                        writer?.Flush();
-                    }
-                    catch
-                    { /* squelch */ }
-                }
-            }
-        }
-
-        void ITrace.WriteLine(string message, string filePath, int lineNumber, string memberName)
-        {
-            lock (_syncpoint)
-            {
-                if (_writers.Count == 0)
-                    return;
-
-                string text = FormatText(message, filePath, lineNumber, memberName);
-
-                foreach (var writer in _writers)
-                {
-                    try
-                    {
-                        writer?.Write(text);
-                        writer?.Write('\n');
-                        writer?.Flush();
-                    }
-                    catch { /* squelch */ }
-                }
-            }
         }
     }
 }

--- a/Microsoft.Alm.Authentication/Git/Trace.cs
+++ b/Microsoft.Alm.Authentication/Git/Trace.cs
@@ -30,7 +30,7 @@ using System.Text;
 
 namespace Microsoft.Alm.Authentication.Git
 {
-    internal interface ITrace
+    public interface ITrace
     {
         void AddListener(TextWriter listener);
 

--- a/Microsoft.Alm.Authentication/Git/Where.cs
+++ b/Microsoft.Alm.Authentication/Git/Where.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Alm.Authentication.Git
 
             installations = pathSet.ToList();
 
-            Git.Trace.WriteLine($"found {installations.Count} Git installation(s).");
+            // Git.Trace.WriteLine($"found {installations.Count} Git installation(s).");
 
             return installations.Count > 0;
         }

--- a/Microsoft.Alm.Authentication/RuntimeContext.cs
+++ b/Microsoft.Alm.Authentication/RuntimeContext.cs
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using System;
 using System.Threading;
 
 namespace Microsoft.Alm.Authentication
@@ -30,6 +31,15 @@ namespace Microsoft.Alm.Authentication
     public class RuntimeContext
     {
         public static readonly RuntimeContext Default;
+
+        public RuntimeContext(Git.ITrace trace)
+            : this()
+        {
+            if (trace is null)
+                throw new ArgumentNullException(nameof(trace));
+
+            _trace = trace;
+        }
 
         private RuntimeContext()
         {
@@ -42,15 +52,22 @@ namespace Microsoft.Alm.Authentication
             Volatile.Write(ref _count, 0);
 
             Default = new RuntimeContext();
+            Default._trace = new Git.Trace(Default);
         }
 
         private static int _count;
         private readonly int _id;
         private readonly object _syncpoint;
+        private Git.ITrace _trace;
 
         public int Id
         {
             get { return _id; }
+        }
+
+        public Git.ITrace Trace
+        {
+            get { return _trace; }
         }
     }
 }

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -188,8 +188,14 @@ namespace Microsoft.Alm.Authentication
                 throw new ArgumentOutOfRangeException(nameof(token));
         }
 
-        internal static unsafe bool Deserialize(byte[] bytes, TokenType type, out Token token)
+        internal static unsafe bool Deserialize(
+            RuntimeContext context,
+            byte[] bytes,
+            TokenType type,
+            out Token token)
         {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
             if (bytes.Length == 0)
@@ -221,8 +227,10 @@ namespace Microsoft.Alm.Authentication
 
                         if (!string.IsNullOrWhiteSpace(value))
                         {
-                            token = new Token(value, type);
-                            token._targetIdentity = targetIdentity;
+                            token = new Token(value, type)
+                            {
+                                _targetIdentity = targetIdentity
+                            };
                         }
                     }
                 }
@@ -240,13 +248,16 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Git.Trace.WriteLine("! token deserialization error.");
+                context.Trace.WriteLine("! token deserialization error.");
             }
 
             return token != null;
         }
 
-        internal static unsafe bool Serialize(Token token, out byte[] bytes)
+        internal static unsafe bool Serialize(
+            RuntimeContext context,
+            Token token,
+            out byte[] bytes)
         {
             if (token is null)
                 throw new ArgumentNullException(nameof(token));
@@ -271,7 +282,7 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Git.Trace.WriteLine("! token serialization error.");
+                context.Trace.WriteLine("! token serialization error.");
             }
 
             return bytes != null;

--- a/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
+++ b/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Alm.Authentication
 
         private static readonly AuthenticationHeaderValue[] NullResult = new AuthenticationHeaderValue[0];
 
-        public static async Task<AuthenticationHeaderValue[]> GetHeaderValues(TargetUri targetUri)
+        public static async Task<AuthenticationHeaderValue[]> GetHeaderValues(RuntimeContext context, TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Alm.Authentication
                 }
                 catch (Exception exception)
                 {
-                    Git.Trace.WriteLine("error testing targetUri for NTLM: " + exception.Message);
+                    context.Trace.WriteLine("error testing targetUri for NTLM: " + exception.Message);
                 }
             }
 

--- a/Microsoft.Vsts.Authentication/AzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/AzureAuthority.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Alm.Authentication
     /// <summary>
     /// Interfaces with Azure to perform authentication and identity services.
     /// </summary>
-    internal class AzureAuthority : IAzureAuthority
+    internal class AzureAuthority : Base, IAzureAuthority
     {
         /// <summary>
         /// The base URL for logon services in Azure.
@@ -48,7 +48,8 @@ namespace Microsoft.Alm.Authentication
         /// Creates a new instance of `<see cref="AzureAuthority"/>`.
         /// </summary>
         /// <param name="authorityHostUrl">A non-default authority host URL; otherwise defaults to `<see cref="DefaultAuthorityHostUrl"/>`.</param>
-        public AzureAuthority(string authorityHostUrl = DefaultAuthorityHostUrl)
+        public AzureAuthority(RuntimeContext context, string authorityHostUrl = DefaultAuthorityHostUrl)
+            : base (context)
         {
             if (string.IsNullOrEmpty(authorityHostUrl))
                 throw new ArgumentNullException(nameof(authorityHostUrl));
@@ -56,7 +57,7 @@ namespace Microsoft.Alm.Authentication
                 throw new ArgumentException("Uri is not Absolute.", nameof(authorityHostUrl));
 
             AuthorityHostUrl = authorityHostUrl;
-            _adalTokenCache = new VstsAdalTokenCache();
+            _adalTokenCache = new VstsAdalTokenCache(context);
         }
 
         private readonly VstsAdalTokenCache _adalTokenCache;
@@ -107,11 +108,11 @@ namespace Microsoft.Alm.Authentication
                     token = new Token(authResult.AccessToken, tenantId, TokenType.Access);
                 }
 
-                Git.Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition succeeded.");
+                Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition succeeded.");
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition failed.");
+                Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition failed.");
             }
 
             return token;
@@ -153,12 +154,12 @@ namespace Microsoft.Alm.Authentication
                 {
                     token = new Token(authResult.AccessToken, tentantId, TokenType.Access);
 
-                    Git.Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' succeeded.");
+                    Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' succeeded.");
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' failed.");
+                Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' failed.");
             }
 
             return token;

--- a/Microsoft.Vsts.Authentication/VstsAadAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/VstsAadAuthentication.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Alm.Authentication
         {
             if (tenantId == Guid.Empty)
             {
-                VstsAuthority = new VstsAzureAuthority(AzureAuthority.DefaultAuthorityHostUrl);
+                VstsAuthority = new VstsAzureAuthority(context, AzureAuthority.DefaultAuthorityHostUrl);
             }
             else
             {
                 // Create an authority host URL in the format of https://login.microsoft.com/12345678-9ABC-DEF0-1234-56789ABCDEF0.
                 string authorityHost = AzureAuthority.GetAuthorityUrl(tenantId);
-                VstsAuthority = new VstsAzureAuthority(authorityHost);
+                VstsAuthority = new VstsAzureAuthority(context, authorityHost);
             }
         }
 
@@ -95,17 +95,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), null)) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, options);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
+                Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
             }
 
-            Git.Trace.WriteLine($"interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -132,17 +132,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), null)) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
+                Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
             }
 
-            Git.Trace.WriteLine($"interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -164,17 +164,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.NoninteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl))) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
 
                     return await GeneratePersonalAccessToken(targetUri, token, options);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
+                Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
             }
 
-            Git.Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -201,17 +201,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.NoninteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl))) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
 
                     return await GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
+                Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
             }
 
-            Git.Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
             return null;
         }
 

--- a/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
+++ b/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Alm.Authentication
 {
     internal class VstsAdalTokenCache : IdentityModel.Clients.ActiveDirectory.TokenCache
     {
-        private readonly IReadOnlyList<IReadOnlyList<string>> AdalCachePaths = new string[][]
+        private static readonly IReadOnlyList<IReadOnlyList<string>> AdalCachePaths = new string[][]
         {
             new [] { @".IdentityService", @"IdentityServiceAdalCache.cache", },          // VS2017 ADAL v3 cache
             new [] { @"Microsoft\VSCommon\VSAccountManagement", @"AdalCache.cache", },   // VS2015 ADAL v2 cache
@@ -43,8 +43,13 @@ namespace Microsoft.Alm.Authentication
         /// <summary>
         /// Default constructor.
         /// </summary>
-        public VstsAdalTokenCache()
+        public VstsAdalTokenCache(RuntimeContext context)
         {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+
+            _context = context;
+
             string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
             AfterAccess = AfterAccessNotification;
@@ -66,6 +71,7 @@ namespace Microsoft.Alm.Authentication
         }
 
         private readonly string _cacheFilePath;
+        private readonly RuntimeContext _context;
         private readonly object _syncpoint = new object();
 
         private void AfterAccessNotification(TokenCacheNotificationArgs args)
@@ -86,7 +92,7 @@ namespace Microsoft.Alm.Authentication
                     }
                     catch (Exception exception)
                     {
-                        Git.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
+                        _context.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
                     }
                 }
             }
@@ -108,7 +114,7 @@ namespace Microsoft.Alm.Authentication
                     }
                     catch (Exception exception)
                     {
-                        Git.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
+                        _context.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
                     }
                 }
             }

--- a/Microsoft.Vsts.Authentication/VstsMsaAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/VstsMsaAuthentication.cs
@@ -35,10 +35,13 @@ namespace Microsoft.Alm.Authentication
         public const string DefaultAuthorityHost = AzureAuthority.AuthorityHostUrlBase + "/live.com";
         internal const string QueryParameters = "domain_hint=live.com&display=popup&site_id=501454&nux=1";
 
-        public VstsMsaAuthentication(RuntimeContext context, VstsTokenScope tokenScope, ICredentialStore personalAccessTokenStore)
+        public VstsMsaAuthentication(
+            RuntimeContext context,
+            VstsTokenScope tokenScope,
+            ICredentialStore personalAccessTokenStore)
             : base(context, tokenScope, personalAccessTokenStore)
         {
-            VstsAuthority = new VstsAzureAuthority(DefaultAuthorityHost);
+            VstsAuthority = new VstsAzureAuthority(context, DefaultAuthorityHost);
         }
 
         /// <summary>
@@ -79,7 +82,7 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), QueryParameters)) != null)
                 {
-                    Git.Trace.WriteLine($"token '{targetUri}' successfully acquired.");
+                    Trace.WriteLine($"token '{targetUri}' successfully acquired.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, options);
                 }
@@ -89,7 +92,7 @@ namespace Microsoft.Alm.Authentication
                 Debug.Write(exception);
             }
 
-            Git.Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
+            Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
             return null;
         }
 
@@ -109,7 +112,7 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), QueryParameters)) != null)
                 {
-                    Git.Trace.WriteLine($"token '{targetUri}' successfully acquired.");
+                    Trace.WriteLine($"token '{targetUri}' successfully acquired.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
@@ -119,7 +122,7 @@ namespace Microsoft.Alm.Authentication
                 Debug.Write(exception);
             }
 
-            Git.Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
+            Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
             return null;
         }
 


### PR DESCRIPTION
Enables `Trace` as a service, provided by `RuntimeContext`.

- [x] Update 'Microsoft.Alm.Authentication'.
- [x] Update 'Microsoft.Vsts.Authentication'.
- [x] Update 'Github.Authentication'.
- [x] Update 'Bitbucket.Authentication'.

Depends on #570, #572, #573 #574