### PR TITLE
File-system-as-a-Service

### DIFF
--- a/Bitbucket.Authentication/Authentication.cs
+++ b/Bitbucket.Authentication/Authentication.cs
@@ -27,8 +27,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
 
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
-
 namespace Atlassian.Bitbucket.Authentication
 {
     /// <summary>
@@ -301,7 +299,7 @@ namespace Atlassian.Bitbucket.Authentication
             if (targetUri.QueryUri.DnsSafeHost.EndsWith(BitbucketBaseUrlHost, StringComparison.OrdinalIgnoreCase))
             {
                 authentication = new Authentication(context, personalAccessTokenStore, acquireCredentialsCallback, acquireAuthenticationOAuthCallback);
-                Trace.WriteLine("authentication for Bitbucket created");
+                context.Trace.WriteLine("authentication for Bitbucket created");
             }
             else
             {

--- a/Bitbucket.Authentication/AuthenticationPrompts.cs
+++ b/Bitbucket.Authentication/AuthenticationPrompts.cs
@@ -35,7 +35,6 @@ using Atlassian.Bitbucket.Authentication.Views;
 using GitHub.Shared.Controls;
 using GitHub.Shared.ViewModels;
 using Microsoft.Alm.Authentication;
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
 
 namespace Atlassian.Bitbucket.Authentication
 {

--- a/Bitbucket.Authentication/Authority.cs
+++ b/Bitbucket.Authentication/Authority.cs
@@ -30,7 +30,6 @@ using System.Threading.Tasks;
 using Atlassian.Bitbucket.Authentication.BasicAuth;
 using Atlassian.Bitbucket.Authentication.Rest;
 using Microsoft.Alm.Authentication;
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
 
 namespace Atlassian.Bitbucket.Authentication
 {

--- a/Bitbucket.Authentication/OAuth/OAuthAuthenticator.cs
+++ b/Bitbucket.Authentication/OAuth/OAuthAuthenticator.cs
@@ -34,8 +34,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
 
-using Trace = Microsoft.Alm.Authentication.Git.Trace;
-
 namespace Atlassian.Bitbucket.Authentication.OAuth
 {
     /// <summary>

--- a/Bitbucket.Authentication/Rest/RestClient.cs
+++ b/Bitbucket.Authentication/Rest/RestClient.cs
@@ -72,7 +72,7 @@ namespace Atlassian.Bitbucket.Authentication.Rest
             }
         }
 
-        private static string FindUsername(string responseText)
+        private string FindUsername(string responseText)
         {
             Match usernameMatch;
             if ((usernameMatch = UsernameRegex.Match(responseText)).Success

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Alm.Cli
             Out.WriteLine("usage: git askpass '<user_prompt_text>'");
 
             List<Git.Installation> installations;
-            if (Git.Where.FindGitInstallations(out installations))
+            if (Context.Where.FindGitInstallations(out installations))
             {
                 foreach (var installation in installations)
                 {

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Alm.Cli
             _context = context;
 
             Title = AssemblyTitle;
+
+            DebuggerLaunch(this);
         }
 
         internal static bool TryParseUrlCredentials(string targetUrl, out string username, out string password)
@@ -122,7 +124,7 @@ namespace Microsoft.Alm.Cli
 
             if (match.Success)
             {
-                Git.Trace.WriteLine("querying for passphrase key.");
+                _context.Trace.WriteLine("querying for passphrase key.");
 
                 if (match.Groups.Count < 2)
                     throw new ArgumentException("Unable to understand command.");
@@ -130,7 +132,7 @@ namespace Microsoft.Alm.Cli
                 // string request = match.Groups[0].Value;
                 string resource = match.Groups[1].Value;
 
-                Git.Trace.WriteLine($"open dialog for '{resource}'.");
+                _context.Trace.WriteLine($"open dialog for '{resource}'.");
 
                 System.Windows.Application application = new System.Windows.Application();
                 Gui.UserPromptDialog prompt = new Gui.UserPromptDialog(promptKind, resource);
@@ -140,7 +142,7 @@ namespace Microsoft.Alm.Cli
                 {
                     string passphase = prompt.Response;
 
-                    Git.Trace.WriteLine("passphase acquired.");
+                    _context.Trace.WriteLine("passphase acquired.");
 
                     Out.Write(passphase + "\n");
                     return;
@@ -151,7 +153,7 @@ namespace Microsoft.Alm.Cli
 
             if ((match = AskCredentialRegex.Match(args[0])).Success)
             {
-                Git.Trace.WriteLine("querying for basic credentials.");
+                _context.Trace.WriteLine("querying for basic credentials.");
 
                 if (match.Groups.Count < 3)
                     throw new ArgumentException("Unable to understand command.");
@@ -166,7 +168,7 @@ namespace Microsoft.Alm.Cli
                 // Since we're looking for HTTP(s) credentials, we can use NetFx `Uri` class.
                 if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                 {
-                    Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
+                    _context.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
                     if (TryParseUrlCredentials(targetUrl, out username, out password))
                     {
@@ -213,9 +215,9 @@ namespace Microsoft.Alm.Cli
 
                     if (Uri.TryCreate(targetUrl, UriKind.Absolute, out targetUri))
                     {
-                        Git.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
+                        _context.Trace.WriteLine($"success parsing URL, targetUri = '{targetUri}'.");
 
-                        OperationArguments operationArguments = new OperationArguments(targetUri);
+                        OperationArguments operationArguments = new OperationArguments(_context, targetUri);
                         operationArguments.SetCredentials(username ?? string.Empty, password ?? string.Empty);
 
                         // Load up the operation arguments, enable tracing, and query for credentials.
@@ -229,7 +231,7 @@ namespace Microsoft.Alm.Cli
                             {
                                 if (seeking.Equals("Username", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    Git.Trace.WriteLine($"username for '{targetUrl}' asked for and found.");
+                                    _context.Trace.WriteLine($"username for '{targetUrl}' asked for and found.");
 
                                     Out.Write(credentials.Username + '\n');
                                     return;
@@ -237,7 +239,7 @@ namespace Microsoft.Alm.Cli
 
                                 if (seeking.Equals("Password", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    Git.Trace.WriteLine($"password for '{targetUrl}' asked for and found.");
+                                    _context.Trace.WriteLine($"password for '{targetUrl}' asked for and found.");
 
                                     Out.Write(credentials.Password + '\n');
                                     return;
@@ -245,19 +247,19 @@ namespace Microsoft.Alm.Cli
                             }
                             else
                             {
-                                Git.Trace.WriteLine($"user cancelled credential dialog.");
+                                _context.Trace.WriteLine($"user cancelled credential dialog.");
                                 return;
                             }
                         }).Wait();
                     }
                     else
                     {
-                        Git.Trace.WriteLine("error: unable to parse target URL.");
+                        _context.Trace.WriteLine("error: unable to parse target URL.");
                     }
                 }
                 else
                 {
-                    Git.Trace.WriteLine("error: unable to parse supplied URL.");
+                    _context.Trace.WriteLine("error: unable to parse supplied URL.");
                 }
 
                 Die($"failed to detect {seeking} in target URL.");
@@ -268,7 +270,7 @@ namespace Microsoft.Alm.Cli
                 string host = match.Groups[1].Value;
                 string fingerprint = match.Groups[2].Value;
 
-                Git.Trace.WriteLine($"requesting authorization to add {host} ({fingerprint}) to known hosts.");
+                _context.Trace.WriteLine($"requesting authorization to add {host} ({fingerprint}) to known hosts.");
 
                 System.Windows.Application application = new System.Windows.Application();
                 Gui.UserPromptDialog prompt = new Gui.UserPromptDialog(host, fingerprint);
@@ -276,12 +278,12 @@ namespace Microsoft.Alm.Cli
 
                 if (prompt.Failed)
                 {
-                    Git.Trace.WriteLine("denied authorization of host.");
+                    _context.Trace.WriteLine("denied authorization of host.");
                     Out.Write("no\n");
                 }
                 else
                 {
-                    Git.Trace.WriteLine("approved authorization of host.");
+                    _context.Trace.WriteLine("approved authorization of host.");
                     Out.Write("yes\n");
                 }
 
@@ -309,7 +311,7 @@ namespace Microsoft.Alm.Cli
                         // if the help file exists, send it to the operating system to display to the user
                         if (File.Exists(doc))
                         {
-                            Git.Trace.WriteLine($"opening help documentation '{doc}'.");
+                            _context.Trace.WriteLine($"opening help documentation '{doc}'.");
 
                             Process.Start(doc);
 

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -304,16 +304,16 @@ namespace Microsoft.Alm.Cli
             {
                 foreach (var installation in installations)
                 {
-                    if (Directory.Exists(installation.Doc))
+                    if (FileSystem.DirectoryExists(installation.Doc))
                     {
-                        string doc = Path.Combine(installation.Doc, HelpFileName);
+                        string docPath = Path.Combine(installation.Doc, HelpFileName);
 
                         // if the help file exists, send it to the operating system to display to the user
-                        if (File.Exists(doc))
+                        if (FileSystem.FileExists(docPath))
                         {
-                            _context.Trace.WriteLine($"opening help documentation '{doc}'.");
+                            _context.Trace.WriteLine($"opening help documentation '{docPath}'.");
 
-                            Process.Start(doc);
+                            Process.Start(docPath);
 
                             return;
                         }

--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Microsoft.Alm.Authentication;
 using Xunit;
 
 namespace Microsoft.Alm.Cli.Test
@@ -30,7 +31,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                cut = new OperationArguments(memory);
+                cut = new OperationArguments(RuntimeContext.Default, memory);
             }
 
             Assert.Equal(input.Protocol, cut.QueryProtocol);
@@ -68,7 +69,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                cut = new OperationArguments(memory);
+                cut = new OperationArguments(RuntimeContext.Default, memory);
             }
 
             Assert.Equal(input.Protocol, cut.QueryProtocol, StringComparer.Ordinal);
@@ -194,7 +195,7 @@ namespace Microsoft.Alm.Cli.Test
 
                 memory.Seek(0, SeekOrigin.Begin);
 
-                var oparg = new OperationArguments(memory);
+                var oparg = new OperationArguments(RuntimeContext.Default, memory);
 
                 Assert.NotNull(oparg);
                 Assert.Equal(input.Protocol ?? string.Empty, oparg.QueryProtocol, StringComparer.Ordinal);

--- a/Cli-CredentialHelper.Test/ProgramTests.cs
+++ b/Cli-CredentialHelper.Test/ProgramTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Alm.Cli.Test
             {
                 { "HOME", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) },
             };
-            var gitconfig = new Git.Configuration(configs);
+            var gitconfig = new Git.Configuration(RuntimeContext.Default, configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();
@@ -200,7 +200,7 @@ namespace Microsoft.Alm.Cli.Test
             if (!setupComplete)
                 return;
 
-            var gitconfig = new Git.Configuration(configs);
+            var gitconfig = new Git.Configuration(RuntimeContext.Default, configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();
@@ -294,7 +294,7 @@ namespace Microsoft.Alm.Cli.Test
             if (!setupComplete)
                 return;
 
-            var gitconfig = new Git.Configuration(configs);
+            var gitconfig = new Git.Configuration(RuntimeContext.Default, configs);
             var targetUri = new Authentication.TargetUri("https://example.visualstudio.com/");
 
             var opargsMock = new Mock<OperationArguments>();

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -231,9 +231,9 @@ namespace Microsoft.Alm.Cli
 
                     // if the custom path points to a git location then treat it properly
                     Installation installation;
-                    if (Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows64v2, out installation)
-                        || Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v2, out installation)
-                        || Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v1, out installation))
+                    if (Program.Context.Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows64v2, out installation)
+                        || Program.Context.Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v2, out installation)
+                        || Program.Context.Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v1, out installation))
                     {
                         Program.Context.Trace.WriteLine($"   Git found: '{installation.Path}'.");
 
@@ -252,7 +252,7 @@ namespace Microsoft.Alm.Cli
                     Program.Out.WriteLine();
                     Program.Out.WriteLine("Looking for Git installation(s)...");
 
-                    if (Where.FindGitInstallations(out installations))
+                    if (Program.Context.Where.FindGitInstallations(out installations))
                     {
                         foreach (var installation in installations)
                         {
@@ -498,9 +498,9 @@ namespace Microsoft.Alm.Cli
 
                     // if the custom path points to a git location then treat it properly
                     Installation installation;
-                    if (Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows64v2, out installation)
-                        || Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v2, out installation)
-                        || Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v1, out installation))
+                    if (Program.Context.Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows64v2, out installation)
+                        || Program.Context.Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v2, out installation)
+                        || Program.Context.Where.FindGitInstallation(_customPath, KnownDistribution.GitForWindows32v1, out installation))
                     {
                         Program.Context.Trace.WriteLine($"Git found: '{installation.Path}'.");
 
@@ -517,7 +517,7 @@ namespace Microsoft.Alm.Cli
                     Program.Out.WriteLine();
                     Program.Out.WriteLine("Looking for Git installation(s)...");
 
-                    if (Where.FindGitInstallations(out installations))
+                    if (Program.Context.Where.FindGitInstallations(out installations))
                     {
                         foreach (var installation in installations)
                         {
@@ -707,7 +707,7 @@ namespace Microsoft.Alm.Cli
 
             updated = ConfigurationLevel.None;
 
-            if ((installations == null || installations.Count == 0) && !Where.FindGitInstallations(out installations))
+            if ((installations == null || installations.Count == 0) && !Program.Context.Where.FindGitInstallations(out installations))
             {
                 Program.Context.Trace.WriteLine("No Git installations detected to update.");
                 return false;

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Alm.Cli
                     {
                         string path = Path.Combine(drive.RootDirectory.FullName, Cygwin64GitPath);
 
-                        if (Directory.Exists(path))
+                        if (Program.FileSystem.DirectoryExists(path))
                         {
                             Program.Context.Trace.WriteLine($"cygwin directory found at '{path}'.");
 
@@ -137,7 +137,7 @@ namespace Microsoft.Alm.Cli
 
                         path = Path.Combine(drive.RootDirectory.FullName, Cygwin32GitPath);
 
-                        if (Directory.Exists(path))
+                        if (Program.FileSystem.DirectoryExists(path))
                         {
                             Program.Context.Trace.WriteLine($"cygwin directory found at '{path}'.");
 
@@ -169,13 +169,13 @@ namespace Microsoft.Alm.Cli
 
                     // Git for Windows checks %HOME% first
                     if ((val1 = vars["HOME"] as string) != null
-                        && Directory.Exists(val1))
+                        && Program.FileSystem.DirectoryExists(val1))
                     {
                         _userBinPath = val1;
                     }
                     // Git for Windows checks %HOMEDRIVE%%HOMEPATH% second
                     else if ((val1 = vars["HOMEDRIVE"] as string) != null && (val2 = vars["HOMEPATH"] as string) != null
-                        && Directory.Exists(val3 = val1 + val2))
+                        && Program.FileSystem.DirectoryExists(val3 = val1 + val2))
                     {
                         _userBinPath = val3;
                     }
@@ -215,7 +215,7 @@ namespace Microsoft.Alm.Cli
                 // use the custom installation path if supplied
                 if (!string.IsNullOrEmpty(_customPath))
                 {
-                    if (!Directory.Exists(_customPath))
+                    if (!Program.FileSystem.DirectoryExists(_customPath))
                     {
                         Program.LogEvent("No Git installation found, unable to continue deployment.", EventLogEntryType.Error);
                         Program.Out.WriteLine();
@@ -288,7 +288,7 @@ namespace Microsoft.Alm.Cli
                         }
 
                         // copy help documents
-                        if (Directory.Exists(installation.Doc)
+                        if (Program.FileSystem.DirectoryExists(installation.Doc)
                             && CopyFiles(Program.Location, installation.Doc, DocsList, out copiedFiles))
                         {
                             copiedCount += copiedFiles.Count;
@@ -321,9 +321,9 @@ namespace Microsoft.Alm.Cli
                 Program.Out.WriteLine();
                 Program.Out.WriteLine($"Deploying from '{Program.Location}' to '{UserBinPath}'.");
 
-                if (!Directory.Exists(UserBinPath))
+                if (!Program.FileSystem.DirectoryExists(UserBinPath))
                 {
-                    Directory.CreateDirectory(UserBinPath);
+                    Program.FileSystem.CreateDirectory(UserBinPath);
                 }
 
                 if (CopyFiles(Program.Location, UserBinPath, FileList, out copiedFiles))
@@ -363,7 +363,7 @@ namespace Microsoft.Alm.Cli
                     return;
                 }
 
-                if (CygwinPath != null && Directory.Exists(CygwinPath))
+                if (CygwinPath != null && Program.FileSystem.DirectoryExists(CygwinPath))
                 {
                     if (CopyFiles(Program.Location, CygwinPath, FileList, out copiedFiles))
                     {
@@ -483,7 +483,7 @@ namespace Microsoft.Alm.Cli
                 // use the custom installation path if supplied
                 if (!string.IsNullOrEmpty(_customPath))
                 {
-                    if (!Directory.Exists(_customPath))
+                    if (!Program.FileSystem.DirectoryExists(_customPath))
                     {
                         Program.Out.WriteLine();
                         Program.WriteLine($"fatal: custom path does not exist: '{_customPath}'. U_U");
@@ -594,7 +594,7 @@ namespace Microsoft.Alm.Cli
                         }
 
                         // clean help documents
-                        if (Directory.Exists(installation.Doc)
+                        if (Program.FileSystem.DirectoryExists(installation.Doc)
                             && CleanFiles(installation.Doc, DocsList, out cleanedFiles))
                         {
                             cleanedCount += cleanedFiles.Count;
@@ -621,7 +621,7 @@ namespace Microsoft.Alm.Cli
                     }
                 }
 
-                if (Directory.Exists(UserBinPath))
+                if (Program.FileSystem.DirectoryExists(UserBinPath))
                 {
                     Program.Out.WriteLine();
                     Program.Out.WriteLine($"Removing from '{UserBinPath}'.");
@@ -661,7 +661,7 @@ namespace Microsoft.Alm.Cli
                     }
                 }
 
-                if (CygwinPath != null && Directory.Exists(CygwinPath))
+                if (CygwinPath != null && Program.FileSystem.DirectoryExists(CygwinPath))
                 {
                     if (CleanFiles(CygwinPath, FileList, out cleanedFiles))
                     {
@@ -777,7 +777,7 @@ namespace Microsoft.Alm.Cli
         {
             cleanedFiles = new List<string>();
 
-            if (!Directory.Exists(path))
+            if (!Program.FileSystem.DirectoryExists(path))
             {
                 Program.Context.Trace.WriteLine($"path '{path}' does not exist.");
                 return false;
@@ -791,7 +791,7 @@ namespace Microsoft.Alm.Cli
 
                     Program.Context.Trace.WriteLine($"clean '{target}'.");
 
-                    File.Delete(target);
+                    Program.FileSystem.FileDelete(target);
 
                     cleanedFiles.Add(file);
                 }
@@ -809,13 +809,13 @@ namespace Microsoft.Alm.Cli
         {
             copiedFiles = new List<string>();
 
-            if (!Directory.Exists(srcPath))
+            if (!Program.FileSystem.DirectoryExists(srcPath))
             {
                 Program.Context.Trace.WriteLine($"source '{srcPath}' does not exist.");
                 return false;
             }
 
-            if (Directory.Exists(dstPath))
+            if (Program.FileSystem.DirectoryExists(dstPath))
             {
                 try
                 {
@@ -826,7 +826,7 @@ namespace Microsoft.Alm.Cli
                         string src = Path.Combine(srcPath, file);
                         string dst = Path.Combine(dstPath, file);
 
-                        File.Copy(src, dst, true);
+                        Program.FileSystem.FileCopy(src, dst, true);
 
                         copiedFiles.Add(file);
                     }
@@ -918,7 +918,7 @@ namespace Microsoft.Alm.Cli
             if (string.IsNullOrEmpty(gitCmdPath) || string.IsNullOrEmpty(command))
                 return false;
 
-            if (!File.Exists(gitCmdPath))
+            if (!Program.FileSystem.FileExists(gitCmdPath))
                 return false;
 
             var options = new ProcessStartInfo()

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Alm.Cli
             WriteLine("usage: " + Name + ".exe [" + string.Join("|", CommandList) + "] [<args>]");
 
             List<Git.Installation> installations;
-            if (Git.Where.FindGitInstallations(out installations))
+            if (_context.Where.FindGitInstallations(out installations))
             {
                 foreach (var installation in installations)
                 {

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -368,12 +368,12 @@ namespace Microsoft.Alm.Cli
             {
                 foreach (var installation in installations)
                 {
-                    if (Directory.Exists(installation.Doc))
+                    if (FileSystem.DirectoryExists(installation.Doc))
                     {
                         string doc = Path.Combine(installation.Doc, HelpFileName);
 
                         // if the help file exists, send it to the operating system to display to the user
-                        if (File.Exists(doc))
+                        if (FileSystem.FileExists(doc))
                         {
                             Context.Trace.WriteLine($"opening help documentation '{doc}'.");
 

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentException(innerException.Message, nameof(operationArguments), innerException);
             }
 
+            var trace = program.Context.Trace;
             var secretsNamespace = operationArguments.CustomNamespace ?? Program.SecretsNamespace;
             BaseAuthentication authority = null;
 
@@ -81,7 +82,7 @@ namespace Microsoft.Alm.Cli
             switch (operationArguments.Authority)
             {
                 case AuthorityType.Auto:
-                    Git.Trace.WriteLine($"detecting authority type for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"detecting authority type for '{operationArguments.TargetUri}'.");
 
                     // Detect the authority.
                     authority = await BaseVstsAuthentication.GetAuthentication(program.Context,
@@ -128,12 +129,12 @@ namespace Microsoft.Alm.Cli
                     goto default;
 
                 case AuthorityType.AzureDirectory:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Azure Directory.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Azure Directory.");
 
                     Guid tenantId = Guid.Empty;
 
                     // Get the identity of the tenant.
-                    var result = await BaseVstsAuthentication.DetectAuthority(operationArguments.TargetUri);
+                    var result = await BaseVstsAuthentication.DetectAuthority(program.Context, operationArguments.TargetUri);
 
                     if (result.Key)
                     {
@@ -152,7 +153,7 @@ namespace Microsoft.Alm.Cli
                     goto default;
 
                 case AuthorityType.GitHub:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is GitHub.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is GitHub.");
 
                     // Return a GitHub authentication object.
                     return authority ?? new Github.Authentication(program.Context,
@@ -164,7 +165,7 @@ namespace Microsoft.Alm.Cli
                                                                   null);
 
                 case AuthorityType.Bitbucket:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}'  is Bitbucket");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}'  is Bitbucket");
 
                     // Return a Bitbucket authentication object.
                     return authority ?? new Bitbucket.Authentication(program.Context,
@@ -173,7 +174,7 @@ namespace Microsoft.Alm.Cli
                                                                      bitbucketOauthCallback);
 
                 case AuthorityType.MicrosoftAccount:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Microsoft Live.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Microsoft Live.");
 
                     // Return the allocated authority or a generic MSA backed VSTS authentication object.
                     return authority ?? new VstsMsaAuthentication(program.Context,
@@ -186,7 +187,7 @@ namespace Microsoft.Alm.Cli
                     goto default;
 
                 default:
-                    Git.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is basic with NTLM={basicNtlmSupport}.");
+                    trace.WriteLine($"authority for '{operationArguments.TargetUri}' is basic with NTLM={basicNtlmSupport}.");
 
                     // Return a generic username + password authentication object.
                     return authority ?? new BasicAuthentication(program.Context, 
@@ -204,28 +205,29 @@ namespace Microsoft.Alm.Cli
             if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
+            var trace = program.Context.Trace;
             BaseAuthentication authentication = await program.CreateAuthentication(operationArguments);
 
             switch (operationArguments.Authority)
             {
                 default:
                 case AuthorityType.Basic:
-                    Git.Trace.WriteLine($"deleting basic credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting basic credentials for '{operationArguments.TargetUri}'.");
                     return await authentication.DeleteCredentials(operationArguments.TargetUri);
 
                 case AuthorityType.AzureDirectory:
                 case AuthorityType.MicrosoftAccount:
-                    Git.Trace.WriteLine($"deleting VSTS credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting VSTS credentials for '{operationArguments.TargetUri}'.");
                     var vstsAuth = authentication as BaseVstsAuthentication;
                     return await vstsAuth.DeleteCredentials(operationArguments.TargetUri);
 
                 case AuthorityType.GitHub:
-                    Git.Trace.WriteLine($"deleting GitHub credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting GitHub credentials for '{operationArguments.TargetUri}'.");
                     var ghAuth = authentication as Github.Authentication;
                     return await ghAuth.DeleteCredentials(operationArguments.TargetUri);
 
                 case AuthorityType.Bitbucket:
-                    Git.Trace.WriteLine($"deleting Bitbucket credentials for '{operationArguments.TargetUri}'.");
+                    trace.WriteLine($"deleting Bitbucket credentials for '{operationArguments.TargetUri}'.");
                     var bbAuth = authentication as Bitbucket.Authentication;
                     return await bbAuth.DeleteCredentials(operationArguments.TargetUri, operationArguments.Username);
             }
@@ -238,7 +240,7 @@ namespace Microsoft.Alm.Cli
             if (exception is null)
                 throw new ArgumentNullException(nameof(exception));
 
-            Git.Trace.WriteLine(exception.ToString(), path, line, name);
+            program.Context.Trace.WriteLine(exception.ToString(), path, line, name);
             program.LogEvent(exception.ToString(), EventLogEntryType.Error);
 
             string message;
@@ -273,14 +275,16 @@ namespace Microsoft.Alm.Cli
             if (operationArguments is null)
                 throw new ArgumentNullException(nameof(operationArguments));
 
+            var trace = program.Context.Trace;
+
             if (operationArguments.WriteLog)
             {
-                Git.Trace.WriteLine("trace logging enabled.");
+                trace.WriteLine("trace logging enabled.");
 
                 string gitConfigPath;
                 if (Git.Where.GitLocalConfig(out gitConfigPath))
                 {
-                    Git.Trace.WriteLine($"git local config found at '{gitConfigPath}'.");
+                    trace.WriteLine($"git local config found at '{gitConfigPath}'.");
 
                     string gitDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -291,7 +295,7 @@ namespace Microsoft.Alm.Cli
                 }
                 else if (Git.Where.GitGlobalConfig(out gitConfigPath))
                 {
-                    Git.Trace.WriteLine($"git global config found at '{gitConfigPath}'.");
+                    trace.WriteLine($"git global config found at '{gitConfigPath}'.");
 
                     string homeDirPath = Path.GetDirectoryName(gitConfigPath);
 
@@ -302,7 +306,7 @@ namespace Microsoft.Alm.Cli
                 }
             }
 #if DEBUG
-            Git.Trace.WriteLine($"GCM arguments:{Environment.NewLine}{operationArguments}");
+            trace.WriteLine($"GCM arguments:{Environment.NewLine}{operationArguments}");
 #endif
         }
 
@@ -317,6 +321,7 @@ namespace Microsoft.Alm.Cli
             if (logFilePath is null)
                 throw new ArgumentNullException(nameof(logFilePath));
 
+            var trace = program.Context.Trace;
             string logFileName = Path.Combine(logFilePath, Path.ChangeExtension(Program.ConfigPrefix, ".log"));
 
             var logFileInfo = new FileInfo(logFileName);
@@ -335,12 +340,12 @@ namespace Microsoft.Alm.Cli
                 }
             }
 
-            Git.Trace.WriteLine($"trace log destination is '{logFilePath}'.");
+            trace.WriteLine($"trace log destination is '{logFilePath}'.");
 
             using (var fileStream = File.Open(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
             {
                 var listener = new StreamWriter(fileStream, Encoding.UTF8);
-                Git.Trace.AddListener(listener);
+                trace.AddListener(listener);
 
                 // write a small header to help with identifying new log entries
                 listener.Write('\n');
@@ -361,19 +366,21 @@ namespace Microsoft.Alm.Cli
                 program.Die("No host information, unable to continue.");
             }
 
+            var trace = program.Context.Trace;
+
             string value;
             bool? yesno;
 
             if (program.TryReadBoolean(operationArguments, KeyType.ConfigNoLocal, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoLocal)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoLocal)} = '{yesno}'.");
 
                 operationArguments.UseConfigLocal = yesno.Value;
             }
 
             if (program.TryReadBoolean(operationArguments, KeyType.ConfigNoSystem, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoSystem)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.ConfigNoSystem)} = '{yesno}'.");
 
                 operationArguments.UseConfigSystem = yesno.Value;
             }
@@ -384,7 +391,7 @@ namespace Microsoft.Alm.Cli
             // If a user-agent has been specified in the environment, set it globally.
             if (program.TryReadString(operationArguments, KeyType.HttpUserAgent, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpUserAgent)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.HttpUserAgent)} = '{value}'.");
 
                 Global.UserAgent = value;
             }
@@ -392,7 +399,7 @@ namespace Microsoft.Alm.Cli
             // Look for authority settings.
             if (program.TryReadString(operationArguments, KeyType.Authority, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Authority)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Authority)} = '{value}'.");
 
                 if (Program.ConfigKeyComparer.Equals(value, "MSA")
                     || Program.ConfigKeyComparer.Equals(value, "Microsoft")
@@ -436,7 +443,7 @@ namespace Microsoft.Alm.Cli
             // Look for interactivity config settings.
             if (program.TryReadString(operationArguments, KeyType.Interactive, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Interactive)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Interactive)} = '{value}'.");
 
                 if (Program.ConfigKeyComparer.Equals(value, "always")
                     || Program.ConfigKeyComparer.Equals(value, "true")
@@ -454,7 +461,7 @@ namespace Microsoft.Alm.Cli
             // Look for credential validation config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.Validate, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Validate)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Validate)} = '{yesno}'.");
 
                 operationArguments.ValidateCredentials = yesno.Value;
             }
@@ -462,7 +469,7 @@ namespace Microsoft.Alm.Cli
             // Look for write log config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.Writelog, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Writelog)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Writelog)} = '{yesno}'.");
 
                 operationArguments.WriteLog = yesno.Value;
             }
@@ -470,7 +477,7 @@ namespace Microsoft.Alm.Cli
             // Look for modal prompt config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.ModalPrompt, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.ModalPrompt)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.ModalPrompt)} = '{yesno}'.");
 
                 operationArguments.UseModalUi = yesno.Value;
             }
@@ -478,7 +485,7 @@ namespace Microsoft.Alm.Cli
             // Look for credential preservation config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.PreserveCredentials, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.PreserveCredentials)} = '{yesno}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.PreserveCredentials)} = '{yesno}'.");
 
                 operationArguments.PreserveCredentials = yesno.Value;
             }
@@ -489,18 +496,18 @@ namespace Microsoft.Alm.Cli
                     || StringComparer.OrdinalIgnoreCase.Equals(value, "1")
                     || StringComparer.OrdinalIgnoreCase.Equals(value, "on"))
                 {
-                    Git.Trace.WriteLine($"GCM_PRESERVE_CREDS = '{yesno}'.");
+                    trace.WriteLine($"GCM_PRESERVE_CREDS = '{yesno}'.");
 
                     operationArguments.PreserveCredentials = true;
 
-                    Git.Trace.WriteLine($"WARNING: the 'GCM_PRESERVE_CREDS' variable has been deprecated, use '{ program.KeyTypeName(KeyType.PreserveCredentials) }' instead.");
+                    trace.WriteLine($"WARNING: the 'GCM_PRESERVE_CREDS' variable has been deprecated, use '{ program.KeyTypeName(KeyType.PreserveCredentials) }' instead.");
                 }
             }
 
             // Look for HTTP path usage config settings.
             if (program.TryReadBoolean(operationArguments, KeyType.HttpPath, out yesno))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpPath)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.HttpPath)} = '{value}'.");
 
                 operationArguments.UseHttpPath = yesno.Value;
             }
@@ -510,7 +517,7 @@ namespace Microsoft.Alm.Cli
                     && program.TryReadString(operationArguments, KeyType.HttpsProxy, out value))
                 || program.TryReadString(operationArguments, KeyType.HttpProxy, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.HttpProxy)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.HttpProxy)} = '{value}'.");
 
                 operationArguments.SetProxy(value);
             }
@@ -518,14 +525,14 @@ namespace Microsoft.Alm.Cli
             else if ((operationArguments.EnvironmentVariables.TryGetValue("GCM_HTTP_PROXY", out value)
                     && !string.IsNullOrWhiteSpace(value)))
             {
-                Git.Trace.WriteLine($"GCM_HTTP_PROXY = '{value}'.");
+                trace.WriteLine($"GCM_HTTP_PROXY = '{value}'.");
 
                 var keyName = (operationArguments.TargetUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                     ? "HTTPS_PROXY"
                     : "HTTP_PROXY";
                 var warning = $"WARNING: the 'GCM_HTTP_PROXY' variable has been deprecated, use '{ keyName }' instead.";
 
-                Git.Trace.WriteLine(warning);
+                trace.WriteLine(warning);
                 program.WriteLine(warning);
 
                 operationArguments.SetProxy(value);
@@ -537,7 +544,7 @@ namespace Microsoft.Alm.Cli
                 if (operationArguments.GitConfiguration.TryGetEntry("http", operationArguments.QueryUri, "proxy", out entry)
                     && !string.IsNullOrWhiteSpace(entry.Value))
                 {
-                    Git.Trace.WriteLine($"http.proxy = '{entry.Value}'.");
+                    trace.WriteLine($"http.proxy = '{entry.Value}'.");
 
                     operationArguments.SetProxy(entry.Value);
                 }
@@ -546,7 +553,7 @@ namespace Microsoft.Alm.Cli
             // Look for custom namespace config settings.
             if (program.TryReadString(operationArguments, KeyType.Namespace, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Namespace)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Namespace)} = '{value}'.");
 
                 operationArguments.CustomNamespace = value;
             }
@@ -554,7 +561,7 @@ namespace Microsoft.Alm.Cli
             // Look for custom token duration settings.
             if (program.TryReadString(operationArguments, KeyType.TokenDuration, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.TokenDuration)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.TokenDuration)} = '{value}'.");
 
                 int hours;
                 if (int.TryParse(value, out hours))
@@ -566,7 +573,7 @@ namespace Microsoft.Alm.Cli
             // Look for custom VSTS scope settings.
             if (program.TryReadString(operationArguments, KeyType.VstsScope, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.VstsScope)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.VstsScope)} = '{value}'.");
 
                 VstsTokenScope vstsTokenScope = VstsTokenScope.None;
 
@@ -581,7 +588,7 @@ namespace Microsoft.Alm.Cli
                     }
                     else
                     {
-                        Git.Trace.WriteLine($"Unknown VSTS Token scope: '{scopes[i]}'.");
+                        trace.WriteLine($"Unknown VSTS Token scope: '{scopes[i]}'.");
                     }
                 }
 
@@ -591,7 +598,7 @@ namespace Microsoft.Alm.Cli
             // Check for configuration supplied user-info.
             if (program.TryReadString(operationArguments, KeyType.Username, out value))
             {
-                Git.Trace.WriteLine($"{program.KeyTypeName(KeyType.Username)} = '{value}'.");
+                trace.WriteLine($"{program.KeyTypeName(KeyType.Username)} = '{value}'.");
 
                 operationArguments.Username = value;
             }
@@ -606,7 +613,7 @@ namespace Microsoft.Alm.Cli
 
             /*** try-squelch due to UAC issues which require a proper installer to work around ***/
 
-            Git.Trace.WriteLine(message);
+            program.Context.Trace.WriteLine(message);
 
             try
             {
@@ -641,7 +648,7 @@ namespace Microsoft.Alm.Cli
             }
 
             // Fake being part of the Main method for clarity.
-            Git.Trace.WriteLine(builder.ToString(), memberName: "Main");
+            program.Context.Trace.WriteLine(builder.ToString(), memberName: "Main");
             builder = null;
         }
 
@@ -659,6 +666,7 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentException(innerException.Message, nameof(operationArguments), innerException);
             }
 
+            var trace = program.Context.Trace;
             BaseAuthentication authentication = await program.CreateAuthentication(operationArguments);
             Credential credentials = null;
 
@@ -675,13 +683,13 @@ namespace Microsoft.Alm.Cli
                             || (operationArguments.Interactivity != Interactivity.Never
                                 && (credentials = await basicAuth.AcquireCredentials(operationArguments.TargetUri)) != null))
                         {
-                            Git.Trace.WriteLine("credentials found.");
+                            trace.WriteLine("credentials found.");
                             // No need to save the credentials explicitly, as Git will call back
                             // with a store command if the credentials are valid.
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -712,12 +720,12 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await aadAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             program.LogEvent($"Azure Directory credentials  for '{operationArguments.TargetUri}' successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve Azure Directory credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -744,12 +752,12 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await msaAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             program.LogEvent($"Microsoft Live credentials for '{operationArguments.TargetUri}' successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve Microsoft Live credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -768,12 +776,12 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || await ghAuth.ValidateCredentials(operationArguments.TargetUri, credentials))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             program.LogEvent($"GitHub credentials for '{operationArguments.TargetUri}' successfully retrieved.", EventLogEntryType.SuccessAudit);
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' not found.");
                             program.LogEvent($"Failed to retrieve GitHub credentials for '{operationArguments.TargetUri}'.", EventLogEntryType.FailureAudit);
                         }
                     }
@@ -792,7 +800,7 @@ namespace Microsoft.Alm.Cli
                                 && (!operationArguments.ValidateCredentials
                                     || ((credentials = await bbcAuth.ValidateCredentials(operationArguments.TargetUri, operationArguments.Username, credentials)) != null))))
                         {
-                            Git.Trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
+                            trace.WriteLine($"credentials for '{operationArguments.TargetUri}' found.");
                             // Bitbucket relies on a username + secret, so make sure there is a
                             // username to return.
                             if (operationArguments.Username != null)
@@ -810,7 +818,7 @@ namespace Microsoft.Alm.Cli
 
                 case AuthorityType.Ntlm:
                     {
-                        Git.Trace.WriteLine($"'{operationArguments.TargetUri}' is NTLM.");
+                        trace.WriteLine($"'{operationArguments.TargetUri}' is NTLM.");
                         credentials = BasicAuthentication.NtlmCredentials;
                     }
                     break;

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Alm.Cli
 
                     string gitDirPath = Path.GetDirectoryName(gitConfigPath);
 
-                    if (Directory.Exists(gitDirPath))
+                    if (program.FileSystem.DirectoryExists(gitDirPath))
                     {
                         program.EnableTraceLogging(operationArguments, gitDirPath);
                     }
@@ -300,7 +300,7 @@ namespace Microsoft.Alm.Cli
 
                     string homeDirPath = Path.GetDirectoryName(gitConfigPath);
 
-                    if (Directory.Exists(homeDirPath))
+                    if (program.FileSystem.DirectoryExists(homeDirPath))
                     {
                         program.EnableTraceLogging(operationArguments, homeDirPath);
                     }
@@ -322,6 +322,7 @@ namespace Microsoft.Alm.Cli
             if (logFilePath is null)
                 throw new ArgumentNullException(nameof(logFilePath));
 
+            var fs = program.FileSystem;
             var trace = program.Context.Trace;
             string logFileName = Path.Combine(logFilePath, Path.ChangeExtension(Program.ConfigPrefix, ".log"));
 
@@ -333,7 +334,7 @@ namespace Microsoft.Alm.Cli
                     string moveName = string.Format("{0}{1:000}.log", Program.ConfigPrefix, i);
                     string movePath = Path.Combine(logFilePath, moveName);
 
-                    if (!File.Exists(movePath))
+                    if (!fs.FileExists(movePath))
                     {
                         logFileInfo.MoveTo(movePath);
                         break;
@@ -343,7 +344,7 @@ namespace Microsoft.Alm.Cli
 
             trace.WriteLine($"trace log destination is '{logFilePath}'.");
 
-            using (var fileStream = File.Open(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            using (var fileStream = fs.FileOpen(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
             {
                 var listener = new StreamWriter(fileStream, Encoding.UTF8);
                 trace.AddListener(listener);

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -276,13 +276,14 @@ namespace Microsoft.Alm.Cli
                 throw new ArgumentNullException(nameof(operationArguments));
 
             var trace = program.Context.Trace;
+            var where = program.Context.Where;
 
             if (operationArguments.WriteLog)
             {
                 trace.WriteLine("trace logging enabled.");
 
                 string gitConfigPath;
-                if (Git.Where.GitLocalConfig(out gitConfigPath))
+                if (where.GitLocalConfig(out gitConfigPath))
                 {
                     trace.WriteLine($"git local config found at '{gitConfigPath}'.");
 
@@ -293,7 +294,7 @@ namespace Microsoft.Alm.Cli
                         program.EnableTraceLogging(operationArguments, gitDirPath);
                     }
                 }
-                else if (Git.Where.GitGlobalConfig(out gitConfigPath))
+                else if (where.GitGlobalConfig(out gitConfigPath))
                 {
                     trace.WriteLine($"git global config found at '{gitConfigPath}'.");
 

--- a/Cli-Shared/Functions/Console.cs
+++ b/Cli-Shared/Functions/Console.cs
@@ -43,7 +43,12 @@ namespace Microsoft.Alm.Cli
             // ReadConsole 32768 fail, 32767 OK @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
             const int BufferReadSize = 16 * 1024;
 
-            Debug.Assert(targetUri != null);
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            var trace = program.Context.Trace;
 
             titleMessage = titleMessage ?? "Please enter your credentials for ";
 
@@ -64,7 +69,7 @@ namespace Microsoft.Alm.Cli
                 // Read the current console mode.
                 if (stdin.IsInvalid || stdout.IsInvalid)
                 {
-                    Git.Trace.WriteLine("not a tty detected, abandoning prompt.");
+                    trace.WriteLine("not a tty detected, abandoning prompt.");
                     return null;
                 }
                 else if (!NativeMethods.GetConsoleMode(stdin, out consoleMode))
@@ -73,7 +78,7 @@ namespace Microsoft.Alm.Cli
                     throw new Win32Exception(error, "Unable to determine console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                 }
 
-                Git.Trace.WriteLine($"console mode = '{consoleMode}'.");
+                trace.WriteLine($"console mode = '{consoleMode}'.");
 
                 string username = null;
                 string password = null;
@@ -127,7 +132,7 @@ namespace Microsoft.Alm.Cli
                         throw new Win32Exception(error, "Unable to set console mode (" + NativeMethods.Win32Error.GetText(error) + ").");
                     }
 
-                    Git.Trace.WriteLine($"console mode = '{consoleMode2}'.");
+                    trace.WriteLine($"console mode = '{consoleMode2}'.");
 
                     // Prompt the user for password.
                     buffer.Append("password: ");
@@ -156,7 +161,7 @@ namespace Microsoft.Alm.Cli
                     // Restore the console mode to its original value.
                     NativeMethods.SetConsoleMode(stdin, consoleMode);
 
-                    Git.Trace.WriteLine($"console mode = '{consoleMode}'.");
+                    trace.WriteLine($"console mode = '{consoleMode}'.");
                 }
 
                 if (username != null && password != null)
@@ -168,13 +173,18 @@ namespace Microsoft.Alm.Cli
 
         public static void Exit(Program program, int exitcode, string message, string path, int line, string name)
         {
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+
+            var trace = program.Context.Trace;
+
             if (!string.IsNullOrWhiteSpace(message))
             {
-                Git.Trace.WriteLine(message, path, line, name);
+                trace.WriteLine(message, path, line, name);
                 program.WriteLine(message);
             }
 
-            Git.Trace.Flush();
+            trace.Flush();
 
             Environment.Exit(exitcode);
         }

--- a/Cli-Shared/Functions/Dialog.cs
+++ b/Cli-Shared/Functions/Dialog.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Alm.Cli
             if (program is null)
                 throw new ArgumentNullException(nameof(program));
 
+            var trace = program.Context.Trace;
+
             int error;
 
             try
@@ -64,7 +66,7 @@ namespace Microsoft.Alm.Cli
                                                                              saveCredentials: ref saveCredentials,
                                                                              flags: flags)) != NativeMethods.Win32Error.Success)
                 {
-                    Git.Trace.WriteLine($"credential prompt failed ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"credential prompt failed ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     username = null;
                     password = null;
@@ -95,12 +97,12 @@ namespace Microsoft.Alm.Cli
                     password = null;
 
                     error = Marshal.GetLastWin32Error();
-                    Git.Trace.WriteLine($"failed to unpack buffer ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"failed to unpack buffer ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     return false;
                 }
 
-                Git.Trace.WriteLine("successfully acquired credentials from user.");
+                trace.WriteLine("successfully acquired credentials from user.");
 
                 username = usernameBuffer.ToString();
                 password = passwordBuffer.ToString();
@@ -188,6 +190,8 @@ namespace Microsoft.Alm.Cli
             int inBufferSize = 0;
             string password = null;
 
+            var trace = program.Context.Trace;
+
             try
             {
                 int error;
@@ -202,7 +206,7 @@ namespace Microsoft.Alm.Cli
                 if (inBufferSize <= 0)
                 {
                     error = Marshal.GetLastWin32Error();
-                    Git.Trace.WriteLine($"unable to determine credential buffer size ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"unable to determine credential buffer size ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     return null;
                 }
@@ -216,7 +220,7 @@ namespace Microsoft.Alm.Cli
                                                                 packedCredentialsSize: ref inBufferSize))
                 {
                     error = Marshal.GetLastWin32Error();
-                    Git.Trace.WriteLine($"unable to write to credential buffer ('{NativeMethods.Win32Error.GetText(error)}').");
+                    trace.WriteLine($"unable to write to credential buffer ('{NativeMethods.Win32Error.GetText(error)}').");
 
                     return null;
                 }

--- a/Cli-Shared/Functions/GitHub.cs
+++ b/Cli-Shared/Functions/GitHub.cs
@@ -42,7 +42,12 @@ namespace Microsoft.Alm.Cli
             // ReadConsole 32768 fail, 32767 ok @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
             const int BufferReadSize = 16 * 1024;
 
-            Debug.Assert(targetUri != null);
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            var trace = program.Context.Trace;
 
             StringBuilder buffer = new StringBuilder(BufferReadSize);
             uint read = 0;
@@ -62,7 +67,7 @@ namespace Microsoft.Alm.Cli
                     ? "app"
                     : "sms";
 
-                Git.Trace.WriteLine($"2fa type = '{type}'.");
+                trace.WriteLine($"2fa type = '{type}'.");
 
                 buffer.AppendLine()
                       .Append("authcode (")

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -34,10 +34,10 @@ using Git = Microsoft.Alm.Authentication.Git;
 
 namespace Microsoft.Alm.Cli
 {
-    internal class OperationArguments
+    internal class OperationArguments : Base
     {
-        public OperationArguments(Stream readableStream)
-                : this()
+        public OperationArguments(RuntimeContext context, Stream readableStream)
+                : this(context)
         {
             if (readableStream is null)
                 throw new ArgumentNullException(nameof(readableStream));
@@ -141,8 +141,8 @@ namespace Microsoft.Alm.Cli
             CreateTargetUri();
         }
 
-        public OperationArguments(Uri targetUri)
-            : this()
+        public OperationArguments(RuntimeContext context, Uri targetUri)
+            : this(context)
         {
             if (targetUri is null)
                 throw new ArgumentNullException("targetUri");
@@ -156,7 +156,8 @@ namespace Microsoft.Alm.Cli
             CreateTargetUri();
         }
 
-        public OperationArguments()
+        public OperationArguments(RuntimeContext context)
+            : base(context)
         {
             _authorityType = AuthorityType.Auto;
             _interactivity = Interactivity.Auto;
@@ -166,6 +167,11 @@ namespace Microsoft.Alm.Cli
             _validateCredentials = true;
             _vstsTokenScope = Program.VstsCredentialScope;
         }
+
+        // Test-only constructor
+        internal OperationArguments()
+            : this(RuntimeContext.Default)
+        { }
 
         private AuthorityType _authorityType;
         private Git.Configuration _configuration;
@@ -403,7 +409,7 @@ namespace Microsoft.Alm.Cli
 
         public virtual async Task LoadConfiguration()
         {
-            _configuration = await Git.Configuration.ReadConfiuration(Environment.CurrentDirectory, UseConfigLocal, UseConfigSystem);
+            _configuration = await Git.Configuration.ReadConfiuration(Context, Environment.CurrentDirectory, UseConfigLocal, UseConfigSystem);
         }
 
         public virtual void SetCredentials(string username, string password)
@@ -417,16 +423,16 @@ namespace Microsoft.Alm.Cli
 
             if (Uri.TryCreate(url, UriKind.Absolute, out tmp))
             {
-                Git.Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
+                Trace.WriteLine($"successfully set proxy to '{tmp.AbsoluteUri}'.");
             }
             else
             {
                 if (!string.IsNullOrWhiteSpace(url))
                 {
-                    Git.Trace.WriteLine($"failed to parse '{url}'.");
+                    Trace.WriteLine($"failed to parse '{url}'.");
                 }
 
-                Git.Trace.WriteLine("proxy cleared.");
+                Trace.WriteLine("proxy cleared.");
             }
 
             ProxyUri = tmp;

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -310,6 +310,9 @@ namespace Microsoft.Alm.Cli
             }
         }
 
+        internal IFileSystem FileSystem
+            => _context.FileSystem;
+
         internal TextReader In
         {
             get

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Alm.Cli
         internal static readonly StringComparer ConfigValueComparer = StringComparer.OrdinalIgnoreCase;
 
         internal const string EnvironConfigDebugKey = "GCM_DEBUG";
-        internal const string EnvironConfigTraceKey = Git.Trace.EnvironmentVariableKey;
+        internal const string EnvironConfigTraceKey = "GCM_TRACE";
 
         internal static readonly StringComparer EnvironKeyComparer = StringComparer.OrdinalIgnoreCase;
 
@@ -150,8 +150,6 @@ namespace Microsoft.Alm.Cli
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static Program()
         {
-            DebuggerLaunch();
-
             ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
         }
 
@@ -376,8 +374,11 @@ namespace Microsoft.Alm.Cli
             }
         }
 
-        internal static void DebuggerLaunch()
+        internal static void DebuggerLaunch(Program program)
         {
+            if (program is null)
+                throw new ArgumentNullException(nameof(program));
+
             if (Debugger.IsAttached)
                 return;
 
@@ -387,7 +388,7 @@ namespace Microsoft.Alm.Cli
                     || StringComparer.OrdinalIgnoreCase.Equals(debug, "1")
                     || StringComparer.OrdinalIgnoreCase.Equals(debug, "debug")))
             {
-                Git.Trace.WriteLine($"'{EnvironConfigDebugKey}': '{debug}', launching debugger...");
+                program.Context.Trace.WriteLine($"'{EnvironConfigDebugKey}': '{debug}', launching debugger...");
 
                 Debugger.Launch();
             }
@@ -453,7 +454,7 @@ namespace Microsoft.Alm.Cli
         {
             // use the stderr stream for the trace as stdout is used in the cross-process
             // communications protocol
-            Git.Trace.AddListener(Error);
+            _context.Trace.AddListener(Error);
         }
 
         internal void EnableTraceLogging(OperationArguments operationArguments)
@@ -475,7 +476,7 @@ namespace Microsoft.Alm.Cli
             if (!_configurationKeys.TryGetValue(type, out value)
                 && !_environmentKeys.TryGetValue(type, out value))
             {
-                Git.Trace.WriteLine($"BUG: unknown {nameof(KeyType)}: '{type}' encountered.");
+                _context.Trace.WriteLine($"BUG: unknown {nameof(KeyType)}: '{type}' encountered.");
             }
 
             return value;

--- a/GitHub.Authentication/Authentication.cs
+++ b/GitHub.Authentication/Authentication.cs
@@ -101,7 +101,7 @@ namespace GitHub.Authentication
             if (await PersonalAccessTokenStore.ReadCredentials(normalizedTargetUri) != null)
             {
                 result = await PersonalAccessTokenStore.DeleteCredentials(normalizedTargetUri);
-                Git.Trace.WriteLine($"credentials for '{normalizedTargetUri}' deleted");
+                Trace.WriteLine($"credentials for '{normalizedTargetUri}' deleted");
             }
 
             return result;
@@ -144,12 +144,12 @@ namespace GitHub.Authentication
                                                     acquireCredentialsCallback,
                                                     acquireAuthenticationCodeCallback,
                                                     authenticationResultCallback);
-                Git.Trace.WriteLine($"created GitHub authentication for '{normalizedTargetUri}'.");
+                context.Trace.WriteLine($"created GitHub authentication for '{normalizedTargetUri}'.");
             }
             else
             {
                 authentication = null;
-                Git.Trace.WriteLine($"not github.com, authentication creation aborted.");
+                context.Trace.WriteLine($"not github.com, authentication creation aborted.");
             }
 
             return authentication;
@@ -170,7 +170,7 @@ namespace GitHub.Authentication
             var normalizedTargetUri = NormalizeUri(targetUri);
             if ((credentials = await PersonalAccessTokenStore.ReadCredentials(normalizedTargetUri)) != null)
             {
-                Git.Trace.WriteLine($"credentials for '{normalizedTargetUri}' found.");
+                Trace.WriteLine($"credentials for '{normalizedTargetUri}' found.");
             }
 
             return credentials;
@@ -198,7 +198,7 @@ namespace GitHub.Authentication
 
                 if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, null, TokenScope))
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded");
+                    Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded");
 
                     credentials = (Credential)result.Token;
                     await PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
@@ -216,7 +216,7 @@ namespace GitHub.Authentication
                     {
                         if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, authenticationCode, TokenScope))
                         {
-                            Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
+                            Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
 
                             credentials = (Credential)result.Token;
                             await PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
@@ -232,7 +232,7 @@ namespace GitHub.Authentication
                 AuthenticationResultCallback?.Invoke(normalizedTargetUri, result);
             }
 
-            Git.Trace.WriteLine($"interactive logon for '{normalizedTargetUri}' failed.");
+            Trace.WriteLine($"interactive logon for '{normalizedTargetUri}' failed.");
             return credentials;
         }
 
@@ -262,7 +262,7 @@ namespace GitHub.Authentication
             AuthenticationResult result;
             if (result = await Authority.AcquireToken(normalizedTargetUri, username, password, authenticationCode, TokenScope))
             {
-                Git.Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
+                Trace.WriteLine($"token acquisition for '{normalizedTargetUri}' succeeded.");
 
                 credentials = (Credential)result.Token;
                 await PersonalAccessTokenStore.WriteCredentials(normalizedTargetUri, credentials);
@@ -270,7 +270,7 @@ namespace GitHub.Authentication
                 return credentials;
             }
 
-            Git.Trace.WriteLine($"non-interactive logon for '{normalizedTargetUri}' failed.");
+            Trace.WriteLine($"non-interactive logon for '{normalizedTargetUri}' failed.");
             return credentials;
         }
 

--- a/GitHub.Authentication/AuthenticationPrompts.cs
+++ b/GitHub.Authentication/AuthenticationPrompts.cs
@@ -47,7 +47,7 @@ namespace GitHub.Authentication
         {
             var credentialViewModel = new CredentialsViewModel();
 
-            Git.Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
+            Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
 
             bool credentialValid = ShowViewModel(credentialViewModel, () => new CredentialsWindow());
 
@@ -61,7 +61,7 @@ namespace GitHub.Authentication
         {
             var twoFactorViewModel = new TwoFactorViewModel(resultType == GitHubAuthenticationResultType.TwoFactorSms);
 
-            Git.Trace.WriteLine($"prompting user for authentication code for '{targetUri}'.");
+            Trace.WriteLine($"prompting user for authentication code for '{targetUri}'.");
 
             bool authenticationCodeValid = ShowViewModel(twoFactorViewModel, () => new TwoFactorWindow());
 

--- a/GitHub.Authentication/Authority.cs
+++ b/GitHub.Authentication/Authority.cs
@@ -125,7 +125,7 @@ namespace GitHub.Authentication
                 using (StringContent content = new StringContent(jsonContent, Encoding.UTF8, HttpJsonContentType))
                 using (HttpResponseMessage response = await httpClient.PostAsync(_authorityUrl, content))
                 {
-                    Git.Trace.WriteLine($"server responded with {response.StatusCode}.");
+                    Trace.WriteLine($"server responded with {response.StatusCode}.");
 
                     switch (response.StatusCode)
                     {
@@ -144,12 +144,12 @@ namespace GitHub.Authentication
 
                                 if (token == null)
                                 {
-                                    Git.Trace.WriteLine($"authentication for '{targetUri}' failed.");
+                                    Trace.WriteLine($"authentication for '{targetUri}' failed.");
                                     return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                                 else
                                 {
-                                    Git.Trace.WriteLine($"authentication success: new personal access token for '{targetUri}' created.");
+                                    Trace.WriteLine($"authentication success: new personal access token for '{targetUri}' created.");
                                     return new AuthenticationResult(GitHubAuthenticationResultType.Success, token);
                                 }
                             }
@@ -163,18 +163,18 @@ namespace GitHub.Authentication
 
                                     if (mfakvp.Value.First().Contains("app"))
                                     {
-                                        Git.Trace.WriteLine($"two-factor app authentication code required for '{targetUri}'.");
+                                        Trace.WriteLine($"two-factor app authentication code required for '{targetUri}'.");
                                         return new AuthenticationResult(GitHubAuthenticationResultType.TwoFactorApp);
                                     }
                                     else
                                     {
-                                        Git.Trace.WriteLine($"two-factor sms authentication code required for '{targetUri}'.");
+                                        Trace.WriteLine($"two-factor sms authentication code required for '{targetUri}'.");
                                         return new AuthenticationResult(GitHubAuthenticationResultType.TwoFactorSms);
                                     }
                                 }
                                 else
                                 {
-                                    Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
+                                    Trace.WriteLine($"authentication failed for '{targetUri}'.");
                                     return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
                                 }
                             }
@@ -186,15 +186,15 @@ namespace GitHub.Authentication
                             var contentBody = await response.Content.ReadAsStringAsync();
                             if (contentBody.Contains("This API can only be accessed with username and password Basic Auth"))
                             {
-                                Git.Trace.WriteLine($"authentication success: user supplied personal access token for '{targetUri}'.");
+                                Trace.WriteLine($"authentication success: user supplied personal access token for '{targetUri}'.");
 
                                 return new AuthenticationResult(GitHubAuthenticationResultType.Success, new Token(password, TokenType.Personal));
                             }
-                            Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
+                            Trace.WriteLine($"authentication failed for '{targetUri}'.");
                             return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
 
                         default:
-                            Git.Trace.WriteLine($"authentication failed for '{targetUri}'.");
+                            Trace.WriteLine($"authentication failed for '{targetUri}'.");
                             return new AuthenticationResult(GitHubAuthenticationResultType.Failure);
                     }
                 }
@@ -225,12 +225,12 @@ namespace GitHub.Authentication
                 {
                     if (response.IsSuccessStatusCode)
                     {
-                        Git.Trace.WriteLine($"credential validation for '{targetUri}' succeeded.");
+                        Trace.WriteLine($"credential validation for '{targetUri}' succeeded.");
                         return true;
                     }
                     else
                     {
-                        Git.Trace.WriteLine($"credential validation for '{targetUri}' failed.");
+                        Trace.WriteLine($"credential validation for '{targetUri}' failed.");
                         return false;
                     }
                 }

--- a/Microsoft.Alm.Authentication.Test/Git/InstallationTests.cs
+++ b/Microsoft.Alm.Authentication.Test/Git/InstallationTests.cs
@@ -15,23 +15,23 @@ namespace Microsoft.Alm.Authentication.Git.Test
         {
             List<Installation> list = new List<Installation>
             {
-                new Installation(@"C:\Program Files (x86)\Git", KnownDistribution.GitForWindows32v1),
-                new Installation(@"C:\Program Files (x86)\Git", KnownDistribution.GitForWindows32v2),
-                new Installation(@"C:\Program Files\Git", KnownDistribution.GitForWindows32v1),
-                new Installation(@"C:\Program Files\Git", KnownDistribution.GitForWindows32v2),
-                new Installation(@"C:\Program Files\Git", KnownDistribution.GitForWindows64v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files (x86)\Git", KnownDistribution.GitForWindows32v1),
+                new Installation(RuntimeContext.Default, @"C:\Program Files (x86)\Git", KnownDistribution.GitForWindows32v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git", KnownDistribution.GitForWindows32v1),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git", KnownDistribution.GitForWindows32v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git", KnownDistribution.GitForWindows64v2),
                 // ToLower versions
-                new Installation(@"C:\Program Files (x86)\Git".ToLower(), KnownDistribution.GitForWindows32v1),
-                new Installation(@"C:\Program Files (x86)\Git".ToLower(), KnownDistribution.GitForWindows32v2),
-                new Installation(@"C:\Program Files\Git".ToLower(), KnownDistribution.GitForWindows32v1),
-                new Installation(@"C:\Program Files\Git".ToLower(), KnownDistribution.GitForWindows32v2),
-                new Installation(@"C:\Program Files\Git".ToLower(), KnownDistribution.GitForWindows64v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files (x86)\Git".ToLower(), KnownDistribution.GitForWindows32v1),
+                new Installation(RuntimeContext.Default, @"C:\Program Files (x86)\Git".ToLower(), KnownDistribution.GitForWindows32v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git".ToLower(), KnownDistribution.GitForWindows32v1),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git".ToLower(), KnownDistribution.GitForWindows32v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git".ToLower(), KnownDistribution.GitForWindows64v2),
                 // ToUpper versions
-                new Installation(@"C:\Program Files (x86)\Git".ToUpper(), KnownDistribution.GitForWindows32v1),
-                new Installation(@"C:\Program Files (x86)\Git".ToUpper(), KnownDistribution.GitForWindows32v2),
-                new Installation(@"C:\Program Files\Git".ToUpper(), KnownDistribution.GitForWindows32v1),
-                new Installation(@"C:\Program Files\Git".ToUpper(), KnownDistribution.GitForWindows32v2),
-                new Installation(@"C:\Program Files\Git".ToUpper(), KnownDistribution.GitForWindows64v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files (x86)\Git".ToUpper(), KnownDistribution.GitForWindows32v1),
+                new Installation(RuntimeContext.Default, @"C:\Program Files (x86)\Git".ToUpper(), KnownDistribution.GitForWindows32v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git".ToUpper(), KnownDistribution.GitForWindows32v1),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git".ToUpper(), KnownDistribution.GitForWindows32v2),
+                new Installation(RuntimeContext.Default, @"C:\Program Files\Git".ToUpper(), KnownDistribution.GitForWindows64v2),
             };
 
             HashSet<Installation> set = new HashSet<Installation>(list);

--- a/Microsoft.Alm.Authentication.Test/Git/WhereTests.cs
+++ b/Microsoft.Alm.Authentication.Test/Git/WhereTests.cs
@@ -42,12 +42,10 @@ namespace Microsoft.Alm.Authentication.Git.Test
         [Fact]
         public void Where_FindGit()
         {
-            string gitPath;
-            if (!RuntimeContext.Default.Where.FindApp("git", out gitPath))
+            if (!RuntimeContext.Default.Where.FindApp("git", out string gitPath))
                 throw new Exception("Git not found on system");
 
-            List<Installation> installations;
-            Assert.True(RuntimeContext.Default.Where.FindGitInstallations(out installations));
+            Assert.True(RuntimeContext.Default.Where.FindGitInstallations(out List<Installation> installations));
             Assert.True(installations.Count > 0);
             Assert.True(PathComparer.Equals(installations[0].Git, gitPath));
 

--- a/Microsoft.Alm.Authentication.Test/Git/WhereTests.cs
+++ b/Microsoft.Alm.Authentication.Test/Git/WhereTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Alm.Authentication.Git.Test
 {
     public class WhereTests
     {
-        private static StringComparer PathComparer = StringComparer.InvariantCultureIgnoreCase;
+        private static readonly StringComparer PathComparer = StringComparer.InvariantCultureIgnoreCase;
 
         public static object[][] FindAppData
         {
@@ -34,7 +34,7 @@ namespace Microsoft.Alm.Authentication.Git.Test
             Assert.True(CmdWhere(app, out path1));
 
             string path2;
-            Assert.True(Where.FindApp(app, out path2));
+            Assert.True(RuntimeContext.Default.Where.FindApp(app, out path2));
 
             Assert.True(PathComparer.Equals(path1, path2));
         }
@@ -43,16 +43,16 @@ namespace Microsoft.Alm.Authentication.Git.Test
         public void Where_FindGit()
         {
             string gitPath;
-            if (!Where.FindApp("git", out gitPath))
+            if (!RuntimeContext.Default.Where.FindApp("git", out gitPath))
                 throw new Exception("Git not found on system");
 
             List<Installation> installations;
-            Assert.True(Where.FindGitInstallations(out installations));
+            Assert.True(RuntimeContext.Default.Where.FindGitInstallations(out installations));
             Assert.True(installations.Count > 0);
             Assert.True(PathComparer.Equals(installations[0].Git, gitPath));
 
             Installation installation;
-            Assert.True(Where.FindGitInstallation(installations[0].Path, installations[0].Version, out installation));
+            Assert.True(RuntimeContext.Default.Where.FindGitInstallation(installations[0].Path, installations[0].Version, out installation));
             Assert.True(installations[0] == installation);
         }
 

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -43,5 +43,8 @@ namespace Microsoft.Alm.Authentication
         {
             get { return _context; }
         }
+
+        protected Git.ITrace Trace
+            => _context.Trace;
     }
 }

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -46,5 +46,8 @@ namespace Microsoft.Alm.Authentication
 
         protected Git.ITrace Trace
             => _context.Trace;
+
+        protected Git.IWhere Where
+            => _context.Where;
     }
 }

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Alm.Authentication
             get { return _context; }
         }
 
+        protected IFileSystem FileSystem
+            => _context.FileSystem;
+
         protected Git.ITrace Trace
             => _context.Trace;
 

--- a/Microsoft.Alm.Authentication/BaseSecureStore.cs
+++ b/Microsoft.Alm.Authentication/BaseSecureStore.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Alm.Authentication
                     {
                         case NativeMethods.Win32Error.NotFound:
                         case NativeMethods.Win32Error.NoSuchLogonSession:
-                            Git.Trace.WriteLine($"credentials not found for '{targetName}'.");
+                            Trace.WriteLine($"credentials not found for '{targetName}'.");
                             break;
 
                         default:
@@ -60,7 +60,7 @@ namespace Microsoft.Alm.Authentication
                 }
                 else
                 {
-                    Git.Trace.WriteLine($"credentials for '{targetName}' deleted from store.");
+                    Trace.WriteLine($"credentials for '{targetName}' deleted from store.");
                 }
             }
             catch (Exception exception)
@@ -101,7 +101,7 @@ namespace Microsoft.Alm.Authentication
                         }
                         else
                         {
-                            Git.Trace.WriteLine($"credentials for '{@namespace}' purged from store.");
+                            Trace.WriteLine($"credentials for '{@namespace}' purged from store.");
                         }
                     }
                 }
@@ -139,14 +139,14 @@ namespace Microsoft.Alm.Authentication
 
                     credentials = new Credential(username, password);
 
-                    Git.Trace.WriteLine($"credentials for '{targetName}' read from store.");
+                    Trace.WriteLine($"credentials for '{targetName}' read from store.");
                 }
             }
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
 
-                Git.Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
+                Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
 
                 return null;
             }
@@ -181,10 +181,10 @@ namespace Microsoft.Alm.Authentication
                         TokenType type;
                         if (Token.GetTypeFromFriendlyName(credStruct.UserName, out type))
                         {
-                            Token.Deserialize(bytes, type, out token);
+                            Token.Deserialize(Context, bytes, type, out token);
                         }
 
-                        Git.Trace.WriteLine($"token for '{targetName}' read from store.");
+                        Trace.WriteLine($"token for '{targetName}' read from store.");
                     }
                 }
             }
@@ -192,7 +192,7 @@ namespace Microsoft.Alm.Authentication
             {
                 Debug.WriteLine(exception);
 
-                Git.Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
+                Trace.WriteLine($"failed to read credentials: {exception.GetType().Name}.");
 
                 return null;
             }
@@ -233,13 +233,13 @@ namespace Microsoft.Alm.Authentication
                     throw new Win32Exception(error, "Failed to write credentials");
                 }
 
-                Git.Trace.WriteLine($"credentials for '{targetName}' written to store.");
+                Trace.WriteLine($"credentials for '{targetName}' written to store.");
             }
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
 
-                Git.Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
+                Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
 
                 return false;
             }
@@ -263,7 +263,7 @@ namespace Microsoft.Alm.Authentication
                 throw new ArgumentNullException(nameof(token));
 
             byte[] bytes = null;
-            if (Token.Serialize(token, out bytes))
+            if (Token.Serialize(Context, token, out bytes))
             {
                 string name;
                 if (Token.GetFriendlyNameFromType(token.Type, out name))
@@ -288,13 +288,13 @@ namespace Microsoft.Alm.Authentication
                             throw new Win32Exception(error, "Failed to write credentials");
                         }
 
-                        Git.Trace.WriteLine($"token for '{targetName}' written to store.");
+                        Trace.WriteLine($"token for '{targetName}' written to store.");
                     }
                     catch (Exception exception)
                     {
                         Debug.WriteLine(exception);
 
-                        Git.Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
+                        Trace.WriteLine($"failed to write credentials: {exception.GetType().Name}.");
 
                         return false;
                     }

--- a/Microsoft.Alm.Authentication/BasicAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BasicAuthentication.cs
@@ -108,13 +108,13 @@ namespace Microsoft.Alm.Authentication
                 // Get the WWW-Authenticate headers (if any).
                 if (_httpAuthenticateOptions == null)
                 {
-                    _httpAuthenticateOptions = await WwwAuthenticateHelper.GetHeaderValues(targetUri);
+                    _httpAuthenticateOptions = await WwwAuthenticateHelper.GetHeaderValues(Context, targetUri);
                 }
 
                 // If the headers contain NTLM as an option, then fall back to NTLM.
                 if (_httpAuthenticateOptions.Any(x => WwwAuthenticateHelper.IsNtlm(x)))
                 {
-                    Git.Trace.WriteLine($"'{targetUri}' supports NTLM, sending NTLM credentials instead");
+                    Trace.WriteLine($"'{targetUri}' supports NTLM, sending NTLM credentials instead");
 
                     return NtlmCredentials;
                 }
@@ -124,7 +124,7 @@ namespace Microsoft.Alm.Authentication
 
             if (_ntlmSupport != NtlmSupport.Always && _acquireCredentials != null)
             {
-                Git.Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
+                Trace.WriteLine($"prompting user for credentials for '{targetUri}'.");
 
                 credentials = _acquireCredentials(targetUri);
 

--- a/Microsoft.Alm.Authentication/FileSystem.cs
+++ b/Microsoft.Alm.Authentication/FileSystem.cs
@@ -1,0 +1,244 @@
+﻿/**** Git Credential Manager for Windows ****
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the """"Software""""), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+**/
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Alm.Authentication
+{
+    public interface IFileSystem
+    {
+        /// <summary>
+        /// Creates all directories and subdirectories in the specified path.
+        /// </summary>
+        /// <param name="path">The directory path to create.</param>
+        void CreateDirectory(string path);
+
+        /// <summary>
+        /// Determines whether the given path refers to an existing directory on disk.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if path refers to an existing directory; otherwise, `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="path">The path to test.</param>
+        bool DirectoryExists(string path);
+
+        /// <summary>
+        ///  Returns an enumerable collection of file names and directory names that match a search pattern in a specified path, and optionally searches subdirectories.
+        /// </summary>
+        /// <param name="path">The directory to search.</param>
+        /// <param name="pattern">
+        /// The search string to match against the names of directories in path
+        /// </param>
+        /// <param name="options">
+        /// ne of the enumeration values that specifies whether the search operation should include only the current directory or should include all subdirectories.
+        /// <para/>
+        /// The default value is `<see cref="System.IO.SearchOption.TopDirectoryOnly"/>`.
+        /// </param>
+        IEnumerable<string> EnumerateFileSystemEntries(string path, string pattern, SearchOption options);
+
+        /// <summary>
+        /// Returns an enumerable collection of file-system entries in a specified path.
+        /// </summary>
+        /// <param name="path">The directory to search.</param>
+        IEnumerable<string> EnumerateFileSystemEntries(string path);
+
+        /// <summary>
+        /// Copies an existing file to a new file.
+        /// <para/>
+        /// Overwriting a file of the same name is not allowed.
+        /// </summary>
+        /// <param name="sourcePath">The file to copy.</param>
+        /// <param name="destinationPath">
+        /// The name of the destination file.
+        /// <para/>
+        /// This cannot be a directory or an existing file.
+        /// </param>
+        void FileCopy(string sourcePath, string destinationPath, bool overwrite);
+
+        /// <summary>
+        /// Copies an existing file to a new file.
+        /// </summary>
+        /// <param name="sourcePath">The file to copy.</param>
+        /// <param name="destinationPath">
+        /// The name of the destination file.
+        /// <para/>
+        /// This cannot be a directory.
+        /// </param>
+        /// <param name="overwrite">
+        /// `<see langword="true"/>` if the destination file can be overwritten; otherwise, `<see langword="false"/>`.
+        /// </param>
+        void FileCopy(string sourcePath, string destinationPath);
+
+        /// <summary>
+        /// Deletes the specified file.
+        /// </summary>
+        /// <param name="path">
+        /// The name of the file to be deleted.
+        /// <para/>
+        /// Wildcard characters are not supported.
+        /// </param>
+        void FileDelete(string path);
+
+        /// <summary>
+        /// Determines whether the specified file exists.
+        /// <para/>
+        /// `<see langword="true"/>` if the caller has the required permissions and path contains the name of an existing file; otherwise, `<see langword="false"/>`.
+        /// <para/>
+        /// Returns `<see langword="false"/>` if `<paramref name="path"/>` is `<see langword="null"/>`, an invalid path, or a zero-length `<see langword="string"/>`.
+        /// <para/>
+        /// Returns `<see langword="false"/>` if the caller does not have sufficient permissions to read the specified file, no exception is thrown.
+        /// <para/>
+        /// </summary>
+        /// <param name="path">The file to check.</param>
+        bool FileExists(string path);
+
+        /// <summary>
+        /// Returns a `<see cref="FileStream"/>` specified by `<paramref name="path"/>`, having the specified mode with read, write, or read/write access and the specified sharing option.
+        /// </summary>
+        /// <param name="path">The file to open.</param>
+        /// <param name="mode">
+        /// A `<see cref="FileMode"/>` value that specifies whether a file is created if one does not exist, and determines whether the contents of existing files are retained or overwritten.
+        /// </param>
+        /// <param name="access">
+        /// A `<see cref="FileAccess"/>` value that specifies the operations that can be performed on the file.
+        /// </param>
+        /// <param name="share">
+        /// A `<see cref="FileShare value"/>` specifying the type of access other threads have to the file.
+        /// </param>
+        FileStream FileOpen(string path, FileMode mode, FileAccess access, FileShare share);
+
+        /// <summary>
+        /// Opens a binary file, reads the contents of the file into a byte array, and then closes the file.
+        /// <para/>
+        /// Returns a byte array containing the contents of the file.
+        /// </summary>
+        /// <param name="path">The file to open for reading.</param>
+        byte[] FileReadAllBytes(string path);
+
+        /// <summary>
+        /// Creates a new file, writes the specified byte array to the file, and then closes the file.
+        /// <para/>
+        /// If `<paramref name="path"/>` already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="bytes">The bytes to write to the file.</param>
+        void FileWriteAllBytes(string path, byte[] data);
+
+        /// <summary>
+        /// Returns an array of paths to all known drive roots.
+        /// </summary
+        string[] GetDriveRoots();
+
+        /// <summary>
+        /// Returns the file name and extension of the specified path string.
+        /// <para/>
+        /// If the last character f path is a directory or volume separator character, this method returns `<see cref="string.Empty"/>`.
+        /// <para/>
+        /// If `<paramref name="path"/>` is `<see langword="null"/>`, this method returns `<see langword="null"/>`.
+        /// </summary>
+        /// <param name="path">
+        /// The path string from which to obtain the file name and extension.
+        /// </param>
+        string GetFileName(string path);
+
+        /// <summary>
+        /// Returns the absolute path for the specified path string.
+        /// </summary>
+        /// <param name="path">
+        /// The file or directory for which to obtain absolute path information.
+        /// </param>
+        string GetFullPath(string path);
+
+        /// <summary>
+        /// Returns the directory information for the specified path string.
+        /// <para/>
+        /// Returns `<see cref="string.Empty"/>` if `<paramref name="path"/>` does not contain directory information.
+        /// </summary>
+        /// <param name="path">The path of a file or directory.</param>
+        string GetParent(string path);
+    }
+
+    internal class FileSystem : Base, IFileSystem
+    {
+        public FileSystem(RuntimeContext context)
+            : base(context)
+        { }
+
+        public void CreateDirectory(string path)
+            => Directory.CreateDirectory(path);
+
+        public bool DirectoryExists(string path)
+            => Directory.Exists(path);
+
+        public IEnumerable<string> EnumerateFileSystemEntries(string path, string pattern, SearchOption options)
+            => Directory.EnumerateFileSystemEntries(path, pattern, options);
+
+        public IEnumerable<string> EnumerateFileSystemEntries(string path)
+            => Directory.EnumerateFileSystemEntries(path);
+
+        public void FileCopy(string sourcePath, string destinationPath)
+            => File.Copy(sourcePath, destinationPath);
+
+        public void FileCopy(string sourcePath, string destinationPath, bool overwrite)
+            => File.Copy(sourcePath, destinationPath, overwrite);
+
+        public void FileDelete(string path)
+            => File.Delete(path);
+
+        public bool FileExists(string path)
+            => File.Exists(path);
+
+        public FileStream FileOpen(string path, FileMode mode, FileAccess access, FileShare share)
+            => File.Open(path, mode, access, share);
+
+        public byte[] FileReadAllBytes(string path)
+            => File.ReadAllBytes(path);
+
+        public void FileWriteAllBytes(string path, byte[] bytes)
+            => File.WriteAllBytes(path, bytes);
+
+        public string[] GetDriveRoots()
+        {
+            var drives = DriveInfo.GetDrives();
+            var paths = new string[drives.Length];
+
+            for (int i = 0; i < drives.Length; i += 1)
+            {
+                paths[i] = drives[i].RootDirectory.FullName;
+            }
+
+            return paths;
+        }
+
+        public string GetFileName(string path)
+            => Path.GetFileName(path);
+
+        public string GetFullPath(string path)
+            => Path.GetFullPath(path);
+
+        public string GetParent(string path)
+            => Path.GetDirectoryName(path);
+    }
+}

--- a/Microsoft.Alm.Authentication/Git/Configuration.cs
+++ b/Microsoft.Alm.Authentication/Git/Configuration.cs
@@ -418,7 +418,7 @@ namespace Microsoft.Alm.Authentication.Git
                             {
                                 // This is an include directive, import the configuration values from the included file
                                 string includePath = (val.StartsWith("~/", StringComparison.OrdinalIgnoreCase))
-                                    ? Where.Home() + val.Substring(1, val.Length - 1)
+                                    ? context.Where.Home() + val.Substring(1, val.Length - 1)
                                     : val;
 
                                 includePath = Path.GetFullPath(includePath);

--- a/Microsoft.Alm.Authentication/Git/Configuration.cs
+++ b/Microsoft.Alm.Authentication/Git/Configuration.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Alm.Authentication.Git
                 throw new ArgumentNullException(nameof(context));
             if (directory is null)
                 throw new ArgumentNullException(nameof(directory));
-            if (!Directory.Exists(directory))
+            if (!context.FileSystem.DirectoryExists(directory))
             {
                 var inner = new DirectoryNotFoundException(directory);
                 throw new ArgumentException(inner.Message, nameof(directory), inner);
@@ -423,7 +423,7 @@ namespace Microsoft.Alm.Authentication.Git
 
                                 includePath = Path.GetFullPath(includePath);
 
-                                using (FileStream includeFile = File.Open(includePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                                using (FileStream includeFile = context.FileSystem.FileOpen(includePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                                 using (var includeReader = new StreamReader(includeFile))
                                 {
                                     await ParseGitConfig(context, includeReader, destination);
@@ -461,7 +461,7 @@ namespace Microsoft.Alm.Authentication.Git
             if ((level & ~ConfigurationLevel.All) != 0)
                 throw new ArgumentOutOfRangeException(nameof(level));
 
-            if (!File.Exists(configPath))
+            if (!FileSystem.FileExists(configPath))
             {
                 var inner = new FileNotFoundException(configPath);
                 throw new ArgumentException(inner.Message, nameof(configPath), inner);
@@ -469,10 +469,10 @@ namespace Microsoft.Alm.Authentication.Git
 
             if (!_values.ContainsKey(level))
                 return;
-            if (!File.Exists(configPath))
+            if (!FileSystem.FileExists(configPath))
                 return;
 
-            using (FileStream stream = File.OpenRead(configPath))
+            using (FileStream stream = FileSystem.FileOpen(configPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             using (var reader = new StreamReader(stream))
             {
                 await ParseGitConfig(Context, reader, _values[level]);

--- a/Microsoft.Alm.Authentication/Git/Installation.cs
+++ b/Microsoft.Alm.Authentication/Git/Installation.cs
@@ -30,7 +30,7 @@ using System.IO;
 
 namespace Microsoft.Alm.Authentication.Git
 {
-    public struct Installation : IEquatable<Installation>
+    public class Installation : Base, IEquatable<Installation>
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
         public static readonly StringComparer PathComparer = StringComparer.InvariantCultureIgnoreCase;
@@ -104,7 +104,8 @@ namespace Microsoft.Alm.Authentication.Git
                 { KnownDistribution.GitForWindows64v2, Version2Doc64Path },
             };
 
-        internal Installation(string path, KnownDistribution version)
+        internal Installation(RuntimeContext context, string path, KnownDistribution version)
+            : base(context)
         {
             if (string.IsNullOrWhiteSpace(path))
                 throw new ArgumentNullException(nameof(path));
@@ -150,8 +151,8 @@ namespace Microsoft.Alm.Authentication.Git
             _cmd = null;
             _config = null;
             _doc = null;
-            _git = null;
-            _libexec = null;
+            _git = System.IO.Path.Combine(_path, CommonGitPaths[_distribution]);
+            _libexec = System.IO.Path.Combine(_path, CommonLibexecPaths[_distribution]);
             _sh = null;
         }
 
@@ -214,14 +215,7 @@ namespace Microsoft.Alm.Authentication.Git
         /// </summary>
         public string Git
         {
-            get
-            {
-                if (_git == null)
-                {
-                    _git = System.IO.Path.Combine(_path, CommonGitPaths[_distribution]);
-                }
-                return _git;
-            }
+            get { return _git; }
         }
 
         /// <summary>
@@ -229,14 +223,7 @@ namespace Microsoft.Alm.Authentication.Git
         /// </summary>
         public string Libexec
         {
-            get
-            {
-                if (_libexec == null)
-                {
-                    _libexec = System.IO.Path.Combine(_path, CommonLibexecPaths[_distribution]);
-                }
-                return _libexec;
-            }
+            get { return _libexec; }
         }
 
         /// <summary>
@@ -293,11 +280,11 @@ namespace Microsoft.Alm.Authentication.Git
             return _path;
         }
 
-        internal static bool IsValid(Installation value)
+        internal bool IsValid()
         {
-            return Directory.Exists(value._path)
-                && Directory.Exists(value.Libexec)
-                && File.Exists(value.Git);
+            return FileSystem.DirectoryExists(_path)
+                && FileSystem.DirectoryExists(_libexec)
+                && FileSystem.FileExists(_git);
         }
 
         public static bool operator ==(Installation install1, Installation install2)

--- a/Microsoft.Alm.Authentication/Git/Trace.cs
+++ b/Microsoft.Alm.Authentication/Git/Trace.cs
@@ -36,15 +36,19 @@ namespace Microsoft.Alm.Authentication.Git
 
         void Flush();
 
-        void WriteLine(string message, string filePath, int lineNumber, string memberName);
+        void WriteLine(
+            string message,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
     }
 
-    public sealed class Trace : ITrace, IDisposable
+    internal class Trace : Base, ITrace, IDisposable
     {
         public const string EnvironmentVariableKey = "GCM_TRACE";
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        private Trace()
+        public Trace(RuntimeContext context)
+            : base(context)
         {
             _writers = new List<TextWriter>();
 
@@ -76,32 +80,25 @@ namespace Microsoft.Alm.Authentication.Git
             Dispose(true);
         }
 
-        private static ITrace _instance;
-        private static readonly object _syncpoint = new object();
-        private readonly List<TextWriter> _writers;
+        private readonly object _syncpoint = new object();
+        private List<TextWriter> _writers;
 
-        internal static ITrace Instance
-        {
-            get
-            {
-                lock (_syncpoint)
-                {
-                    if (_instance == null)
-                    {
-                        _instance = new Trace();
-                    }
-                    return _instance;
-                }
-            }
-            set { _instance = value; }
-        }
 
         /// <summary>
         /// Add a listener to the trace writer.
         /// </summary>
         /// <param name="listener">The listener to add.</param>
-        public static void AddListener(TextWriter listener)
-            => Instance.AddListener(listener);
+        public void AddListener(TextWriter listener)
+        {
+            lock (_syncpoint)
+            {
+                // Try not to add the same listener more than once
+                if (_writers.Contains(listener))
+                    return;
+
+                _writers.Add(listener);
+            }
+        }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public void Dispose()
@@ -114,8 +111,21 @@ namespace Microsoft.Alm.Authentication.Git
         /// <summary>
         /// Forces any pending trace messages to be written to any listeners.
         /// </summary>
-        public static void Flush()
-            => Instance.Flush();
+        public void Flush()
+        {
+            lock (_syncpoint)
+            {
+                foreach (var writer in _writers)
+                {
+                    try
+                    {
+                        writer?.Flush();
+                    }
+                    catch
+                    { /* squelch */ }
+                }
+            }
+        }
 
         /// <summary>
         /// Writes a message to the trace writer followed by a line terminator.
@@ -125,11 +135,31 @@ namespace Microsoft.Alm.Authentication.Git
         /// <param name="lineNumber">Line number of file this method is called from.</param>
         /// <param name="memberName">Name of the member in which this method is called.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-        public static void WriteLine(string message,
+        public void WriteLine(
+            string message,
             [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
             [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
             [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
-            => Instance.WriteLine(message, filePath, lineNumber, memberName);
+        {
+            lock (_syncpoint)
+            {
+                if (_writers.Count == 0)
+                    return;
+
+                string text = FormatText(message, filePath, lineNumber, memberName);
+
+                foreach (var writer in _writers)
+                {
+                    try
+                    {
+                        writer?.Write(text);
+                        writer?.Write('\n');
+                        writer?.Flush();
+                    }
+                    catch { /* squelch */ }
+                }
+            }
+        }
 
         private void Dispose(bool finalizing)
         {
@@ -193,56 +223,6 @@ namespace Microsoft.Alm.Authentication.Git
             string text = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:HH:mm:ss.ffffff} {1,-23} trace: [{2}] {3}", DateTime.Now, source, memberName, message);
 
             return text;
-        }
-
-        void ITrace.AddListener(TextWriter listener)
-        {
-            lock (_syncpoint)
-            {
-                // Try not to add the same listener more than once
-                if (_writers.Contains(listener))
-                    return;
-
-                _writers.Add(listener);
-            }
-        }
-
-        void ITrace.Flush()
-        {
-            lock (_syncpoint)
-            {
-                foreach (var writer in _writers)
-                {
-                    try
-                    {
-                        writer?.Flush();
-                    }
-                    catch
-                    { /* squelch */ }
-                }
-            }
-        }
-
-        void ITrace.WriteLine(string message, string filePath, int lineNumber, string memberName)
-        {
-            lock (_syncpoint)
-            {
-                if (_writers.Count == 0)
-                    return;
-
-                string text = FormatText(message, filePath, lineNumber, memberName);
-
-                foreach (var writer in _writers)
-                {
-                    try
-                    {
-                        writer?.Write(text);
-                        writer?.Write('\n');
-                        writer?.Flush();
-                    }
-                    catch { /* squelch */ }
-                }
-            }
         }
     }
 }

--- a/Microsoft.Alm.Authentication/Git/Trace.cs
+++ b/Microsoft.Alm.Authentication/Git/Trace.cs
@@ -30,7 +30,7 @@ using System.Text;
 
 namespace Microsoft.Alm.Authentication.Git
 {
-    internal interface ITrace
+    public interface ITrace
     {
         void AddListener(TextWriter listener);
 

--- a/Microsoft.Alm.Authentication/Git/Trace.cs
+++ b/Microsoft.Alm.Authentication/Git/Trace.cs
@@ -51,28 +51,6 @@ namespace Microsoft.Alm.Authentication.Git
             : base(context)
         {
             _writers = new List<TextWriter>();
-
-            try
-            {
-                string traceValue = Environment.GetEnvironmentVariable(EnvironmentVariableKey);
-
-                // if the value is true or a number greater than zero, then trace to standard error
-                if (Configuration.PaserBoolean(traceValue))
-                {
-                    _writers.Add(Console.Error);
-                }
-                // if the value is a rooted path, then trace to that file and not to the console
-                else if (Path.IsPathRooted(traceValue))
-                {
-                    // open or create the log file
-                    var stream = File.Open(traceValue, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-
-                    // create the writer and add it to the list
-                    var writer = new StreamWriter(stream, Encoding.UTF8, 4096, true);
-                    _writers.Add(writer);
-                }
-            }
-            catch { /* squelch */ }
         }
 
         ~Trace()
@@ -82,7 +60,6 @@ namespace Microsoft.Alm.Authentication.Git
 
         private readonly object _syncpoint = new object();
         private List<TextWriter> _writers;
-
 
         /// <summary>
         /// Add a listener to the trace writer.
@@ -159,6 +136,31 @@ namespace Microsoft.Alm.Authentication.Git
                     catch { /* squelch */ }
                 }
             }
+        }
+
+        internal void EnableDefaultWriter()
+        {
+            try
+            {
+                string traceValue = Environment.GetEnvironmentVariable(EnvironmentVariableKey);
+
+                // If the value is true or a number greater than zero, then trace to standard error.
+                if (Configuration.PaserBoolean(traceValue))
+                {
+                    _writers.Add(Console.Error);
+                }
+                // If the value is a rooted path, then trace to that file and not to the console.
+                else if (Path.IsPathRooted(traceValue))
+                {
+                    // Open or create the log file.
+                    var stream = FileSystem.FileOpen(traceValue, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+
+                    // Create the writer and add it to the list.
+                    var writer = new StreamWriter(stream, Encoding.UTF8, 4096, true);
+                    _writers.Add(writer);
+                }
+            }
+            catch { /* squelch */ }
         }
 
         private void Dispose(bool finalizing)

--- a/Microsoft.Alm.Authentication/Git/Where.cs
+++ b/Microsoft.Alm.Authentication/Git/Where.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Alm.Authentication.Git
         /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
         /// </summary>
         /// <param name="path">
-        /// The local respository path if any.
+        /// The local repository path if any.
         /// <para/>
         /// Used to find local Git configuration files.
         /// </param>
@@ -130,7 +130,7 @@ namespace Microsoft.Alm.Authentication.Git
         /// <param name="path">
         /// Path to Git's system configuration if successful; otherwise `<see langword="null"/>`.
         /// </param>
-        bool GitSystemConfig(Installation? installation, out string path);
+        bool GitSystemConfig(Installation installation, out string path);
 
         /// <summary>
         /// Gets the path to Git's XDG configuration file.
@@ -183,7 +183,7 @@ namespace Microsoft.Alm.Authentication.Git
                             continue;
 
                         string value = string.Format("{0}\\{1}{2}", paths[i], name, exts[j]);
-                        if (File.Exists(value))
+                        if (FileSystem.FileExists(value))
                         {
                             value = value.Replace("\\\\", "\\");
                             path = value;
@@ -199,8 +199,8 @@ namespace Microsoft.Alm.Authentication.Git
 
         public bool FindGitInstallation(string path, KnownDistribution distro, out Installation installation)
         {
-            installation = new Installation(path, distro);
-            return Installation.IsValid(installation);
+            installation = new Installation(Context, path, distro);
+            return installation.IsValid();
         }
 
         public bool FindGitInstallations(out List<Installation> installations)
@@ -278,61 +278,61 @@ namespace Microsoft.Alm.Authentication.Git
                     shellPathValue = shellPathValue.Substring(0, shellPathValue.Length - Installation.AllVersionCmdPath.Length);
                 }
 
-                candidates.Add(new Installation(shellPathValue, KnownDistribution.GitForWindows64v2));
-                candidates.Add(new Installation(shellPathValue, KnownDistribution.GitForWindows32v2));
-                candidates.Add(new Installation(shellPathValue, KnownDistribution.GitForWindows32v1));
+                candidates.Add(new Installation(Context, shellPathValue, KnownDistribution.GitForWindows64v2));
+                candidates.Add(new Installation(Context, shellPathValue, KnownDistribution.GitForWindows32v2));
+                candidates.Add(new Installation(Context, shellPathValue, KnownDistribution.GitForWindows32v1));
             }
 
             if (!string.IsNullOrEmpty(reg64HklmPath))
             {
-                candidates.Add(new Installation(reg64HklmPath, KnownDistribution.GitForWindows64v2));
+                candidates.Add(new Installation(Context, reg64HklmPath, KnownDistribution.GitForWindows64v2));
             }
             if (!string.IsNullOrEmpty(programFiles32Path))
             {
-                candidates.Add(new Installation(programFiles64Path, KnownDistribution.GitForWindows64v2));
+                candidates.Add(new Installation(Context, programFiles64Path, KnownDistribution.GitForWindows64v2));
             }
             if (!string.IsNullOrEmpty(reg64HkcuPath))
             {
-                candidates.Add(new Installation(reg64HkcuPath, KnownDistribution.GitForWindows64v2));
+                candidates.Add(new Installation(Context, reg64HkcuPath, KnownDistribution.GitForWindows64v2));
             }
             if (!string.IsNullOrEmpty(reg32HklmPath))
             {
-                candidates.Add(new Installation(reg32HklmPath, KnownDistribution.GitForWindows32v2));
-                candidates.Add(new Installation(reg32HklmPath, KnownDistribution.GitForWindows32v1));
+                candidates.Add(new Installation(Context, reg32HklmPath, KnownDistribution.GitForWindows32v2));
+                candidates.Add(new Installation(Context, reg32HklmPath, KnownDistribution.GitForWindows32v1));
             }
             if (!string.IsNullOrEmpty(programFiles32Path))
             {
-                candidates.Add(new Installation(programFiles32Path, KnownDistribution.GitForWindows32v2));
-                candidates.Add(new Installation(programFiles32Path, KnownDistribution.GitForWindows32v1));
+                candidates.Add(new Installation(Context, programFiles32Path, KnownDistribution.GitForWindows32v2));
+                candidates.Add(new Installation(Context, programFiles32Path, KnownDistribution.GitForWindows32v1));
             }
             if (!string.IsNullOrEmpty(reg32HkcuPath))
             {
-                candidates.Add(new Installation(reg32HkcuPath, KnownDistribution.GitForWindows32v2));
-                candidates.Add(new Installation(reg32HkcuPath, KnownDistribution.GitForWindows32v1));
+                candidates.Add(new Installation(Context, reg32HkcuPath, KnownDistribution.GitForWindows32v2));
+                candidates.Add(new Installation(Context, reg32HkcuPath, KnownDistribution.GitForWindows32v1));
             }
             if (!string.IsNullOrEmpty(programDataPath))
             {
-                candidates.Add(new Installation(programDataPath, KnownDistribution.GitForWindows64v2));
-                candidates.Add(new Installation(programDataPath, KnownDistribution.GitForWindows32v2));
-                candidates.Add(new Installation(programDataPath, KnownDistribution.GitForWindows32v1));
+                candidates.Add(new Installation(Context, programDataPath, KnownDistribution.GitForWindows64v2));
+                candidates.Add(new Installation(Context, programDataPath, KnownDistribution.GitForWindows32v2));
+                candidates.Add(new Installation(Context, programDataPath, KnownDistribution.GitForWindows32v1));
             }
             if (!string.IsNullOrEmpty(appDataLocalPath))
             {
-                candidates.Add(new Installation(appDataLocalPath, KnownDistribution.GitForWindows64v2));
-                candidates.Add(new Installation(appDataLocalPath, KnownDistribution.GitForWindows32v2));
-                candidates.Add(new Installation(appDataLocalPath, KnownDistribution.GitForWindows32v1));
+                candidates.Add(new Installation(Context, appDataLocalPath, KnownDistribution.GitForWindows64v2));
+                candidates.Add(new Installation(Context, appDataLocalPath, KnownDistribution.GitForWindows32v2));
+                candidates.Add(new Installation(Context, appDataLocalPath, KnownDistribution.GitForWindows32v1));
             }
             if (!string.IsNullOrEmpty(appDataRoamingPath))
             {
-                candidates.Add(new Installation(appDataRoamingPath, KnownDistribution.GitForWindows64v2));
-                candidates.Add(new Installation(appDataRoamingPath, KnownDistribution.GitForWindows32v2));
-                candidates.Add(new Installation(appDataRoamingPath, KnownDistribution.GitForWindows32v1));
+                candidates.Add(new Installation(Context, appDataRoamingPath, KnownDistribution.GitForWindows64v2));
+                candidates.Add(new Installation(Context, appDataRoamingPath, KnownDistribution.GitForWindows32v2));
+                candidates.Add(new Installation(Context, appDataRoamingPath, KnownDistribution.GitForWindows32v1));
             }
 
             HashSet<Installation> pathSet = new HashSet<Installation>();
             foreach (var candidate in candidates)
             {
-                if (Installation.IsValid(candidate))
+                if (candidate.IsValid())
                 {
                     pathSet.Add(candidate);
                 }
@@ -356,7 +356,7 @@ namespace Microsoft.Alm.Authentication.Git
                 path = Environment.ExpandEnvironmentVariables(path);
 
                 // If the path is good, return it.
-                if (Directory.Exists(path))
+                if (FileSystem.DirectoryExists(path))
                     return path;
             }
 
@@ -369,7 +369,7 @@ namespace Microsoft.Alm.Authentication.Git
             {
                 path = homeDrive + homePath;
 
-                if (Directory.Exists(path))
+                if (FileSystem.DirectoryExists(path))
                     return path;
             }
 
@@ -387,7 +387,7 @@ namespace Microsoft.Alm.Authentication.Git
             var globalPath = Path.Combine(home, GlobalConfigFileName);
 
             // If the path is valid, return it to the user.
-            if (File.Exists(globalPath))
+            if (FileSystem.FileExists(globalPath))
             {
                 path = globalPath;
                 return true;
@@ -441,7 +441,7 @@ namespace Microsoft.Alm.Authentication.Git
                         if (result is DirectoryInfo)
                         {
                             var localPath = Path.Combine(result.FullName, LocalConfigFileName);
-                            if (File.Exists(localPath))
+                            if (FileSystem.FileExists(localPath))
                             {
                                 path = localPath;
                                 return true;
@@ -482,10 +482,10 @@ namespace Microsoft.Alm.Authentication.Git
                                     localPath = Path.Combine(localPath, content);
                                 }
 
-                                if (Directory.Exists(localPath))
+                                if (FileSystem.DirectoryExists(localPath))
                                 {
                                     localPath = Path.Combine(localPath, LocalConfigFileName);
-                                    if (File.Exists(localPath))
+                                    if (FileSystem.FileExists(localPath))
                                     {
                                         path = localPath;
                                         return true;
@@ -515,7 +515,7 @@ namespace Microsoft.Alm.Authentication.Git
 
             var portableConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), PortableConfigFolder, PortableConfigFileName);
 
-            if (File.Exists(portableConfigPath))
+            if (FileSystem.FileExists(portableConfigPath))
             {
                 path = portableConfigPath;
             }
@@ -523,11 +523,11 @@ namespace Microsoft.Alm.Authentication.Git
             return path != null;
         }
 
-        public bool GitSystemConfig(Installation? installation, out string path)
+        public bool GitSystemConfig(Installation installation, out string path)
         {
-            if (installation.HasValue && File.Exists(installation.Value.Config))
+            if (installation != null && FileSystem.FileExists(installation.Config))
             {
-                path = installation.Value.Path;
+                path = installation.Path;
                 return true;
             }
             // find Git on the local disk - the system config is stored relative to it
@@ -536,7 +536,7 @@ namespace Microsoft.Alm.Authentication.Git
                 List<Installation> installations;
 
                 if (FindGitInstallations(out installations)
-                    && File.Exists(installations[0].Config))
+                    && FileSystem.FileExists(installations[0].Config))
                 {
                     path = installations[0].Config;
                     return true;
@@ -558,11 +558,11 @@ namespace Microsoft.Alm.Authentication.Git
             // The XDG config home is defined by an environment variable.
             xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
 
-            if (Directory.Exists(xdgConfigHome))
+            if (FileSystem.DirectoryExists(xdgConfigHome))
             {
                 xdgConfigPath = Path.Combine(xdgConfigHome, XdgConfigFolder, XdgConfigFileName);
 
-                if (File.Exists(xdgConfigPath))
+                if (FileSystem.FileExists(xdgConfigPath))
                 {
                     path = xdgConfigPath;
                     return true;
@@ -574,7 +574,7 @@ namespace Microsoft.Alm.Authentication.Git
 
             xdgConfigPath = Path.Combine(xdgConfigHome, XdgConfigFolder, XdgConfigFileName);
 
-            if (File.Exists(xdgConfigPath))
+            if (FileSystem.FileExists(xdgConfigPath))
             {
                 path = xdgConfigPath;
                 return true;

--- a/Microsoft.Alm.Authentication/Git/Where.cs
+++ b/Microsoft.Alm.Authentication/Git/Where.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Alm.Authentication.Git
 
             installations = pathSet.ToList();
 
-            Git.Trace.WriteLine($"found {installations.Count} Git installation(s).");
+            // Git.Trace.WriteLine($"found {installations.Count} Git installation(s).");
 
             return installations.Count > 0;
         }

--- a/Microsoft.Alm.Authentication/Git/Where.cs
+++ b/Microsoft.Alm.Authentication/Git/Where.cs
@@ -32,16 +32,129 @@ using Microsoft.Win32;
 
 namespace Microsoft.Alm.Authentication.Git
 {
-    public static class Where
+    public interface IWhere
     {
         /// <summary>
         /// Finds the "best" path to an app of a given name.
         /// <para/>
         /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
         /// </summary>
-        /// <param name="name">The name of the application, without extension, to find.</param>
-        /// <param name="path">Path to the first match file which the operating system considers executable.</param>
-        static public bool FindApp(string name, out string path)
+        /// <param name="name">
+        /// The name of the application, without extension, to find.
+        /// </param>
+        /// <param name="path">
+        /// Path to the first match file which the operating system considers executable.
+        /// </param>
+        bool FindApp(string name, out string path);
+
+        /// <summary>
+        /// Finds and returns path(s) to Git installation(s) in common locations.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="path">
+        /// The local respository path if any.
+        /// <para/>
+        /// Used to find local Git configuration files.
+        /// </param>
+        /// <param name="distro">
+        /// The distribution/version of Git used.
+        /// <para/>
+        /// Used to find system Git configuration files.
+        /// </param>
+        /// <param name="installations">
+        /// The list of found Git installation if successful; otherwise `<see langword="null"/>`.
+        /// </param>
+        bool FindGitInstallation(string path, KnownDistribution distro, out Installation installation);
+
+        /// <summary>
+        /// Finds and returns path(s) to Git installation(s) in common locations.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="installations">The list of found Git installation if successful; otherwise `<see langword="null"/>`.</param>
+        bool FindGitInstallations(out List<Installation> installations);
+
+        /// <summary>
+        /// Gets the path to Git's global configuration file.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="path">
+        /// Path to Git's global configuration if successful; otherwise `<see langword="null"/>`.
+        /// </param>
+        bool GitGlobalConfig(out string path);
+
+        /// <summary>
+        /// Gets the path to Git's local configuration file based on the current working directory.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="path">
+        /// Path to Git's local configuration if successful; otherwise `<see langword="null"/>`.
+        /// </param>
+        bool GitLocalConfig(out string path);
+
+        /// <summary>
+        /// Gets the path to Git's portable system configuration file.
+        /// <para/>
+        /// Searches starting with `<paramref name="startingDirectory"/>` working up towards the device root.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="startingDirectory">
+        /// Working directory of the repository to find the configuration.
+        /// </param>
+        /// <param name="path">
+        /// Path to Git's local configuration if successful; otherwise `<see langword="null"/>`.
+        /// </param>
+        bool GitLocalConfig(string startingDirectory, out string path);
+
+        /// <summary>
+        /// Gets the path to Git's portable system configuration file.
+        /// <para/>
+        /// Searches starting with `<see cref="Environment.CurrentDirectory"/>` working up towards the device root.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="path">
+        /// Path to Git's portable system configuration if successful; otherwise `<see langword="null"/>`.
+        /// </param>
+        bool GitPortableConfig(out string path);
+
+        /// <summary>
+        /// Gets the path to Git's system configuration file.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="path">
+        /// Path to Git's system configuration if successful; otherwise `<see langword="null"/>`.
+        /// </param>
+        bool GitSystemConfig(Installation? installation, out string path);
+
+        /// <summary>
+        /// Gets the path to Git's XDG configuration file.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="path">
+        /// Path to Git's XDG configuration file if successful; otherwise `<see langword="null"/>`.
+        /// </param>
+        bool GitXdgConfig(out string path);
+
+        /// <summary>
+        /// Returns the path to the user's home directory (~/ or %HOME%) that Git will rely on.
+        /// </summary>
+        string Home();
+    }
+
+    internal class Where : Base, IWhere
+    {
+        public Where(RuntimeContext context)
+            : base(context)
+        { }
+
+        public bool FindApp(string name, out string path)
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
@@ -84,19 +197,13 @@ namespace Microsoft.Alm.Authentication.Git
             return false;
         }
 
-        public static bool FindGitInstallation(string path, KnownDistribution distro, out Installation installation)
+        public bool FindGitInstallation(string path, KnownDistribution distro, out Installation installation)
         {
             installation = new Installation(path, distro);
             return Installation.IsValid(installation);
         }
 
-        /// <summary>
-        /// Finds and returns path(s) to Git installation(s) in common locations.
-        /// <para/>
-        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
-        /// </summary>
-        /// <param name="installations">The list of found Git installation if successful; otherwise `<see langword="null"/>`.</param>
-        public static bool FindGitInstallations(out List<Installation> installations)
+        public bool FindGitInstallations(out List<Installation> installations)
         {
             const string GitAppName = @"Git";
             const string GitSubkeyName = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Git_is1";
@@ -163,7 +270,7 @@ namespace Microsoft.Alm.Authentication.Git
 
             List<Installation> candidates = new List<Installation>();
             // Add candidate locations in order of preference.
-            if (Where.FindApp(GitAppName, out shellPathValue))
+            if (FindApp(GitAppName, out shellPathValue))
             {
                 // `Where.App` returns the path to the executable, truncate to the installation root
                 if (shellPathValue.EndsWith(Installation.AllVersionCmdPath, StringComparison.OrdinalIgnoreCase))
@@ -233,15 +340,12 @@ namespace Microsoft.Alm.Authentication.Git
 
             installations = pathSet.ToList();
 
-            // Git.Trace.WriteLine($"found {installations.Count} Git installation(s).");
+            Trace.WriteLine($"found {installations.Count} Git installation(s).");
 
             return installations.Count > 0;
         }
 
-        /// <summary>
-        /// Returns the path to the user's home directory (~/ or %HOME%) that Git will rely on.
-        /// </summary>
-        public static string Home()
+        public string Home()
         {
             // Git relies on the %HOME% environment variable to represent the users home directory it
             // can contain embedded environment variables, so we need to expand it
@@ -273,13 +377,7 @@ namespace Microsoft.Alm.Authentication.Git
             return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         }
 
-        /// <summary>
-        /// Gets the path to Git's global configuration file.
-        /// <para/>
-        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
-        /// </summary>
-        /// <param name="path">Path to Git's global configuration if successful; otherwise `<see langword="null"/>`.</param>
-        public static bool GitGlobalConfig(out string path)
+        public bool GitGlobalConfig(out string path)
         {
             const string GlobalConfigFileName = ".gitconfig";
 
@@ -299,18 +397,9 @@ namespace Microsoft.Alm.Authentication.Git
             return false;
         }
 
-        /// <summary>
-        /// Gets the path to Git's portable system configuration file.
-        /// <para/>
-        /// Searches starting with `<paramref name="startingDirectory"/>` working up towards the device root.
-        /// <para/>
-        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
-        /// </summary>
-        /// <param name="startingDirectory">Working directory of the repository to find the configuration.</param>
-        /// <param name="path">Path to Git's local configuration if successful; otherwise `<see langword="null"/>`.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
-        public static bool GitLocalConfig(string startingDirectory, out string path)
+        public bool GitLocalConfig(string startingDirectory, out string path)
         {
             const string GitFolderName = ".git";
             const string LocalConfigFileName = "config";
@@ -412,25 +501,12 @@ namespace Microsoft.Alm.Authentication.Git
             return false;
         }
 
-        /// <summary>
-        /// Gets the path to Git's local configuration file based on the current working directory.
-        /// </summary>
-        /// <param name="path">Path to Git's local configuration if successful; otherwise `<see langword="null"/>`.</param>
-        /// <returns><see langword="True"/> if succeeds; <see langword="false"/> otherwise.</returns>
-        public static bool GitLocalConfig(out string path)
+        public bool GitLocalConfig(out string path)
         {
             return GitLocalConfig(Environment.CurrentDirectory, out path);
         }
 
-        /// <summary>
-        /// Gets the path to Git's portable system configuration file.
-        /// <para/>
-        /// Searches starting with `<see cref="Environment.CurrentDirectory"/>` working up towards the device root.
-        /// <para/>
-        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
-        /// </summary>
-        /// <param name="path">Path to Git's portable system configuration if successful; otherwise `<see langword="null"/>`.</param>
-        public static bool GitPortableConfig(out string path)
+        public bool GitPortableConfig(out string path)
         {
             const string PortableConfigFolder = "Git";
             const string PortableConfigFileName = "config";
@@ -447,13 +523,7 @@ namespace Microsoft.Alm.Authentication.Git
             return path != null;
         }
 
-        /// <summary>
-        /// Gets the path to Git's system configuration file.
-        /// <para/>
-        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
-        /// </summary>
-        /// <param name="path">Path to Git's system configuration if successful; otherwise `<see langword="null"/>`.</param>
-        public static bool GitSystemConfig(Installation? installation, out string path)
+        public bool GitSystemConfig(Installation? installation, out string path)
         {
             if (installation.HasValue && File.Exists(installation.Value.Config))
             {
@@ -477,13 +547,7 @@ namespace Microsoft.Alm.Authentication.Git
             return false;
         }
 
-        /// <summary>
-        /// Gets the path to Git's XDG configuration file.
-        /// <para/>
-        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
-        /// </summary>
-        /// <param name="path">Path to Git's XDG configuration file if successful; otherwise `<see langword="null"/>`.</param>
-        public static bool GitXdgConfig(out string path)
+        public bool GitXdgConfig(out string path)
         {
             const string XdgConfigFolder = "Git";
             const string XdgConfigFileName = "config";

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Base.cs" />
+    <Compile Include="FileSystem.cs" />
     <Compile Include="Git\Configuration.cs" />
     <Compile Include="Git\ConfigurationLevel.cs" />
     <Compile Include="Git\Installation.cs" />

--- a/Microsoft.Alm.Authentication/RuntimeContext.cs
+++ b/Microsoft.Alm.Authentication/RuntimeContext.cs
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 **/
 
+using System;
 using System.Threading;
 
 namespace Microsoft.Alm.Authentication
@@ -30,6 +31,15 @@ namespace Microsoft.Alm.Authentication
     public class RuntimeContext
     {
         public static readonly RuntimeContext Default;
+
+        public RuntimeContext(Git.ITrace trace)
+            : this()
+        {
+            if (trace is null)
+                throw new ArgumentNullException(nameof(trace));
+
+            _trace = trace;
+        }
 
         private RuntimeContext()
         {
@@ -42,15 +52,22 @@ namespace Microsoft.Alm.Authentication
             Volatile.Write(ref _count, 0);
 
             Default = new RuntimeContext();
+            Default._trace = new Git.Trace(Default);
         }
 
         private static int _count;
         private readonly int _id;
         private readonly object _syncpoint;
+        private Git.ITrace _trace;
 
         public int Id
         {
             get { return _id; }
+        }
+
+        public Git.ITrace Trace
+        {
+            get { return _trace; }
         }
     }
 }

--- a/Microsoft.Alm.Authentication/RuntimeContext.cs
+++ b/Microsoft.Alm.Authentication/RuntimeContext.cs
@@ -32,13 +32,18 @@ namespace Microsoft.Alm.Authentication
     {
         public static readonly RuntimeContext Default;
 
-        public RuntimeContext(Git.ITrace trace)
+        public RuntimeContext(
+            Git.ITrace trace,
+            Git.IWhere where)
             : this()
         {
             if (trace is null)
                 throw new ArgumentNullException(nameof(trace));
+            if (where is null)
+                throw new ArgumentNullException(nameof(where));
 
             _trace = trace;
+            _where = where;
         }
 
         private RuntimeContext()
@@ -53,12 +58,14 @@ namespace Microsoft.Alm.Authentication
 
             Default = new RuntimeContext();
             Default._trace = new Git.Trace(Default);
+            Default._where = new Git.Where(Default);
         }
 
         private static int _count;
         private readonly int _id;
         private readonly object _syncpoint;
         private Git.ITrace _trace;
+        private Git.IWhere _where;
 
         public int Id
         {
@@ -68,6 +75,11 @@ namespace Microsoft.Alm.Authentication
         public Git.ITrace Trace
         {
             get { return _trace; }
+        }
+
+        public Git.IWhere Where
+        {
+            get { return _where; }
         }
     }
 }

--- a/Microsoft.Alm.Authentication/RuntimeContext.cs
+++ b/Microsoft.Alm.Authentication/RuntimeContext.cs
@@ -33,15 +33,19 @@ namespace Microsoft.Alm.Authentication
         public static readonly RuntimeContext Default;
 
         public RuntimeContext(
+            IFileSystem fileSystem,
             Git.ITrace trace,
             Git.IWhere where)
             : this()
         {
+            if (fileSystem is null)
+                throw new ArgumentNullException(nameof(fileSystem));
             if (trace is null)
                 throw new ArgumentNullException(nameof(trace));
             if (where is null)
                 throw new ArgumentNullException(nameof(where));
 
+            _fileSystem = fileSystem;
             _trace = trace;
             _where = where;
         }
@@ -57,15 +61,22 @@ namespace Microsoft.Alm.Authentication
             Volatile.Write(ref _count, 0);
 
             Default = new RuntimeContext();
+            Default._fileSystem = new FileSystem(Default);
             Default._trace = new Git.Trace(Default);
             Default._where = new Git.Where(Default);
         }
 
         private static int _count;
+        private IFileSystem _fileSystem;
         private readonly int _id;
         private readonly object _syncpoint;
         private Git.ITrace _trace;
         private Git.IWhere _where;
+
+        public IFileSystem FileSystem
+        {
+            get { return _fileSystem; }
+        }
 
         public int Id
         {

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -188,8 +188,14 @@ namespace Microsoft.Alm.Authentication
                 throw new ArgumentOutOfRangeException(nameof(token));
         }
 
-        internal static unsafe bool Deserialize(byte[] bytes, TokenType type, out Token token)
+        internal static unsafe bool Deserialize(
+            RuntimeContext context,
+            byte[] bytes,
+            TokenType type,
+            out Token token)
         {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
             if (bytes.Length == 0)
@@ -221,8 +227,10 @@ namespace Microsoft.Alm.Authentication
 
                         if (!string.IsNullOrWhiteSpace(value))
                         {
-                            token = new Token(value, type);
-                            token._targetIdentity = targetIdentity;
+                            token = new Token(value, type)
+                            {
+                                _targetIdentity = targetIdentity
+                            };
                         }
                     }
                 }
@@ -240,13 +248,16 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Git.Trace.WriteLine("! token deserialization error.");
+                context.Trace.WriteLine("! token deserialization error.");
             }
 
             return token != null;
         }
 
-        internal static unsafe bool Serialize(Token token, out byte[] bytes)
+        internal static unsafe bool Serialize(
+            RuntimeContext context,
+            Token token,
+            out byte[] bytes)
         {
             if (token is null)
                 throw new ArgumentNullException(nameof(token));
@@ -271,7 +282,7 @@ namespace Microsoft.Alm.Authentication
             }
             catch
             {
-                Git.Trace.WriteLine("! token serialization error.");
+                context.Trace.WriteLine("! token serialization error.");
             }
 
             return bytes != null;

--- a/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
+++ b/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Alm.Authentication
 
         private static readonly AuthenticationHeaderValue[] NullResult = new AuthenticationHeaderValue[0];
 
-        public static async Task<AuthenticationHeaderValue[]> GetHeaderValues(TargetUri targetUri)
+        public static async Task<AuthenticationHeaderValue[]> GetHeaderValues(RuntimeContext context, TargetUri targetUri)
         {
             BaseSecureStore.ValidateTargetUri(targetUri);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Alm.Authentication
                 }
                 catch (Exception exception)
                 {
-                    Git.Trace.WriteLine("error testing targetUri for NTLM: " + exception.Message);
+                    context.Trace.WriteLine("error testing targetUri for NTLM: " + exception.Message);
                 }
             }
 

--- a/Microsoft.Vsts.Authentication/AzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/AzureAuthority.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Alm.Authentication
     /// <summary>
     /// Interfaces with Azure to perform authentication and identity services.
     /// </summary>
-    internal class AzureAuthority : IAzureAuthority
+    internal class AzureAuthority : Base, IAzureAuthority
     {
         /// <summary>
         /// The base URL for logon services in Azure.
@@ -48,7 +48,8 @@ namespace Microsoft.Alm.Authentication
         /// Creates a new instance of `<see cref="AzureAuthority"/>`.
         /// </summary>
         /// <param name="authorityHostUrl">A non-default authority host URL; otherwise defaults to `<see cref="DefaultAuthorityHostUrl"/>`.</param>
-        public AzureAuthority(string authorityHostUrl = DefaultAuthorityHostUrl)
+        public AzureAuthority(RuntimeContext context, string authorityHostUrl = DefaultAuthorityHostUrl)
+            : base (context)
         {
             if (string.IsNullOrEmpty(authorityHostUrl))
                 throw new ArgumentNullException(nameof(authorityHostUrl));
@@ -56,7 +57,7 @@ namespace Microsoft.Alm.Authentication
                 throw new ArgumentException("Uri is not Absolute.", nameof(authorityHostUrl));
 
             AuthorityHostUrl = authorityHostUrl;
-            _adalTokenCache = new VstsAdalTokenCache();
+            _adalTokenCache = new VstsAdalTokenCache(context);
         }
 
         private readonly VstsAdalTokenCache _adalTokenCache;
@@ -107,11 +108,11 @@ namespace Microsoft.Alm.Authentication
                     token = new Token(authResult.AccessToken, tenantId, TokenType.Access);
                 }
 
-                Git.Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition succeeded.");
+                Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition succeeded.");
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition failed.");
+                Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition failed.");
             }
 
             return token;
@@ -153,12 +154,12 @@ namespace Microsoft.Alm.Authentication
                 {
                     token = new Token(authResult.AccessToken, tentantId, TokenType.Access);
 
-                    Git.Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' succeeded.");
+                    Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' succeeded.");
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' failed.");
+                Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' failed.");
             }
 
             return token;

--- a/Microsoft.Vsts.Authentication/VstsAadAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/VstsAadAuthentication.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Alm.Authentication
         {
             if (tenantId == Guid.Empty)
             {
-                VstsAuthority = new VstsAzureAuthority(AzureAuthority.DefaultAuthorityHostUrl);
+                VstsAuthority = new VstsAzureAuthority(context, AzureAuthority.DefaultAuthorityHostUrl);
             }
             else
             {
                 // Create an authority host URL in the format of https://login.microsoft.com/12345678-9ABC-DEF0-1234-56789ABCDEF0.
                 string authorityHost = AzureAuthority.GetAuthorityUrl(tenantId);
-                VstsAuthority = new VstsAzureAuthority(authorityHost);
+                VstsAuthority = new VstsAzureAuthority(context, authorityHost);
             }
         }
 
@@ -95,17 +95,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), null)) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, options);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
+                Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
             }
 
-            Git.Trace.WriteLine($"interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -132,17 +132,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), null)) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
+                Trace.WriteLine($"token acquisition for '{targetUri}' failed.");
             }
 
-            Git.Trace.WriteLine($"interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -164,17 +164,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.NoninteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl))) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
 
                     return await GeneratePersonalAccessToken(targetUri, token, options);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
+                Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
             }
 
-            Git.Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
             return null;
         }
 
@@ -201,17 +201,17 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.NoninteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl))) != null)
                 {
-                    Git.Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
+                    Trace.WriteLine($"token acquisition for '{targetUri}' succeeded");
 
                     return await GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
             }
             catch (AdalException)
             {
-                Git.Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
+                Trace.WriteLine($"failed to acquire for '{targetUri}' token from VstsAuthority.");
             }
 
-            Git.Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
+            Trace.WriteLine($"non-interactive logon for '{targetUri}' failed");
             return null;
         }
 

--- a/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
+++ b/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Alm.Authentication
                 string directoryPath = Path.Combine(localAppDataPath, AdalCachePaths[i][0]);
                 string filePath = Path.Combine(directoryPath, AdalCachePaths[i][1]);
 
-                if (File.Exists(filePath))
+                if (context.FileSystem.FileExists(filePath))
                 {
                     _cacheFilePath = filePath;
                     break;
@@ -78,7 +78,7 @@ namespace Microsoft.Alm.Authentication
         {
             lock (_syncpoint)
             {
-                if (File.Exists(_cacheFilePath) && HasStateChanged)
+                if (_context.FileSystem.FileExists(_cacheFilePath) && HasStateChanged)
                 {
                     try
                     {
@@ -86,7 +86,7 @@ namespace Microsoft.Alm.Authentication
 
                         byte[] data = ProtectedData.Protect(state, null, DataProtectionScope.CurrentUser);
 
-                        File.WriteAllBytes(_cacheFilePath, data);
+                        _context.FileSystem.FileWriteAllBytes(_cacheFilePath, data);
 
                         HasStateChanged = false;
                     }
@@ -102,11 +102,11 @@ namespace Microsoft.Alm.Authentication
         {
             lock (_syncpoint)
             {
-                if (File.Exists(_cacheFilePath))
+                if (_context.FileSystem.FileExists(_cacheFilePath))
                 {
                     try
                     {
-                        byte[] data = File.ReadAllBytes(_cacheFilePath);
+                        byte[] data = _context.FileSystem.FileReadAllBytes(_cacheFilePath);
 
                         byte[] state = ProtectedData.Unprotect(data, null, DataProtectionScope.CurrentUser);
 

--- a/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
+++ b/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Alm.Authentication
 {
     internal class VstsAdalTokenCache : IdentityModel.Clients.ActiveDirectory.TokenCache
     {
-        private readonly IReadOnlyList<IReadOnlyList<string>> AdalCachePaths = new string[][]
+        private static readonly IReadOnlyList<IReadOnlyList<string>> AdalCachePaths = new string[][]
         {
             new [] { @".IdentityService", @"IdentityServiceAdalCache.cache", },          // VS2017 ADAL v3 cache
             new [] { @"Microsoft\VSCommon\VSAccountManagement", @"AdalCache.cache", },   // VS2015 ADAL v2 cache
@@ -43,8 +43,13 @@ namespace Microsoft.Alm.Authentication
         /// <summary>
         /// Default constructor.
         /// </summary>
-        public VstsAdalTokenCache()
+        public VstsAdalTokenCache(RuntimeContext context)
         {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+
+            _context = context;
+
             string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
             AfterAccess = AfterAccessNotification;
@@ -66,6 +71,7 @@ namespace Microsoft.Alm.Authentication
         }
 
         private readonly string _cacheFilePath;
+        private readonly RuntimeContext _context;
         private readonly object _syncpoint = new object();
 
         private void AfterAccessNotification(TokenCacheNotificationArgs args)
@@ -86,7 +92,7 @@ namespace Microsoft.Alm.Authentication
                     }
                     catch (Exception exception)
                     {
-                        Git.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
+                        _context.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
                     }
                 }
             }
@@ -108,7 +114,7 @@ namespace Microsoft.Alm.Authentication
                     }
                     catch (Exception exception)
                     {
-                        Git.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
+                        _context.Trace.WriteLine($"error: {nameof(VstsAdalTokenCache)} \"{_cacheFilePath}\": {exception.Message}");
                     }
                 }
             }

--- a/Microsoft.Vsts.Authentication/VstsMsaAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/VstsMsaAuthentication.cs
@@ -35,10 +35,13 @@ namespace Microsoft.Alm.Authentication
         public const string DefaultAuthorityHost = AzureAuthority.AuthorityHostUrlBase + "/live.com";
         internal const string QueryParameters = "domain_hint=live.com&display=popup&site_id=501454&nux=1";
 
-        public VstsMsaAuthentication(RuntimeContext context, VstsTokenScope tokenScope, ICredentialStore personalAccessTokenStore)
+        public VstsMsaAuthentication(
+            RuntimeContext context,
+            VstsTokenScope tokenScope,
+            ICredentialStore personalAccessTokenStore)
             : base(context, tokenScope, personalAccessTokenStore)
         {
-            VstsAuthority = new VstsAzureAuthority(DefaultAuthorityHost);
+            VstsAuthority = new VstsAzureAuthority(context, DefaultAuthorityHost);
         }
 
         /// <summary>
@@ -79,7 +82,7 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), QueryParameters)) != null)
                 {
-                    Git.Trace.WriteLine($"token '{targetUri}' successfully acquired.");
+                    Trace.WriteLine($"token '{targetUri}' successfully acquired.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, options);
                 }
@@ -89,7 +92,7 @@ namespace Microsoft.Alm.Authentication
                 Debug.Write(exception);
             }
 
-            Git.Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
+            Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
             return null;
         }
 
@@ -109,7 +112,7 @@ namespace Microsoft.Alm.Authentication
                 Token token;
                 if ((token = await VstsAuthority.InteractiveAcquireToken(targetUri, ClientId, Resource, new Uri(RedirectUrl), QueryParameters)) != null)
                 {
-                    Git.Trace.WriteLine($"token '{targetUri}' successfully acquired.");
+                    Trace.WriteLine($"token '{targetUri}' successfully acquired.");
 
                     return await GeneratePersonalAccessToken(targetUri, token, requestCompactToken);
                 }
@@ -119,7 +122,7 @@ namespace Microsoft.Alm.Authentication
                 Debug.Write(exception);
             }
 
-            Git.Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
+            Trace.WriteLine($"failed to acquire token for '{targetUri}'.");
             return null;
         }
 


### PR DESCRIPTION
Adopt `FileSystem` as a servive, provided by `RuntimeContext`.

- [x] Add new `FileSystem` and `IFileSystem` types.
- [x] Provide new types via `RuntimeContext` and `Base`.
- [x] Update VSTS authentication.
- [x] Update GitHub authentication.
- [x] Update BitBucket authentication.

Depends on #570, #571, #572, #573, #574, #575 