### PR TITLE
Network-as-a-Service

### DIFF
--- a/Bitbucket.Authentication.Test/AuthenticationTest.cs
+++ b/Bitbucket.Authentication.Test/AuthenticationTest.cs
@@ -352,7 +352,6 @@ namespace Atlassian.Bitbucket.Authentication.Test
             Assert.Null(resultUri.ProxyUri);
             Assert.Equal("https://johnsquire@example.com/", resultUri.QueryUri.AbsoluteUri);
             Assert.Equal("https", resultUri.Scheme);
-            Assert.Equal(new WebProxy().Address, resultUri.WebProxy.Address);
             Assert.Equal("https://example.com/", resultUri.ToString(false, true, true));
         }
 
@@ -377,7 +376,6 @@ namespace Atlassian.Bitbucket.Authentication.Test
             Assert.Null(resultUri.ProxyUri);
             Assert.Equal("https://johnsquire%40stoneroses.com@example.com/", resultUri.QueryUri.AbsoluteUri);
             Assert.Equal("https", resultUri.Scheme);
-            Assert.Equal(new WebProxy().Address, resultUri.WebProxy.Address);
             Assert.Equal("https://example.com/", resultUri.ToString(false, true, true));
         }
         [Fact]
@@ -401,7 +399,6 @@ namespace Atlassian.Bitbucket.Authentication.Test
             Assert.Null(resultUri.ProxyUri);
             Assert.Equal("https://johnsquire@example.com/", resultUri.QueryUri.AbsoluteUri);
             Assert.Equal("https", resultUri.Scheme);
-            Assert.Equal(new WebProxy().Address, resultUri.WebProxy.Address);
             Assert.Equal("https://example.com/", resultUri.ToString(false, true, true));
         }
     }

--- a/Bitbucket.Authentication/Authentication.cs
+++ b/Bitbucket.Authentication/Authentication.cs
@@ -332,12 +332,13 @@ namespace Atlassian.Bitbucket.Authentication
             string username;
             string password;
 
-            // Ask the user for Basic Auth credentials
+            // Ask the user for basic authentication credentials
             if (AcquireCredentialsCallback("Please enter your Bitbucket credentials for ", targetUri, out username, out password))
             {
                 AuthenticationResult result;
+                credentials = new Credential(username, password);
 
-                if (result = await BitbucketAuthority.AcquireToken(targetUri, username, password, AuthenticationResultType.None, TokenScope))
+                if (result = await BitbucketAuthority.AcquireToken(targetUri, credentials, AuthenticationResultType.None, TokenScope))
                 {
                     Trace.WriteLine("token acquisition succeeded");
 
@@ -354,11 +355,11 @@ namespace Atlassian.Bitbucket.Authentication
                 }
                 else if (result == AuthenticationResultType.TwoFactor)
                 {
-                    // Basic Auth attempt returned a result indicating the user has 2FA on so prompt
+                    // Basic authentication attempt returned a result indicating the user has 2FA on so prompt
                     // the user to run the OAuth dance.
                     if (AcquireAuthenticationOAuthCallback("", targetUri, result, username))
                     {
-                        if (result = await BitbucketAuthority.AcquireToken(targetUri, username, password, AuthenticationResultType.TwoFactor, TokenScope))
+                        if (result = await BitbucketAuthority.AcquireToken(targetUri, credentials, AuthenticationResultType.TwoFactor, TokenScope))
                         {
                             Trace.WriteLine("token acquisition succeeded");
 
@@ -403,7 +404,7 @@ namespace Atlassian.Bitbucket.Authentication
 
             if (!targetUri.TargetUriContainsUsername)
             {
-                // no user info in uri so personalize the credentials
+                // No user info in Uri so personalize the credentials.
                 credentials = new Credential(realUsername, credentials.Password);
             }
 

--- a/Bitbucket.Authentication/IAuthority.cs
+++ b/Bitbucket.Authentication/IAuthority.cs
@@ -41,15 +41,14 @@ namespace Atlassian.Bitbucket.Authentication
         /// </para>
         /// </summary>
         /// <param name="targetUri">defines the Authority to call</param>
-        /// <param name="username">the username to use when requesting the token</param>
-        /// <param name="password">the password to use when requesting the token</param>
+        /// <param name="credentials">the credentials to use when requesting the token</param>
         /// <param name="resultType">
         /// Optional parameter. Used to pass in the results of a previous token request, e.g. first
         /// attempt used Basic Auth now try OAuth
         /// </param>
         /// <param name="scope">the access scopes to request</param>
         /// <returns></returns>
-        Task<AuthenticationResult> AcquireToken(TargetUri targetUri, string username, string password, AuthenticationResultType resultType, TokenScope scope);
+        Task<AuthenticationResult> AcquireToken(TargetUri targetUri, Credential credentials, AuthenticationResultType resultType, TokenScope scope);
 
         /// <summary>
         /// Use an existing refresh token to request a new access token from the specified Authority

--- a/Bitbucket.Authentication/Rest/RestClient.cs
+++ b/Bitbucket.Authentication/Rest/RestClient.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Net;
-using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
-using Microsoft.Alm.Authentication.Git;
 
 namespace Atlassian.Bitbucket.Authentication.Rest
 {
@@ -21,53 +19,51 @@ namespace Atlassian.Bitbucket.Authentication.Rest
             get { return "/2.0/user"; }
         }
 
-        public async Task<AuthenticationResult> TryGetUser(TargetUri targetUri, int requestTimeout, Uri restRootUrl, string authHeader)
+        public async Task<AuthenticationResult> TryGetUser(TargetUri targetUri, int requestTimeout, Uri restRootUrl, Secret authorization)
         {
-            using (HttpClientHandler handler = targetUri.HttpClientHandler)
+            var options = new NetworkRequestOptions(true)
             {
-                using (HttpClient httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromMilliseconds(requestTimeout) })
+                Authorization = authorization,
+                Timeout = TimeSpan.FromMilliseconds(requestTimeout),
+            };
+            var requestUri = new TargetUri(restRootUrl, targetUri.ProxyUri);
+
+            using (var response = await Network.HttpGetAsync(requestUri, options))
+            {
+                Trace.WriteLine($"server responded with {response.StatusCode}.");
+
+                switch (response.StatusCode)
                 {
-                    httpClient.DefaultRequestHeaders.Add("Authorization", authHeader);
-
-                    var url = new Uri(restRootUrl, UserUrl).AbsoluteUri;
-                    using (HttpResponseMessage response = await httpClient.GetAsync(url))
-                    {
-                        Trace.WriteLine($"server responded with {response.StatusCode}.");
-
-                        switch (response.StatusCode)
+                    case HttpStatusCode.OK:
+                    case HttpStatusCode.Created:
                         {
-                            case HttpStatusCode.OK:
-                            case HttpStatusCode.Created:
-                                {
-                                    Trace.WriteLine("authentication success: new password token created.");
+                            Trace.WriteLine("authentication success: new password token created.");
 
-                                    // Get useername to cross check against supplied one
-                                    var responseText = await response.Content.ReadAsStringAsync();
-                                    var username = FindUsername(responseText);
-                                    return new AuthenticationResult(AuthenticationResultType.Success, username);
-                                }
-
-                            case HttpStatusCode.Forbidden:
-                                {
-                                    // A 403/Forbidden response indicates the username/password are
-                                    // recognized and good but 2FA is on in which case we want to
-                                    // indicate that with the TwoFactor result
-                                    Trace.WriteLine("two-factor app authentication code required");
-                                    return new AuthenticationResult(AuthenticationResultType.TwoFactor);
-                                }
-                            case HttpStatusCode.Unauthorized:
-                                {
-                                    // username or password are wrong.
-                                    Trace.WriteLine("authentication unauthorised");
-                                    return new AuthenticationResult(AuthenticationResultType.Failure);
-                                }
-
-                            default:
-                                // any unexpected result can be treated as a failure.
-                                Trace.WriteLine("authentication failed");
-                                return new AuthenticationResult(AuthenticationResultType.Failure);
+                            // Get username to cross check against supplied one
+                            var responseText = await response.Content.ReadAsStringAsync();
+                            var username = FindUsername(responseText);
+                            return new AuthenticationResult(AuthenticationResultType.Success, username);
                         }
-                    }
+
+                    case HttpStatusCode.Forbidden:
+                        {
+                            // A 403/Forbidden response indicates the username/password are
+                            // recognized and good but 2FA is on in which case we want to
+                            // indicate that with the TwoFactor result
+                            Trace.WriteLine("two-factor app authentication code required");
+                            return new AuthenticationResult(AuthenticationResultType.TwoFactor);
+                        }
+                    case HttpStatusCode.Unauthorized:
+                        {
+                            // username or password are wrong.
+                            Trace.WriteLine("authentication unauthorized");
+                            return new AuthenticationResult(AuthenticationResultType.Failure);
+                        }
+
+                    default:
+                        // any unexpected result can be treated as a failure.
+                        Trace.WriteLine("authentication failed");
+                        return new AuthenticationResult(AuthenticationResultType.Failure);
                 }
             }
         }

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Alm.Cli
                     // Get the identity of the tenant.
                     var result = await BaseVstsAuthentication.DetectAuthority(program.Context, operationArguments.TargetUri);
 
-                    if (result.Key)
+                    if (result.HasValue)
                     {
                         tenantId = result.Value;
                     }

--- a/Microsoft.Alm.Authentication.Test/TargetUriTests.cs
+++ b/Microsoft.Alm.Authentication.Test/TargetUriTests.cs
@@ -84,50 +84,5 @@ namespace Microsoft.Alm.Authentication.Test
             Assert.Equal(uri, targetUri.QueryUri);
             Assert.Equal(proxyUri, targetUri.ProxyUri);
         }
-
-        [Theory]
-        [MemberData(nameof(UrlData), DisableDiscoveryEnumeration = true)]
-        public void TargetUri_WebProxy( string queryUrl, string proxyUrl)
-        {
-            var targetUri = new TargetUri(queryUrl, proxyUrl);
-
-            var proxy = targetUri.WebProxy;
-            Assert.NotNull(proxy);
-
-            if (!(proxyUrl is null))
-            {
-                Assert.Equal(new Uri(proxyUrl), proxy.Address);
-            }
-            else
-            {
-                Assert.Null(proxy.Address);
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(UrlData), DisableDiscoveryEnumeration = true)]
-        public void TargetUri_HttpClientHandler(string queryUrl, string proxyUrl)
-        {
-            var targetUri = new TargetUri( queryUrl, proxyUrl);
-
-            var client = targetUri.HttpClientHandler;
-            Assert.NotNull(client);
-
-            if (!(proxyUrl is null))
-            {
-                Assert.True(client.UseProxy);
-                Assert.NotNull(client.Proxy);
-
-                if (client.Proxy is System.Net.WebProxy proxy)
-                {
-                    Assert.Equal(new Uri(proxyUrl), proxy.Address);
-                }
-            }
-            else
-            {
-                Assert.Null(client.Proxy);
-                Assert.False(client.UseProxy);
-            }
-        }
     }
 }

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Alm.Authentication
         protected IFileSystem FileSystem
             => _context.FileSystem;
 
+        protected INetwork Network
+            => _context.Network;
+
         protected Git.ITrace Trace
             => _context.Trace;
 

--- a/Microsoft.Alm.Authentication/BasicAuthentication.cs
+++ b/Microsoft.Alm.Authentication/BasicAuthentication.cs
@@ -24,6 +24,7 @@
 **/
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -56,7 +57,7 @@ namespace Microsoft.Alm.Authentication
             AcquireResultDelegate acquireResultCallback)
             : base(context)
         {
-            if (credentialStore == null)
+            if (credentialStore is null)
                 throw new ArgumentNullException(nameof(credentialStore));
 
             _acquireCredentials = acquireCredentialsCallback;
@@ -72,16 +73,8 @@ namespace Microsoft.Alm.Authentication
         private readonly AcquireCredentialsDelegate _acquireCredentials;
         private readonly AcquireResultDelegate _acquireResult;
         private readonly ICredentialStore _credentialStore;
-        private AuthenticationHeaderValue[] _httpAuthenticateOptions;
+        private IReadOnlyList<AuthenticationHeaderValue> _httpAuthenticateOptions;
         private NtlmSupport _ntlmSupport;
-
-        /// <summary>
-        /// Gets the underlying credential store for this instance of `<see cref="BasicAuthentication"/>`.
-        /// </summary>
-        internal ICredentialStore CredentialStore
-        {
-            get { return _credentialStore; }
-        }
 
         /// <summary>
         /// Gets the level of NTLM support for this instance of `<see cref="BasicAuthentication"/>`.
@@ -89,6 +82,14 @@ namespace Microsoft.Alm.Authentication
         public NtlmSupport NtlmSupport
         {
             get { return _ntlmSupport; }
+        }
+
+        /// <summary>
+        /// Gets the underlying credential store for this instance of `<see cref="BasicAuthentication"/>`.
+        /// </summary>
+        internal ICredentialStore CredentialStore
+        {
+            get { return _credentialStore; }
         }
 
         /// <summary>

--- a/Microsoft.Alm.Authentication/Credential.cs
+++ b/Microsoft.Alm.Authentication/Credential.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Alm.Authentication
             if (username is null)
                 throw new ArgumentNullException(nameof(username));
 
-            Username = username;
-            Password = password ?? string.Empty;
+            _password = password ?? string.Empty;
+            _username = username;
         }
 
         /// <summary>
@@ -56,15 +56,24 @@ namespace Microsoft.Alm.Authentication
             : this(username, string.Empty)
         { }
 
+        private string _password;
+        private string _username;
+
         /// <summary>
         /// Secret related to the username.
         /// </summary>
-        public readonly string Password;
+        public  string Password
+        {
+            get { return _password; }
+        }
 
         /// <summary>
         /// Unique identifier of the user.
         /// </summary>
-        public readonly string Username;
+        public string Username
+        {
+            get { return _username; }
+        }
 
         /// <summary>
         /// Compares an object to this <see cref="Credential"/> for equality.
@@ -96,6 +105,13 @@ namespace Microsoft.Alm.Authentication
             {
                 return Username.GetHashCode() + 7 * Password.GetHashCode();
             }
+        }
+
+        public string ToBase64String()
+        {
+            string basicAuthValue = string.Format("{0}:{1}", _username, _password);
+            byte[] authBytes = System.Text.Encoding.UTF8.GetBytes(basicAuthValue);
+            return Convert.ToBase64String(authBytes);
         }
 
         /// <summary>

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Git\Where.cs" />
     <Compile Include="Global.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Network.cs" />
     <Compile Include="NtlmSupport.cs" />
     <Compile Include="RuntimeContext.cs" />
     <Compile Include="SecretCache.cs" />

--- a/Microsoft.Alm.Authentication/Network.cs
+++ b/Microsoft.Alm.Authentication/Network.cs
@@ -1,0 +1,517 @@
+﻿/**** Git Credential Manager for Windows ****
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the """"Software""""), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+**/
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Microsoft.Alm.Authentication
+{
+    [Flags]
+    public enum NetworkRequestOptionFlags
+    {
+        None = 0,
+
+        /// <summary>
+        /// The handler should follow redirection responses.
+        /// <para/>
+        /// Requests a coupled `<see cref="NetworkRequestOptions.MaxRedirections"/>` is greater than zero.
+        /// </summary>
+        AllowRedirections = 1 << 0,
+
+        /// <summary>
+        /// The handler to send an HTTP Authorization header with requests after authentication has taken place.
+        /// </summary>
+        PreAuthenticate = 1 << 1,
+
+        /// <summary>
+        /// The handler should use these cookies when sending requests.
+        /// <para/>
+        /// Allocates a `<see cref="CookieContainer"/>` for the request, unless a coupled `<see cref="NetworkRequestOptions.CookieContainer"/>` is not `<see langword="null"/>`.
+        /// </summary>
+        UseCookies = 1 << 2,
+
+        /// <summary>
+        /// The handler should use credentials when authenticating.
+        /// <para/>
+        /// Requires a coupled `<see cref="NetworkRequestOptions.Authorization"/>` is not `<see langword="null"/>`.
+        /// </summary>
+        UseCredentials = 1 << 3,
+
+        /// <summary>
+        /// The handler should use a proxy for requests.
+        /// <para/>
+        /// Ignored without a coupled `<see cref="TargetUri.ProxyUri"/>` is not `<see langword="null"/>`.
+        /// </summary>
+        UseProxy = 1 << 4,
+    }
+
+    public class NetworkRequestOptions
+    {
+        public NetworkRequestOptions(bool setDefaults)
+            : this()
+        {
+            if (setDefaults)
+            {
+                _authentication = null;
+                _cookieContainer = null;
+                _flags = NetworkRequestOptionFlags.AllowRedirections
+                       | NetworkRequestOptionFlags.PreAuthenticate
+                       | NetworkRequestOptionFlags.UseProxy;
+                _headers.Add("User-Agent", Global.UserAgent);
+                _maxRedirections = Global.MaxAutomaticRedirections;
+                Timeout = TimeSpan.FromMilliseconds(Global.RequestTimeout);
+            }
+        }
+
+        private NetworkRequestOptions()
+        {
+            // Terrible, evil, do not want to do, why does NetFx force this?
+            var type = typeof(HttpRequestHeaders);
+            var assembly = type.Assembly;
+            var flags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic;
+
+            _headers = (HttpRequestHeaders)assembly.CreateInstance(type.FullName, false, flags, null, new object[0], null, null);
+        }
+
+        private Secret _authentication;
+        private CookieContainer _cookieContainer;
+        private NetworkRequestOptionFlags _flags;
+        private readonly HttpRequestHeaders _headers;
+        private int _maxRedirections;
+        private TimeSpan _timeout;
+
+        /// <summary>
+        /// The authentication credentials associated with the handler.
+        /// <para/>
+        /// This property is ignored unless `<see cref="Flags"/>` contains `<see cref="NetworkRequestOptionFlags.UseCredentials"/>`.
+        /// </summary>
+        public Secret Authorization
+        {
+            get { return _authentication; }
+            set
+            {
+                _authentication = value;
+                _flags = (value is null)
+                    ? (_flags & ~NetworkRequestOptionFlags.UseCredentials)
+                    : (_flags | NetworkRequestOptionFlags.UseCredentials);
+            }
+        }
+
+        /// <summary>
+        /// The cookie container used to store server cookies by the handler.
+        /// <para/>
+        /// When `<see langword="null"/>`, a new container could be allocated by the calling method.
+        /// </summary>
+        public CookieContainer CookieContainer
+        {
+            get { return _cookieContainer; }
+            set
+            {
+                _cookieContainer = value;
+                _flags = (value is null)
+                    ? (_flags & ~NetworkRequestOptionFlags.UseCookies)
+                    : (_flags | NetworkRequestOptionFlags.UseCookies);
+            }
+        }
+
+        /// <summary>
+        /// Gets an instance of `<see cref="NetworkRequestOptions"/>` with all default property values set.
+        /// </summary>
+        public static NetworkRequestOptions Default
+        {
+            get
+            {
+                return new NetworkRequestOptions(true);
+            }
+        }
+
+        /// <summary>
+        /// Flags related to network request options.
+        /// </summary>
+        public NetworkRequestOptionFlags Flags
+        {
+            get { return _flags; }
+            set
+            {
+                _flags = value;
+
+                if ((_flags & NetworkRequestOptionFlags.UseCredentials) == 0)
+                {
+                    _authentication = null;
+                }
+                if ((_flags & NetworkRequestOptionFlags.UseCookies) == 0)
+                {
+                    _cookieContainer = null;
+                }
+                if ((_flags & NetworkRequestOptionFlags.AllowRedirections) == 0)
+                {
+                    _maxRedirections = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The headers which should be sent with the request.
+        /// <para/>
+        /// This property is ignored when `<see langword="null"/>`.
+        /// </summary>
+        public HttpRequestHeaders Headers
+        {
+            get { return _headers; }
+        }
+
+        /// <summary>
+        /// The maximum number of redirection responses that the handler follows.
+        /// <para/>
+        /// This property is ignored if `<see cref="Flags"/>` does not contain `<see cref="NetworkRequestOptionFlags.AllowRedirections"/>`.
+        /// </summary>
+        public int MaxRedirections
+        {
+            get { return _maxRedirections; }
+            set
+            {
+                _maxRedirections = value;
+                _flags = (_maxRedirections > 0)
+                    ? (_flags | NetworkRequestOptionFlags.AllowRedirections)
+                    : (_flags & ~NetworkRequestOptionFlags.AllowRedirections);
+
+            }
+        }
+
+        /// <summary>
+        /// The amount of time to wait before the request times out.
+        /// <para/>
+        /// This property is ignored if the value is less than `<see cref="TimeSpan.Zero"/>`.
+        /// </summary>
+        public TimeSpan Timeout
+        {
+            get { return _timeout; }
+            set { _timeout = value; }
+        }
+    }
+
+    public interface INetwork
+    {
+        /// <summary>
+        /// Send a GET request, using `<paramref name="options"/>`, to the specified server as an asynchronous operation.
+        /// <para/>
+        /// Returns a task to get the response from the server.
+        /// </summary>
+        /// <param name="targetUri">The Uri of the target.</param>
+        /// <param name="options">Options which govern how the HTTP request is sent.</param>
+        Task<HttpResponseMessage> HttpGetAsync(TargetUri targetUri, NetworkRequestOptions options);
+
+        /// <summary>
+        /// Send a GET request, using `<see cref="NetworkRequestOptions.Default"/>`, to the specified server as an asynchronous operation.
+        /// <para/>
+        /// Returns a task to get the response from the server.
+        /// </summary>
+        /// <param name="targetUri">The Uri of the server.</param>
+        Task<HttpResponseMessage> HttpGetAsync(TargetUri targetUri);
+
+        /// <summary>
+        /// Send a HEAD request, using `<paramref name="options"/>`, to the specified server as an asynchronous operation.
+        /// <para/>
+        /// Returns a task to get the response from the server.
+        /// </summary>
+        /// <param name="targetUri">The Uri of the server.</param>
+        /// <param name="options">Options which govern how the HTTP request is sent.</param>
+        Task<HttpResponseMessage> HttpHeadAsync(TargetUri targetUri, NetworkRequestOptions options);
+
+        /// <summary>
+        /// Send a GET request, using `<see cref="NetworkRequestOptions.Default"/>`, to the specified target as an asynchronous operation.
+        /// <para/>
+        /// Returns a task to get the response from the target.
+        /// </summary>
+        /// <param name="targetUri">The Uri of the target.</param>
+        Task<HttpResponseMessage> HttpHeadAsync(TargetUri targetUri);
+
+        /// <summary>
+        /// Send a POST request, using `<paramref name="options"/>`, to the specified server as an asynchronous operation.
+        /// <para/>
+        /// Returns a task to get the response from the server.
+        /// </summary>
+        /// <param name="targetUri">The Uri of the target.</param>
+        /// <param name="content">Content to send, as part of the request, to the server.</param>
+        /// <param name="options">Options which govern how the HTTP request is sent.</param>
+        Task<HttpResponseMessage> HttpPostAsync(TargetUri targetUri, HttpContent content, NetworkRequestOptions options);
+
+        /// <summary>
+        /// Send a POST request, using `<see cref="NetworkRequestOptions.Default"/>`, to the specified server as an asynchronous operation.
+        /// <para/>
+        /// Returns a task to get the response from the server.
+        /// </summary>
+        /// <param name="targetUri">The Uri of the target.</param>
+        /// <param name="content">Content to send, as part of the request, to the server.</param>
+        Task<HttpResponseMessage> HttpPostAsync(TargetUri targetUri, StringContent content);
+    }
+
+    internal class Network : Base, INetwork
+    {
+        private const string BearerPrefix = "Bearer ";
+        private static readonly AuthenticationHeaderValue[] NullResult = new AuthenticationHeaderValue[0];
+
+        public Network(RuntimeContext context)
+            : base(context)
+        { }
+
+        public async Task<HttpResponseMessage> HttpGetAsync(TargetUri targetUri, NetworkRequestOptions options)
+        {
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            // Craft the request header for the GitHub v3 API w/ credentials;
+            using (var handler = GetHttpMessageHandler(targetUri, options))
+            using (var httpClient = GetHttpClient(targetUri, handler, options))
+            {
+                return await httpClient.GetAsync(targetUri);
+            }
+        }
+
+        public Task<HttpResponseMessage> HttpGetAsync(TargetUri targetUri)
+            => HttpGetAsync(targetUri, NetworkRequestOptions.Default);
+
+        public async Task<HttpResponseMessage> HttpHeadAsync(TargetUri targetUri, NetworkRequestOptions options)
+        {
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            using (var httpMessageHandler = GetHttpMessageHandler(targetUri, options))
+            using (var httpClient = GetHttpClient(targetUri, httpMessageHandler, options))
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Head, targetUri))
+            {
+                // Copy the headers from the client into the message because the framework
+                // will not do this when using `SendAsync`.
+                foreach (var header in httpClient.DefaultRequestHeaders)
+                {
+                    requestMessage.Headers.Add(header.Key, header.Value);
+                }
+
+                return await httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead);
+            }
+        }
+
+        public Task<HttpResponseMessage> HttpHeadAsync(TargetUri targetUri)
+            => HttpHeadAsync(targetUri, NetworkRequestOptions.Default);
+
+        public async Task<HttpResponseMessage> HttpPostAsync(TargetUri targetUri, HttpContent content, NetworkRequestOptions options)
+        {
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+            if (content is null)
+                throw new ArgumentNullException(nameof(content));
+
+            using (var handler = GetHttpMessageHandler(targetUri, options))
+            using (var httpClient = GetHttpClient(targetUri, handler, options))
+            {
+                return await httpClient.PostAsync(targetUri, content);
+            }
+        }
+
+        public Task<HttpResponseMessage> HttpPostAsync(TargetUri targetUri, StringContent content)
+            => HttpPostAsync(targetUri, content, NetworkRequestOptions.Default);
+
+        private static HttpMessageHandler GetHttpMessageHandler(TargetUri targetUri, NetworkRequestOptions options)
+        {
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            var handler = new HttpClientHandler();
+
+            if (options != null)
+            {
+                if ((options.Flags & NetworkRequestOptionFlags.AllowRedirections) != 0 && options.MaxRedirections <= 0)
+                {
+                    var inner = new ArgumentOutOfRangeException(nameof(options.MaxRedirections));
+                    throw new ArgumentException("`NetworkRequestOption.MaxRedirections` must be greater than zero with `NetworkRequestOptionFlags.AllowAutoRedirect`.", nameof(options), inner);
+                }
+
+                if (options.CookieContainer is null && (options.Flags & NetworkRequestOptionFlags.UseCookies) != 0)
+                {
+                    var inner = new ArgumentNullException(nameof(options.CookieContainer));
+                    throw new ArgumentException("`NetworkRequestOption.CookieContainer` cannot be null with `NetworkRequestOptionFlags.UseCookies`.", nameof(options), inner);
+                }
+
+                if ((options.Flags & NetworkRequestOptionFlags.UseCredentials) != 0 && options.Authorization is null)
+                {
+                    var inner = new ArgumentNullException(nameof(options.Authorization));
+                    throw new ArgumentException("`NetworkRequestOption.Authentication` cannot be null with `NetworkRequestOptionFlags.UseCredentials`.", nameof(options), inner);
+                }
+
+                if ((options.Flags & NetworkRequestOptionFlags.AllowRedirections) == 0
+                    || options.MaxRedirections <= 0)
+                {
+                    handler.AllowAutoRedirect = false;
+                }
+                else
+                {
+                    handler.AllowAutoRedirect = true;
+                    handler.MaxAutomaticRedirections = options.MaxRedirections;
+                }
+
+                if ((options.Flags & NetworkRequestOptionFlags.UseCookies) != 0
+                    && options.CookieContainer != null)
+                {
+                    handler.CookieContainer = options.CookieContainer;
+                    handler.UseCookies = true;
+                }
+
+                if ((options.Flags & NetworkRequestOptionFlags.UseCredentials) != 0
+                    && options.Authorization != null)
+                {
+                    handler.UseDefaultCredentials = false;
+                }
+
+                handler.PreAuthenticate = (options.Flags & NetworkRequestOptionFlags.PreAuthenticate) != 0;
+
+                if ((options.Flags & NetworkRequestOptionFlags.UseProxy) != 0
+                    && targetUri.ProxyUri != null)
+                {
+                    var proxy = GetHttpWebProxy(targetUri);
+
+                    if (proxy != null)
+                    {
+                        handler.Proxy = proxy;
+                        handler.UseProxy = true;
+                    }
+                }
+            }
+
+            return handler;
+        }
+
+        private HttpClient GetHttpClient(TargetUri targetUri, HttpMessageHandler handler, NetworkRequestOptions options)
+        {
+            var httpClient = new HttpClient(handler);
+
+            if (options != null)
+            {
+                if (options.Timeout > TimeSpan.Zero)
+                {
+                    httpClient.Timeout = options.Timeout;
+                }
+
+                if (options.Headers != null)
+                {
+                    foreach (var header in options.Headers)
+                    {
+                        httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+                    }
+                }
+
+                // Manually add the correct headers for the type of authentication that is happening because if
+                // we rely on the framework to correctly write the headers neither GitHub nor VSTS authentication
+                // works reliably.
+                if (options.Authorization != null)
+                {
+                    switch (options.Authorization)
+                    {
+                        case Token token:
+                            {
+                                // Different types of tokens are packed differently.
+                                switch (token.Type)
+                                {
+                                    case TokenType.AzureAccess:
+                                        {
+                                            // ADAL access tokens are packed into the Authorization header.
+                                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+                                        }
+                                        break;
+
+                                    case TokenType.AzureFederated:
+                                        {
+                                            // Federated authentication tokens are sent as cookie(s).
+                                            httpClient.DefaultRequestHeaders.Add("Cookie", token.Value);
+                                        }
+                                        break;
+
+                                    default:
+                                        Trace.WriteLine("! unsupported token type, not appeding an authentication header to the request.");
+                                        break;
+                                }
+                            }
+                            break;
+
+                        case Credential credentials:
+                            {
+                                // Credentials are packed into the 'Authorization' header as a base64 encoded pair.
+                                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials.ToBase64String());
+                            }
+                            break;
+                    }
+                }
+            }
+
+            // Ensure that the user-agent string is set.
+            if (httpClient.DefaultRequestHeaders.UserAgent is null
+                || httpClient.DefaultRequestHeaders.UserAgent.Count == 0)
+            {
+                httpClient.DefaultRequestHeaders.Add("User-Agent", Global.UserAgent);
+            }
+
+            return httpClient;
+        }
+
+        private static IWebProxy GetHttpWebProxy(TargetUri targetUri)
+        {
+            if (targetUri is null || targetUri.ProxyUri is null)
+                return null;
+
+            var proxyUri = targetUri.ProxyUri;
+
+            if (proxyUri != null)
+            {
+                WebProxy proxy = new WebProxy(proxyUri) { UseDefaultCredentials = true };
+
+                // check if the user has specified authentications (comes as UserInfo)
+                if (!string.IsNullOrWhiteSpace(proxyUri.UserInfo) && proxyUri.UserInfo.Length > 1)
+                {
+                    int tokenIndex = proxyUri.UserInfo.IndexOf(':');
+                    bool hasUserNameAndPassword = tokenIndex != -1;
+
+                    if (hasUserNameAndPassword)
+                    {
+                        string userName = proxyUri.UserInfo.Substring(0, tokenIndex);
+                        string password = proxyUri.UserInfo.Substring(tokenIndex + 1);
+
+                        NetworkCredential proxyCreds = new NetworkCredential(userName, password);
+
+                        proxy.UseDefaultCredentials = false;
+                        proxy.Credentials = proxyCreds;
+                    }
+                }
+
+                return proxy;
+            }
+            else
+            {
+                return new WebProxy();
+            }
+        }
+    }
+}

--- a/Microsoft.Alm.Authentication/RuntimeContext.cs
+++ b/Microsoft.Alm.Authentication/RuntimeContext.cs
@@ -34,18 +34,22 @@ namespace Microsoft.Alm.Authentication
 
         public RuntimeContext(
             IFileSystem fileSystem,
+            INetwork network,
             Git.ITrace trace,
             Git.IWhere where)
             : this()
         {
             if (fileSystem is null)
                 throw new ArgumentNullException(nameof(fileSystem));
+            if (network is null)
+                throw new ArgumentNullException(nameof(network));
             if (trace is null)
                 throw new ArgumentNullException(nameof(trace));
             if (where is null)
                 throw new ArgumentNullException(nameof(where));
 
             _fileSystem = fileSystem;
+            _network = network;
             _trace = trace;
             _where = where;
         }
@@ -62,6 +66,7 @@ namespace Microsoft.Alm.Authentication
 
             Default = new RuntimeContext();
             Default._fileSystem = new FileSystem(Default);
+            Default._network = new Network(Default);
             Default._trace = new Git.Trace(Default);
             Default._where = new Git.Where(Default);
         }
@@ -69,6 +74,7 @@ namespace Microsoft.Alm.Authentication
         private static int _count;
         private IFileSystem _fileSystem;
         private readonly int _id;
+        private INetwork _network;
         private readonly object _syncpoint;
         private Git.ITrace _trace;
         private Git.IWhere _where;
@@ -81,6 +87,11 @@ namespace Microsoft.Alm.Authentication
         public int Id
         {
             get { return _id; }
+        }
+
+        public INetwork Network
+        {
+            get { return _network; }
         }
 
         public Git.ITrace Trace

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -24,8 +24,6 @@
 **/
 
 using System;
-using System.Net;
-using System.Net.Http;
 using System.Text;
 
 namespace Microsoft.Alm.Authentication
@@ -108,34 +106,6 @@ namespace Microsoft.Alm.Authentication
         }
 
         /// <summary>
-        /// Gets the client header enabled to work with proxies as necessary.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        public HttpClientHandler HttpClientHandler
-        {
-            get
-            {
-                bool useProxy = ProxyUri != null;
-
-                var client = new HttpClientHandler()
-                {
-                    AllowAutoRedirect = true,
-                    UseCookies = true,
-                    UseProxy = useProxy,
-                    MaxAutomaticRedirections = Global.MaxAutomaticRedirections,
-                    UseDefaultCredentials = true,
-                };
-
-                if (useProxy)
-                {
-                    client.Proxy = WebProxy;
-                }
-
-                return client;
-            }
-        }
-
-        /// <summary>
         /// Gets whether the `<see cref="QueryUri"/>` is absolute.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic")]
@@ -183,47 +153,6 @@ namespace Microsoft.Alm.Authentication
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
         public string TargetUriUsername { get { return QueryUri.UserInfo; } }
-
-        /// <summary>
-        /// Gets the web proxy abstraction for working with proxies as necessary.
-        /// </summary>
-        public WebProxy WebProxy
-        {
-            get
-            {
-                if (ProxyUri != null)
-                {
-                    WebProxy proxy = new WebProxy(ProxyUri) { UseDefaultCredentials = true };
-
-                    // check if the user has specified authentications (comes as UserInfo)
-                    if (!string.IsNullOrWhiteSpace(ProxyUri.UserInfo) && ProxyUri.UserInfo.Length > 1)
-                    {
-                        int tokenIndex = ProxyUri.UserInfo.IndexOf(':');
-                        bool hasUserNameAndPassword = tokenIndex != -1;
-
-                        if (hasUserNameAndPassword)
-                        {
-                            string userName = ProxyUri.UserInfo.Substring(0, tokenIndex);
-                            string password = ProxyUri.UserInfo.Substring(tokenIndex + 1);
-
-                            NetworkCredential proxyCreds = new NetworkCredential(
-                                userName,
-                                password
-                            );
-
-                            proxy.UseDefaultCredentials = false;
-                            proxy.Credentials = proxyCreds;
-                        }
-                    }
-
-                    return proxy;
-                }
-                else
-                {
-                    return new WebProxy();
-                }
-            }
-        }
 
         /// <summary>
         /// Returns a version of this `<see cref="TargetUri"/>` that contains the specified username.

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Alm.Authentication
         {
             if (value is null)
                 throw new ArgumentNullException(nameof(value));
-            if ((type & ~(TokenType.Access | TokenType.Federated | TokenType.Personal | TokenType.Test)) != 0)
+            if (type != TokenType.AzureAccess && type != TokenType.AzureFederated && type != TokenType.Personal && type != TokenType.Test)
                 throw new ArgumentOutOfRangeException(nameof(type));
 
             _targetIdentity = tenantId;
@@ -79,12 +79,18 @@ namespace Microsoft.Alm.Authentication
         /// <summary>
         /// The type of the security token.
         /// </summary>
-        public TokenType Type { get { return _type; } }
+        public TokenType Type
+        {
+            get { return _type; }
+        }
 
         /// <summary>
         /// The raw contents of the token.
         /// </summary>
-        public string Value { get { return _value; } }
+        public string Value
+        {
+            get { return _value; }
+        }
 
         /// <summary>
         /// The `<see cref="Guid"/>` form Identity of the target

--- a/Microsoft.Alm.Authentication/TokenType.cs
+++ b/Microsoft.Alm.Authentication/TokenType.cs
@@ -33,26 +33,26 @@ namespace Microsoft.Alm.Authentication
         /// Azure Directory Access Token.
         /// </summary>
         [System.ComponentModel.Description("Azure Directory Access Token")]
-        Access = 1,
+        AzureAccess = 1,
 
         /// <summary>
         /// Azure Directory Refresh Token.
         /// </summary>
         [System.Obsolete("Azure Directory no longer directly supports Refresh tokens.", true)]
         [System.ComponentModel.Description("Azure Directory Refresh Token")]
-        Refresh = 2,
-
-        /// <summary>
-        /// Personal Access Token, can be compact or not.
-        /// </summary>
-        [System.ComponentModel.Description("Personal Access Token")]
-        Personal = 3,
+        AzureRefresh = 2,
 
         /// <summary>
         /// Federated Authentication (aka FedAuth) Token
         /// </summary>
         [System.ComponentModel.Description("Federated Authentication Token")]
-        Federated = 4,
+        AzureFederated = 3,
+
+        /// <summary>
+        /// Personal Access Token, can be compact or not.
+        /// </summary>
+        [System.ComponentModel.Description("Personal Access Token")]
+        Personal = 4,
 
         /// <summary>
         /// Used only for testing.

--- a/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
+++ b/Microsoft.Alm.Authentication/WwwAuthenticateHelper.cs
@@ -24,9 +24,7 @@
 **/
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
@@ -34,37 +32,38 @@ namespace Microsoft.Alm.Authentication
 {
     internal class WwwAuthenticateHelper
     {
-        internal static readonly Credential Credentials = new Credential(string.Empty, string.Empty);
-        internal static readonly AuthenticationHeaderValue NtlmHeader = new AuthenticationHeaderValue("NTLM");
-        internal static readonly AuthenticationHeaderValue NegotiateHeader = new AuthenticationHeaderValue("Negotiate");
+        public static readonly Credential Credentials = new Credential(string.Empty, string.Empty);
+        public static readonly AuthenticationHeaderValue NtlmHeader = new AuthenticationHeaderValue("NTLM");
+        public static readonly AuthenticationHeaderValue NegotiateHeader = new AuthenticationHeaderValue("Negotiate");
 
         private static readonly AuthenticationHeaderValue[] NullResult = new AuthenticationHeaderValue[0];
 
         public static async Task<AuthenticationHeaderValue[]> GetHeaderValues(RuntimeContext context, TargetUri targetUri)
         {
-            BaseSecureStore.ValidateTargetUri(targetUri);
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
 
             if (targetUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.Ordinal)
                 || targetUri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.Ordinal))
             {
                 try
                 {
-                    // Try the query URI
-                    string queryUrl = targetUri.QueryUri.ToString();
-
-                    // Send off the HTTP requests and wait for them to complete
-                    var result = await RequestAuthenticate(targetUri, queryUrl);
-
-                    // If any of then returned true, then we're looking at a TFS server
-                    HashSet<AuthenticationHeaderValue> set = new HashSet<AuthenticationHeaderValue>();
-
-                    // Combine the results into a unique set
-                    foreach (var item in result)
+                    // Configure the http request to not choose an authentication strategy for us
+                    // because we want to deliver the complete payload to the caller.
+                    var options = new NetworkRequestOptions(false)
                     {
-                        set.Add(item);
-                    }
+                        Flags = NetworkRequestOptionFlags.UseProxy,
+                        Timeout = TimeSpan.FromMilliseconds(Global.RequestTimeout),
+                    };
 
-                    return set.ToArray();
+                    // Make the request and return the response.
+                    using (var result = await context.Network.HttpHeadAsync(targetUri, options))
+                    {
+                        return result.Headers?.WwwAuthenticate?.ToArray()
+                            ?? NullResult;
+                    }
                 }
                 catch (Exception exception)
                 {
@@ -79,32 +78,6 @@ namespace Microsoft.Alm.Authentication
         {
             return value?.Scheme != null
                 && value.Scheme.Equals(NtlmHeader.Scheme, StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static async Task<AuthenticationHeaderValue[]> RequestAuthenticate(TargetUri targetUri, string targetUrl)
-        {
-            using (var httpClientHandler = targetUri.HttpClientHandler)
-            {
-                // configure the http client handler to not choose an authentication strategy for us
-                // because we want to deliver the complete payload to the caller
-                httpClientHandler.AllowAutoRedirect = false;
-                httpClientHandler.PreAuthenticate = false;
-                httpClientHandler.UseDefaultCredentials = false;
-
-                using (HttpClient client = new HttpClient(httpClientHandler))
-                {
-                    client.DefaultRequestHeaders.Add("User-Agent", Global.UserAgent);
-                    client.Timeout = TimeSpan.FromMilliseconds(Global.RequestTimeout);
-
-                    using (HttpResponseMessage response = await client.GetAsync(targetUrl, HttpCompletionOption.ResponseHeadersRead))
-                    {
-                        // Check for a WWW-Authenticate header with NTLM protocol specified
-                        return response.Headers.Contains("WWW-Authenticate")
-                            ? response.Headers.WwwAuthenticate.ToArray()
-                            : NullResult;
-                    }
-                }
-            }
         }
     }
 }

--- a/Microsoft.Vsts.Authentication.Test/AuthorityFake.cs
+++ b/Microsoft.Vsts.Authentication.Test/AuthorityFake.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Alm.Authentication.Test
         {
             Assert.Equal(ExpectedQueryParameters, queryParameters);
 
-            return await Task.FromResult(new Token("token-access", TokenType.Access));
+            return await Task.FromResult(new Token("token-access", TokenType.AzureAccess));
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Microsoft.Alm.Authentication.Test
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         public async Task<Token> NoninteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri)
         {
-            return await Task.FromResult(new Token("token-access", TokenType.Access));
+            return await Task.FromResult(new Token("token-access", TokenType.AzureAccess));
         }
 
         /// <summary>

--- a/Microsoft.Vsts.Authentication/AzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/AzureAuthority.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Alm.Authentication
                 Guid tenantId;
                 if (Guid.TryParse(authResult.TenantId, out tenantId))
                 {
-                    token = new Token(authResult.AccessToken, tenantId, TokenType.Access);
+                    token = new Token(authResult.AccessToken, tenantId, TokenType.AzureAccess);
                 }
 
                 Trace.WriteLine($"authority host URL = '{AuthorityHostUrl}', token acquisition succeeded.");
@@ -138,7 +138,10 @@ namespace Microsoft.Alm.Authentication
             if (redirectUri is null)
                 throw new ArgumentNullException(nameof(redirectUri));
             if (!redirectUri.IsAbsoluteUri)
-                throw new ArgumentException(nameof(redirectUri));
+            {
+                var inner = new UriFormatException("Uri is not absolute when an absolute Uri is required.");
+                throw new ArgumentException(inner.Message, nameof(redirectUri), inner);
+            }
 
             Token token = null;
 
@@ -152,7 +155,7 @@ namespace Microsoft.Alm.Authentication
                 Guid tentantId;
                 if (Guid.TryParse(authResult.TenantId, out tentantId))
                 {
-                    token = new Token(authResult.AccessToken, tentantId, TokenType.Access);
+                    token = new Token(authResult.AccessToken, tentantId, TokenType.AzureAccess);
 
                     Trace.WriteLine($"token acquisition for authority host URL = '{AuthorityHostUrl}' succeeded.");
                 }

--- a/Microsoft.Vsts.Authentication/TokenRegistry.cs
+++ b/Microsoft.Vsts.Authentication/TokenRegistry.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Alm.Authentication
                             TokenType tokenType;
                             if (string.Equals(type, "Federated", StringComparison.OrdinalIgnoreCase))
                             {
-                                tokenType = TokenType.Federated;
+                                tokenType = TokenType.AzureFederated;
                             }
                             else
                             {

--- a/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
@@ -138,9 +138,9 @@ namespace Microsoft.Alm.Authentication
                     }
                 }
             }
-            catch (WebException webException)
+            catch (HttpRequestException exception)
             {
-                Trace.WriteLine($"server returned '{webException.Status}'.");
+                Trace.WriteLine($"server returned '{exception.Message}'.");
             }
 
             if (Guid.TryParse(resultId, out Guid instanceId))

--- a/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
@@ -24,11 +24,8 @@
 **/
 
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -66,33 +63,32 @@ namespace Microsoft.Alm.Authentication
 
             try
             {
-                using (HttpClient httpClient = CreateHttpClient(targetUri, accessToken))
+                var options = new NetworkRequestOptions(true)
                 {
-                    if (await PopulateTokenTargetId(targetUri, accessToken))
+                    Authorization = accessToken,
+                };
+
+                var requestUri = await CreatePersonalAccessTokenRequestUri(targetUri, requireCompactToken);
+
+                using (StringContent content = GetAccessTokenRequestBody(targetUri, accessToken, tokenScope, tokenDuration))
+                using (var response = await Network.HttpPostAsync(targetUri, content, options))
+                {
+                    if (response.IsSuccessStatusCode)
                     {
-                        Uri requestUri = await CreatePersonalAccessTokenRequestUri(httpClient, targetUri, requireCompactToken);
+                        string responseText = await response.Content.ReadAsStringAsync();
 
-                        using (StringContent content = GetAccessTokenRequestBody(targetUri, accessToken, tokenScope, tokenDuration))
-                        using (HttpResponseMessage response = await httpClient.PostAsync(requestUri, content))
+                        if (!string.IsNullOrWhiteSpace(responseText))
                         {
-                            if (response.IsSuccessStatusCode)
+                            // Find the 'token : <value>' portion of the result content, if any.
+                            Match tokenMatch = null;
+                            if ((tokenMatch = Regex.Match(responseText, @"\s*""token""\s*:\s*""([^\""]+)""\s*", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success)
                             {
-                                string responseText = await response.Content.ReadAsStringAsync();
+                                string tokenValue = tokenMatch.Groups[1].Value;
+                                Token token = new Token(tokenValue, TokenType.Personal);
 
-                                if (!string.IsNullOrWhiteSpace(responseText))
-                                {
-                                    // Find the 'token : <value>' portion of the result content, if any.
-                                    Match tokenMatch = null;
-                                    if ((tokenMatch = Regex.Match(responseText, @"\s*""token""\s*:\s*""([^\""]+)""\s*", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success)
-                                    {
-                                        string tokenValue = tokenMatch.Groups[1].Value;
-                                        Token token = new Token(tokenValue, TokenType.Personal);
+                                Trace.WriteLine($"personal access token acquisition for '{targetUri}' succeeded.");
 
-                                        Trace.WriteLine($"personal access token acquisition for '{targetUri}' succeeded.");
-
-                                        return token;
-                                    }
-                                }
+                                return token;
                             }
                         }
                     }
@@ -110,31 +106,35 @@ namespace Microsoft.Alm.Authentication
 
         public async Task<bool> PopulateTokenTargetId(TargetUri targetUri, Token accessToken)
         {
-            BaseSecureStore.ValidateTargetUri(targetUri);
-            BaseSecureStore.ValidateToken(accessToken);
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+            if (accessToken is null)
+                throw new ArgumentNullException(nameof(accessToken));
 
             string resultId = null;
-            Guid instanceId;
 
             try
             {
                 // Create an request to the VSTS deployment data end-point.
-                HttpWebRequest request = GetConnectionDataRequest(targetUri, accessToken);
-
-                Trace.WriteLine($"access token end-point is '{request.Method}' '{request.RequestUri}'.");
+                var requestUri = GetConnectionDataUri(targetUri);
+                var options = new NetworkRequestOptions(true)
+                {
+                    Authorization = accessToken,
+                };
 
                 // Send the request and wait for the response.
-                using (var response = await request.GetResponseAsync())
-                using (var stream = response.GetResponseStream())
-                using (var reader = new StreamReader(stream, Encoding.UTF8))
+                using (var response = await Network.HttpGetAsync(requestUri, options))
                 {
-                    string content = await reader.ReadToEndAsync();
-                    Match match;
-
-                    if ((match = Regex.Match(content, @"""instanceId""\s*\:\s*""([^""]+)""", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success
-                        && match.Groups.Count == 2)
+                    if (response.IsSuccessStatusCode)
                     {
-                        resultId = match.Groups[1].Value;
+                        string content = await response.Content.ReadAsStringAsync();
+                        Match match;
+
+                        if ((match = Regex.Match(content, @"""instanceId""\s*\:\s*""([^""]+)""", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success
+                            && match.Groups.Count == 2)
+                        {
+                            resultId = match.Groups[1].Value;
+                        }
                     }
                 }
             }
@@ -143,9 +143,9 @@ namespace Microsoft.Alm.Authentication
                 Trace.WriteLine($"server returned '{webException.Status}'.");
             }
 
-            if (Guid.TryParse(resultId, out instanceId))
+            if (Guid.TryParse(resultId, out Guid instanceId))
             {
-                Trace.WriteLine($"target identity is {resultId}.");
+                Trace.WriteLine($"target identity is '{resultId}'.");
                 accessToken.TargetIdentity = instanceId;
 
                 return true;
@@ -163,66 +163,38 @@ namespace Microsoft.Alm.Authentication
         /// <param name="credentials">`<see cref="Credential"/>` expected to grant access to the VSTS service.</param>
         public async Task<bool> ValidateCredentials(TargetUri targetUri, Credential credentials)
         {
-            BaseSecureStore.ValidateTargetUri(targetUri);
-            BaseSecureStore.ValidateCredential(credentials);
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+            if (credentials is null)
+                throw new ArgumentNullException(nameof(credentials));
 
             try
             {
                 // Create an request to the VSTS deployment data end-point.
-                HttpWebRequest request = GetConnectionDataRequest(targetUri, credentials);
-
-                Trace.WriteLine($"validating credentials against '{request.RequestUri}'.");
+                var requestUri = GetConnectionDataUri(targetUri);
+                var options = new NetworkRequestOptions(true)
+                {
+                    Authorization = credentials,
+                };
 
                 // Send the request and wait for the response.
-                using (HttpWebResponse response = await request.GetResponseAsync() as HttpWebResponse)
+                using (var response = await Network.HttpGetAsync(requestUri, options))
                 {
-                    // We're looking for 'OK 200' here, anything else is failure
-                    Trace.WriteLine($"server returned: ({response.StatusCode}).");
-                    return response.StatusCode == HttpStatusCode.OK;
-                }
-            }
-            catch (WebException webException)
-            {
-                // Avoid invalidation credentials based on what is likely a networking problem.
-                switch (webException.Status)
-                {
-                    case WebExceptionStatus.ConnectFailure:
-                    case WebExceptionStatus.ConnectionClosed:
-                    case WebExceptionStatus.NameResolutionFailure:
-                    case WebExceptionStatus.ProxyNameResolutionFailure:
-                    case WebExceptionStatus.ReceiveFailure:
-                    case WebExceptionStatus.RequestCanceled:
-                    case WebExceptionStatus.RequestProhibitedByCachePolicy:
-                    case WebExceptionStatus.RequestProhibitedByProxy:
-                    case WebExceptionStatus.SecureChannelFailure:
-                    case WebExceptionStatus.SendFailure:
-                    case WebExceptionStatus.TrustFailure:
-                        {
-                            Trace.WriteLine($"unable to validate credentials due to '{webException.Status}'.");
-
-                            return true;
-                        }
-                }
-
-                // Even if the service responded, if the issue isn't a 400 class response then
-                // the credentials were likely not rejected.
-                if (webException.Response is HttpWebResponse response)
-                {
-                    int statusCode = (int)response.StatusCode;
-
-                    if (statusCode < 400 && statusCode >= 500)
+                    if (!response.IsSuccessStatusCode)
                     {
-                        Trace.WriteLine($"server returned: ({statusCode}).");
+                        // Even if the service responded, if the issue isn't a 400 class response then
+                        // the credentials were likely not rejected.
+                        if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                            return false;
 
+                        Trace.WriteLine($"unable to validate credentials due to '{response.StatusCode}'.");
                         return true;
                     }
                 }
-
-                Trace.WriteLine($"server returned: '{webException.Message}.");
             }
-            catch
+            catch(Exception exception)
             {
-                Trace.WriteLine("! unexpected error");
+                Trace.WriteLine($"! error: '{exception.Message}'.");
             }
 
             Trace.WriteLine($"credential validation for '{targetUri}' failed.");
@@ -238,8 +210,10 @@ namespace Microsoft.Alm.Authentication
         /// <param name="token">`<see cref="Token"/>` expected to grant access to the VSTS resource.</param>
         public async Task<bool> ValidateToken(TargetUri targetUri, Token token)
         {
-            BaseSecureStore.ValidateTargetUri(targetUri);
-            BaseSecureStore.ValidateToken(token);
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+            if (token is null)
+                throw new ArgumentNullException(nameof(token));
 
             // Personal access tokens are effectively credentials, treat them as such.
             if (token.Type == TokenType.Personal)
@@ -248,171 +222,92 @@ namespace Microsoft.Alm.Authentication
             try
             {
                 // Create an request to the VSTS deployment data end-point.
-                HttpWebRequest request = GetConnectionDataRequest(targetUri, token);
-
-                Trace.WriteLine($"validating token against '{request.Host}'.");
+                var requestUri = GetConnectionDataUri(targetUri);
+                var options = new NetworkRequestOptions(true)
+                {
+                    Authorization = token,
+                };
 
                 // Send the request and wait for the response.
-                using (HttpWebResponse response = await request.GetResponseAsync() as HttpWebResponse)
+                using (var response = await Network.HttpGetAsync(requestUri, options))
                 {
-                    // We're looking for 'OK 200' here, anything else is failure.
-                    Trace.WriteLine($"server returned: '{response.StatusCode}'.");
-                    return response.StatusCode == HttpStatusCode.OK;
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        // Even if the service responded, if the issue isn't a 400 class response then
+                        // the credentials were likely not rejected.
+                        if ((int)response.StatusCode >= 400 && (int)response.StatusCode < 500)
+                            return false;
+
+                        Trace.WriteLine($"unable to validate credentials due to '{response.StatusCode}'.");
+                        return true;
+                    }
                 }
             }
-            catch (WebException webException)
+            catch (Exception exception)
             {
-                Trace.WriteLine($"! server returned: '{webException.Message}'.");
-            }
-            catch
-            {
-                Trace.WriteLine("! unexpected error");
-            }
+                Trace.WriteLine($"! error: '{exception.Message}'.");
+            };
 
+            
             Trace.WriteLine($"token validation for '{targetUri}' failed.");
             return false;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        internal static HttpClient CreateHttpClient(TargetUri targetUri, Token accessToken)
-        {
-            const string AccessTokenHeader = "Bearer";
-            const string FederatedTokenHeader = "Cookie";
-
-            Debug.Assert(targetUri != null, $"The `{nameof(targetUri)}` parameter is null.");
-            Debug.Assert(accessToken != null && !string.IsNullOrWhiteSpace(accessToken.Value), $"The `{nameof(accessToken)}' is null or invalid.");
-
-            HttpClient httpClient = CreateHttpClient(targetUri);
-
-            switch (accessToken.Type)
-            {
-                case TokenType.Access:
-                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AccessTokenHeader, accessToken.Value);
-                    break;
-
-                case TokenType.Federated:
-                    httpClient.DefaultRequestHeaders.Add(FederatedTokenHeader, accessToken.Value);
-                    break;
-
-                default:
-                    return null;
-            }
-
-            return httpClient;
-        }
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        internal static HttpClient CreateHttpClient(TargetUri targetUri, Credential credentials)
-        {
-            const string CredentialHeader = "Basic";
-
-            Debug.Assert(targetUri != null, $"The `{nameof(targetUri)}` parameter is null.");
-
-            HttpClient httpClient = CreateHttpClient(targetUri);
-
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(CredentialHeader, GetBase64EncodedCredentials(credentials));
-
-            return httpClient;
-        }
-
-        internal HttpWebRequest GetConnectionDataRequest(Uri uri, Token token)
-        {
-            const string BearerPrefix = "Bearer ";
-
-            Debug.Assert(uri != null && uri.IsAbsoluteUri, $"The `{nameof(uri)}` parameter is null or invalid");
-            Debug.Assert(token != null && (token.Type == TokenType.Access || token.Type == TokenType.Federated), $"The `{nameof(token)}` parameter is null or invalid");
-
-            // Create an request to the VSTS deployment data end-point.
-            HttpWebRequest request = GetConnectionDataRequest(uri);
-
-            // Different types of tokens are packed differently.
-            switch (token.Type)
-            {
-                case TokenType.Access:
-                    Trace.WriteLine($"validating ADAL access token for '{uri}'.");
-
-                    // ADAL access tokens are packed into the Authorization header.
-                    string sessionAuthHeader = BearerPrefix + token.Value;
-                    request.Headers.Add(HttpRequestHeader.Authorization, sessionAuthHeader);
-                    break;
-
-                case TokenType.Federated:
-                    Trace.WriteLine($"validating federated authentication token for '{uri}'.");
-
-                    // Federated authentication tokens are sent as cookie(s).
-                    request.Headers.Add(HttpRequestHeader.Cookie, token.Value);
-                    break;
-
-                default:
-                    Trace.WriteLine("! unsupported token type.");
-                    break;
-            }
-
-            return request;
-        }
-
-        internal static HttpWebRequest GetConnectionDataRequest(TargetUri targetUri, Credential credentials)
-        {
-            Debug.Assert(targetUri != null && targetUri.IsAbsoluteUri, "The targetUri parameter is null or invalid");
-            Debug.Assert(credentials != null, "The credentials parameter is null or invalid");
-
-            // Create an request to the VSTS deployment data end-point.
-            HttpWebRequest request = GetConnectionDataRequest(targetUri);
-
-            // Credentials are packed into the 'Authorization' header as a base64 encoded pair.
-            string basicAuthHeader = GetBasicAuthorizationHeader(credentials);
-            request.Headers.Add(HttpRequestHeader.Authorization, basicAuthHeader);
-
-            return request;
-        }
-
-        internal static HttpWebRequest GetConnectionDataRequest(TargetUri targetUri)
+        internal static TargetUri GetConnectionDataUri(TargetUri targetUri)
         {
             const string VstsValidationUrlFormat = "{0}://{1}/_apis/connectiondata";
 
-            Debug.Assert(targetUri != null && targetUri.IsAbsoluteUri, "The targetUri parameter is null or invalid");
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
 
             // Create a URL to the connection data end-point, it's deployment level and "always on".
-            string validationUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, VstsValidationUrlFormat, targetUri.Scheme, targetUri.DnsSafeHost);
+            string validationUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, 
+                                                 VstsValidationUrlFormat,
+                                                 targetUri.Scheme,
+                                                 targetUri.DnsSafeHost);
 
-            // Start building the request, only supports GET.
-            HttpWebRequest request = WebRequest.CreateHttp(validationUrl);
-            request.Timeout = Global.RequestTimeout;
-            request.UserAgent = Global.UserAgent;
-            request.MaximumAutomaticRedirections = Global.MaxAutomaticRedirections;
-
-            return request;
+            return new TargetUri(validationUrl, targetUri.ProxyUri?.ToString());
         }
 
-        internal static async Task<Uri> GetIdentityServiceUri(HttpClient client, TargetUri targetUri)
+        internal async Task<TargetUri> GetIdentityServiceUri(TargetUri targetUri)
         {
             const string LocationServiceUrlFormat = "https://{0}/_apis/ServiceDefinitions/LocationService2/951917AC-A960-4999-8464-E3F0AA25B381?api-version=1.0";
 
-            Debug.Assert(client != null, $"The `{nameof(client)}` parameter is null.");
-            Debug.Assert(targetUri != null && targetUri.IsAbsoluteUri, $"The `{nameof(targetUri)}` parameter is null or invalid");
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
 
-            string locationServiceUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, LocationServiceUrlFormat, targetUri.Host);
-            Uri idenitityServiceUri = null;
+            var locationServiceUrl = string.Format(System.Globalization.CultureInfo.InvariantCulture, LocationServiceUrlFormat, targetUri.Host);
+            var requestUri = new TargetUri(locationServiceUrl, targetUri.ProxyUri?.ToString());
 
-            using (HttpResponseMessage response = await client.GetAsync(locationServiceUrl))
+            try
             {
-                if (response.IsSuccessStatusCode)
+                using (var response = await Network.HttpGetAsync(targetUri))
                 {
-                    using (HttpContent content = response.Content)
+                    if (response.IsSuccessStatusCode)
                     {
-                        string responseText = await content.ReadAsStringAsync();
-
-                        Match match;
-                        if ((match = Regex.Match(responseText, @"\""location\""\:\""([^\""]+)\""", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success)
+                        using (HttpContent content = response.Content)
                         {
-                            string identityServiceUrl = match.Groups[1].Value;
-                            idenitityServiceUri = new Uri(identityServiceUrl, UriKind.Absolute);
+                            string responseText = await content.ReadAsStringAsync();
+
+                            Match match;
+                            if ((match = Regex.Match(responseText, @"\""location\""\:\""([^\""]+)\""", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)).Success)
+                            {
+                                string identityServiceUrl = match.Groups[1].Value;
+                                var idenitityServiceUri = new Uri(identityServiceUrl, UriKind.Absolute);
+
+                                return new TargetUri(idenitityServiceUri, targetUri.ProxyUri);
+                            }
                         }
                     }
                 }
             }
+            catch (Exception exception)
+            {
+                Trace.WriteLine($"! error: '{exception.Message}'.");
+                throw new VstsLocationServiceException($"Failed to find Identity Service for `{targetUri}`.", exception);
+            }
 
-            return idenitityServiceUri;
+            return null;
         }
 
         private StringContent GetAccessTokenRequestBody(TargetUri targetUri, Token accessToken, VstsTokenScope tokenScope, TimeSpan? duration = null)
@@ -436,36 +331,18 @@ namespace Microsoft.Alm.Authentication
             return content;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        private static HttpClient CreateHttpClient(TargetUri targetUri)
-        {
-            if (targetUri is null)
-                throw new ArgumentNullException(nameof(targetUri));
-
-            HttpClient httpClient = new HttpClient(targetUri.HttpClientHandler)
-            {
-                Timeout = TimeSpan.FromMilliseconds(Global.RequestTimeout),
-            };
-
-            httpClient.DefaultRequestHeaders.Add("User-Agent", Global.UserAgent);
-
-            return httpClient;
-        }
-
-        private static async Task<Uri> CreatePersonalAccessTokenRequestUri(HttpClient client, TargetUri targetUri, bool requireCompactToken)
+        private async Task<TargetUri> CreatePersonalAccessTokenRequestUri(TargetUri targetUri, bool requireCompactToken)
         {
             const string SessionTokenUrl = "_apis/token/sessiontokens?api-version=1.0";
             const string CompactTokenUrl = SessionTokenUrl + "&tokentype=compact";
 
-            if (client == null)
-                throw new ArgumentNullException(nameof(client));
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
 
-            BaseSecureStore.ValidateTargetUri(targetUri);
+            var idenityServiceUri = await GetIdentityServiceUri(targetUri);
 
-            Uri idenityServiceUri = await GetIdentityServiceUri(client, targetUri);
-
-            if (idenityServiceUri == null)
-                throw new VstsLocationServiceException($"Failed to find Identity Service for {targetUri}");
+            if (idenityServiceUri is null)
+                throw new VstsLocationServiceException($"Failed to find Identity Service for `{targetUri}`.");
 
             string url = idenityServiceUri.ToString();
 
@@ -473,35 +350,9 @@ namespace Microsoft.Alm.Authentication
                 ? CompactTokenUrl
                 : SessionTokenUrl;
 
-            return new Uri(url, UriKind.Absolute);
-        }
+            var requestUri = new Uri(url, UriKind.Absolute);
 
-        private static string GetBase64EncodedCredentials(Credential credentials)
-        {
-            const string UsernamePasswordFormat = "{0}:{1}";
-
-            if (credentials is null)
-                throw new ArgumentNullException(nameof(credentials));
-
-            string credPair = string.Format(UsernamePasswordFormat, credentials.Username, credentials.Password);
-            byte[] credBytes = Encoding.ASCII.GetBytes(credPair);
-            string base64enc = Convert.ToBase64String(credBytes);
-
-            return base64enc;
-        }
-
-        private static string GetBasicAuthorizationHeader(Credential credentials)
-        {
-            const string BasicPrefix = "Basic ";
-
-            if (credentials is null)
-                throw new ArgumentNullException(nameof(credentials));
-
-            // Credentials are packed into the 'Authorization' header as a base64 encoded pair.
-            string base64enc = GetBase64EncodedCredentials(credentials);
-            string basicAuthHeader = BasicPrefix + base64enc;
-
-            return basicAuthHeader;
+            return new TargetUri(requestUri, targetUri.ProxyUri);
         }
     }
 }


### PR DESCRIPTION
Implement and adopt network as a service with `Network` as service, provided by `RuntimeContext`.

- [x] Provide service implementation.
- [x] Implement provider via `RuntimeContext` and `Base` types.
- [x] Update VSTS authentication.
- [x] Update GitHub authentication.
- [x] Update BitBucket authentication.

Depends on #570, #571, #572, #573, #574, #575, #577