### PR TITLE
Correct trace

### DIFF
--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -42,12 +42,14 @@ namespace Microsoft.Alm.Cli
         public const string AssemblyDesciption = "Secure askpass utility for Windows, by Microsoft";
         public const string DefinitionUrlPassphrase = "https://www.visualstudio.com/docs/git/gcm-ssh-passphrase";
 
+        private const string EnvironConfigGitTraceKey = "GIT_TRACE";
+
         private static readonly Regex AskCredentialRegex = new Regex(@"(\S+)\s+for\s+['""]([^'""]+)['""]:\s*", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         private static readonly Regex AskPassphraseRegex = new Regex(@"Enter\s+passphrase\s*for\s*key\s*['""]([^'""]+)['""]\:\s*", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         private static readonly Regex AskPasswordRegex = new Regex(@"(\S+)'s\s+password:\s*", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         private static readonly Regex AskAuthenticityRegex = new Regex(@"^\s*The authenticity of host '([^']+)' can't be established.\s+RSA key fingerprint is ([^\s:]+:[^\.]+).", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
-        internal Program(Microsoft.Alm.Authentication.RuntimeContext context)
+        internal Program(Authentication.RuntimeContext context)
         {
             if (context is null)
                 throw new ArgumentNullException(nameof(context));
@@ -344,6 +346,9 @@ namespace Microsoft.Alm.Cli
                 PrintHelpMessage();
                 return;
             }
+
+            // Enable tracing if "GIT_TRACE" has been enabled in the environment.
+            DetectTraceEnvironmentKey(EnvironConfigGitTraceKey);
 
             PrintArgs(args);
 

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -470,6 +470,9 @@ namespace Microsoft.Alm.Cli
                     return;
                 }
 
+                // Enable tracing if "GCM_TRACE" has been enabled in the environment.
+                DetectTraceEnvironmentKey(EnvironConfigTraceKey);
+
                 PrintArgs(args);
 
                 // List of `arg` => method associations (case-insensitive).

--- a/Microsoft.Alm.Authentication/Git/Trace.cs
+++ b/Microsoft.Alm.Authentication/Git/Trace.cs
@@ -45,8 +45,6 @@ namespace Microsoft.Alm.Authentication.Git
 
     internal class Trace : Base, ITrace, IDisposable
     {
-        public const string EnvironmentVariableKey = "GCM_TRACE";
-
         public Trace(RuntimeContext context)
             : base(context)
         {
@@ -136,31 +134,6 @@ namespace Microsoft.Alm.Authentication.Git
                     catch { /* squelch */ }
                 }
             }
-        }
-
-        internal void EnableDefaultWriter()
-        {
-            try
-            {
-                string traceValue = Environment.GetEnvironmentVariable(EnvironmentVariableKey);
-
-                // If the value is true or a number greater than zero, then trace to standard error.
-                if (Configuration.PaserBoolean(traceValue))
-                {
-                    _writers.Add(Console.Error);
-                }
-                // If the value is a rooted path, then trace to that file and not to the console.
-                else if (Path.IsPathRooted(traceValue))
-                {
-                    // Open or create the log file.
-                    var stream = FileSystem.FileOpen(traceValue, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-
-                    // Create the writer and add it to the list.
-                    var writer = new StreamWriter(stream, Encoding.UTF8, 4096, true);
-                    _writers.Add(writer);
-                }
-            }
-            catch { /* squelch */ }
         }
 
         private void Dispose(bool finalizing)


### PR DESCRIPTION
The 'Microsoft.Alm.Authentication' library ought to not know about the GCM directly, and its knowledge of the "GCM_TRACE" environment variable is a violation of this assertion.

- [x] Remove the knowledge and use of "GCM_TRACE" from the library. In the next commit, the logic will be moved to the application layer.
- [x] Move the logic to enable environment variable based tracing into the application layer.
