### PR TITLE
Adding safe navigation to equality operator

### DIFF
--- a/Microsoft.Alm.Authentication/Git/Installation.cs
+++ b/Microsoft.Alm.Authentication/Git/Installation.cs
@@ -289,8 +289,8 @@ namespace Microsoft.Alm.Authentication.Git
 
         public static bool operator ==(Installation install1, Installation install2)
         {
-            return install1._distribution == install2._distribution
-                && PathComparer.Equals(install1._path, install2._path);
+            return install1?._distribution == install2?._distribution
+                && PathComparer.Equals(install1?._path, install2?._path);
         }
 
         public static bool operator !=(Installation install1, Installation install2)


### PR DESCRIPTION
Since the equality operator is also used when comparing the `Installation` to null, the current implementation that checks for equality of properties will fail when the object is null.
So added the safe navigation since adding a check for null will cause again the same equality operator to be executed