### PR TITLE
Use comparers to compare.

### DIFF
--- a/Microsoft.Alm.Authentication.Test/Git/InstallationTests.cs
+++ b/Microsoft.Alm.Authentication.Test/Git/InstallationTests.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Alm.Authentication.Git.Test
                 KnownDistribution kgd = (KnownDistribution)v;
 
                 var a = list.Where(x => x.Version == kgd);
-                Assert.True(a.All(x => x != a.First() || Installation.PathComparer.Equals(x.Cmd, a.First().Cmd)));
-                Assert.True(a.All(x => x != a.First() || Installation.PathComparer.Equals(x.Config, a.First().Config)));
-                Assert.True(a.All(x => x != a.First() || Installation.PathComparer.Equals(x.Git, a.First().Git)));
-                Assert.True(a.All(x => x != a.First() || Installation.PathComparer.Equals(x.Libexec, a.First().Libexec)));
-                Assert.True(a.All(x => x != a.First() || Installation.PathComparer.Equals(x.Sh, a.First().Sh)));
+                Assert.True(a.All(x => x != a.First() || InstallationComparer.PathComparer.Equals(x.Cmd, a.First().Cmd)));
+                Assert.True(a.All(x => x != a.First() || InstallationComparer.PathComparer.Equals(x.Config, a.First().Config)));
+                Assert.True(a.All(x => x != a.First() || InstallationComparer.PathComparer.Equals(x.Git, a.First().Git)));
+                Assert.True(a.All(x => x != a.First() || InstallationComparer.PathComparer.Equals(x.Libexec, a.First().Libexec)));
+                Assert.True(a.All(x => x != a.First() || InstallationComparer.PathComparer.Equals(x.Sh, a.First().Sh)));
             }
         }
     }

--- a/Microsoft.Alm.Authentication/Git/Installation.cs
+++ b/Microsoft.Alm.Authentication/Git/Installation.cs
@@ -25,15 +25,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 
 namespace Microsoft.Alm.Authentication.Git
 {
     public class Installation : Base, IEquatable<Installation>
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
-        public static readonly StringComparer PathComparer = StringComparer.InvariantCultureIgnoreCase;
+        public static readonly IEqualityComparer<Installation> Comparer = new InstallationComparer();
 
         internal const string GitExeName = @"git.exe";
         internal const string AllVersionCmdPath = @"cmd";
@@ -259,21 +257,16 @@ namespace Microsoft.Alm.Authentication.Git
 
         public override bool Equals(object obj)
         {
-            if (obj is Installation)
-                return this == (Installation)obj;
-
-            return false;
+            return (obj is Installation other
+                    && Equals(other))
+                || base.Equals(obj);
         }
 
         public bool Equals(Installation other)
-        {
-            return this == other;
-        }
+            => Comparer.Equals(this, other);
 
         public override int GetHashCode()
-        {
-            return StringComparer.OrdinalIgnoreCase.GetHashCode(_path);
-        }
+            => Comparer.GetHashCode(this);
 
         public override string ToString()
         {
@@ -287,15 +280,10 @@ namespace Microsoft.Alm.Authentication.Git
                 && FileSystem.FileExists(_git);
         }
 
-        public static bool operator ==(Installation install1, Installation install2)
-        {
-            return install1._distribution == install2._distribution
-                && PathComparer.Equals(install1._path, install2._path);
-        }
+        public static bool operator ==(Installation lhs, Installation rhs)
+            => Comparer.Equals(lhs, rhs);
 
-        public static bool operator !=(Installation install1, Installation install2)
-        {
-            return !(install1 == install2);
-        }
+        public static bool operator !=(Installation lhs, Installation rhs)
+            => !Comparer.Equals(lhs, rhs);
     }
 }

--- a/Microsoft.Alm.Authentication/Git/InstallationComparer.cs
+++ b/Microsoft.Alm.Authentication/Git/InstallationComparer.cs
@@ -1,0 +1,67 @@
+﻿/**** Git Credential Manager for Windows ****
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the """"Software""""), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+**/
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Alm.Authentication.Git
+{
+    /// <summary>
+    /// Defines methods to support the comparison of `<see cref="Installation"/>` for equality.
+    /// </summary>
+    public class InstallationComparer : IEqualityComparer<Installation>
+    {
+        /// <summary>
+        /// Determines whether the specified objects are equal.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if equal; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="lhs">The first `<see cref="Installation"/>` to compare.</param>
+        /// <param name="rhs">The second `<see cref="Installation"/>` to compare.</param>
+        public bool Equals(Installation lhs, Installation rhs)
+        {
+            if (lhs is null && rhs is null)
+                return true;
+            if (lhs is null || rhs is null)
+                return false;
+
+            return lhs.Version == rhs.Version
+                && StringComparer.OrdinalIgnoreCase.Equals(lhs.Path, rhs.Path);
+        }
+
+        /// <summary>
+        /// Returns a hash code for the specified object.
+        /// </summary>
+        /// <param name="value">The `<see cref="Installation"/>` for which a hash code is to be returned.</param>
+        public int GetHashCode(Installation value)
+        {
+            if (value is null)
+                return 0;
+
+            return (((int)value.Version) << 24) 
+                 | (StringComparer.OrdinalIgnoreCase.GetHashCode(value.Path) >> 24);
+        }            
+    }
+}

--- a/Microsoft.Alm.Authentication/Git/InstallationComparer.cs
+++ b/Microsoft.Alm.Authentication/Git/InstallationComparer.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Alm.Authentication.Git
     /// </summary>
     public class InstallationComparer : IEqualityComparer<Installation>
     {
+        public static readonly StringComparer PathComparer = StringComparer.OrdinalIgnoreCase;
+
         /// <summary>
         /// Determines whether the specified objects are equal.
         /// <para/>

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -33,6 +33,7 @@
     <Compile Include="Git\Configuration.cs" />
     <Compile Include="Git\ConfigurationLevel.cs" />
     <Compile Include="Git\Installation.cs" />
+    <Compile Include="Git\InstallationComparer.cs" />
     <Compile Include="Git\KnownDistribution.cs" />
     <Compile Include="Git\Trace.cs" />
     <Compile Include="Git\Where.cs" />


### PR DESCRIPTION
Types ought to be compared or comparisons or equality using comparers. This change introduces an equality comparer for the installation type; and adopts the `InstallationComparer` to perform all equality comparison operation defined by the `Installation` type.