### PR TITLE
Rename fs

### DIFF
--- a/Cli-AskPass/Program.cs
+++ b/Cli-AskPass/Program.cs
@@ -306,12 +306,12 @@ namespace Microsoft.Alm.Cli
             {
                 foreach (var installation in installations)
                 {
-                    if (FileSystem.DirectoryExists(installation.Doc))
+                    if (Storage.DirectoryExists(installation.Doc))
                     {
                         string docPath = Path.Combine(installation.Doc, HelpFileName);
 
                         // if the help file exists, send it to the operating system to display to the user
-                        if (FileSystem.FileExists(docPath))
+                        if (Storage.FileExists(docPath))
                         {
                             _context.Trace.WriteLine($"opening help documentation '{docPath}'.");
 

--- a/Cli-Askpass/Program.cs
+++ b/Cli-Askpass/Program.cs
@@ -306,12 +306,12 @@ namespace Microsoft.Alm.Cli
             {
                 foreach (var installation in installations)
                 {
-                    if (FileSystem.DirectoryExists(installation.Doc))
+                    if (Storage.DirectoryExists(installation.Doc))
                     {
                         string docPath = Path.Combine(installation.Doc, HelpFileName);
 
                         // if the help file exists, send it to the operating system to display to the user
-                        if (FileSystem.FileExists(docPath))
+                        if (Storage.FileExists(docPath))
                         {
                             _context.Trace.WriteLine($"opening help documentation '{docPath}'.");
 

--- a/Cli-CredentialHelper/Installer.cs
+++ b/Cli-CredentialHelper/Installer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Alm.Cli
                     {
                         string path = Path.Combine(drive.RootDirectory.FullName, Cygwin64GitPath);
 
-                        if (Program.FileSystem.DirectoryExists(path))
+                        if (Program.Storage.DirectoryExists(path))
                         {
                             Program.Trace.WriteLine($"cygwin directory found at '{path}'.");
 
@@ -137,7 +137,7 @@ namespace Microsoft.Alm.Cli
 
                         path = Path.Combine(drive.RootDirectory.FullName, Cygwin32GitPath);
 
-                        if (Program.FileSystem.DirectoryExists(path))
+                        if (Program.Storage.DirectoryExists(path))
                         {
                             Program.Trace.WriteLine($"cygwin directory found at '{path}'.");
 
@@ -169,13 +169,13 @@ namespace Microsoft.Alm.Cli
 
                     // Git for Windows checks %HOME% first
                     if ((val1 = vars["HOME"] as string) != null
-                        && Program.FileSystem.DirectoryExists(val1))
+                        && Program.Storage.DirectoryExists(val1))
                     {
                         _userBinPath = val1;
                     }
                     // Git for Windows checks %HOMEDRIVE%%HOMEPATH% second
                     else if ((val1 = vars["HOMEDRIVE"] as string) != null && (val2 = vars["HOMEPATH"] as string) != null
-                        && Program.FileSystem.DirectoryExists(val3 = val1 + val2))
+                        && Program.Storage.DirectoryExists(val3 = val1 + val2))
                     {
                         _userBinPath = val3;
                     }
@@ -215,7 +215,7 @@ namespace Microsoft.Alm.Cli
                 // use the custom installation path if supplied
                 if (!string.IsNullOrEmpty(_customPath))
                 {
-                    if (!Program.FileSystem.DirectoryExists(_customPath))
+                    if (!Program.Storage.DirectoryExists(_customPath))
                     {
                         Program.LogEvent("No Git installation found, unable to continue deployment.", EventLogEntryType.Error);
                         Program.Out.WriteLine();
@@ -288,7 +288,7 @@ namespace Microsoft.Alm.Cli
                         }
 
                         // copy help documents
-                        if (Program.FileSystem.DirectoryExists(installation.Doc)
+                        if (Program.Storage.DirectoryExists(installation.Doc)
                             && CopyFiles(Program.Location, installation.Doc, DocsList, out copiedFiles))
                         {
                             copiedCount += copiedFiles.Count;
@@ -321,9 +321,9 @@ namespace Microsoft.Alm.Cli
                 Program.Out.WriteLine();
                 Program.Out.WriteLine($"Deploying from '{Program.Location}' to '{UserBinPath}'.");
 
-                if (!Program.FileSystem.DirectoryExists(UserBinPath))
+                if (!Program.Storage.DirectoryExists(UserBinPath))
                 {
-                    Program.FileSystem.CreateDirectory(UserBinPath);
+                    Program.Storage.CreateDirectory(UserBinPath);
                 }
 
                 if (CopyFiles(Program.Location, UserBinPath, FileList, out copiedFiles))
@@ -363,7 +363,7 @@ namespace Microsoft.Alm.Cli
                     return;
                 }
 
-                if (CygwinPath != null && Program.FileSystem.DirectoryExists(CygwinPath))
+                if (CygwinPath != null && Program.Storage.DirectoryExists(CygwinPath))
                 {
                     if (CopyFiles(Program.Location, CygwinPath, FileList, out copiedFiles))
                     {
@@ -483,7 +483,7 @@ namespace Microsoft.Alm.Cli
                 // use the custom installation path if supplied
                 if (!string.IsNullOrEmpty(_customPath))
                 {
-                    if (!Program.FileSystem.DirectoryExists(_customPath))
+                    if (!Program.Storage.DirectoryExists(_customPath))
                     {
                         Program.Out.WriteLine();
                         Program.WriteLine($"fatal: custom path does not exist: '{_customPath}'. U_U");
@@ -594,7 +594,7 @@ namespace Microsoft.Alm.Cli
                         }
 
                         // clean help documents
-                        if (Program.FileSystem.DirectoryExists(installation.Doc)
+                        if (Program.Storage.DirectoryExists(installation.Doc)
                             && CleanFiles(installation.Doc, DocsList, out cleanedFiles))
                         {
                             cleanedCount += cleanedFiles.Count;
@@ -621,7 +621,7 @@ namespace Microsoft.Alm.Cli
                     }
                 }
 
-                if (Program.FileSystem.DirectoryExists(UserBinPath))
+                if (Program.Storage.DirectoryExists(UserBinPath))
                 {
                     Program.Out.WriteLine();
                     Program.Out.WriteLine($"Removing from '{UserBinPath}'.");
@@ -661,7 +661,7 @@ namespace Microsoft.Alm.Cli
                     }
                 }
 
-                if (CygwinPath != null && Program.FileSystem.DirectoryExists(CygwinPath))
+                if (CygwinPath != null && Program.Storage.DirectoryExists(CygwinPath))
                 {
                     if (CleanFiles(CygwinPath, FileList, out cleanedFiles))
                     {
@@ -777,7 +777,7 @@ namespace Microsoft.Alm.Cli
         {
             cleanedFiles = new List<string>();
 
-            if (!Program.FileSystem.DirectoryExists(path))
+            if (!Program.Storage.DirectoryExists(path))
             {
                 Program.Trace.WriteLine($"path '{path}' does not exist.");
                 return false;
@@ -791,7 +791,7 @@ namespace Microsoft.Alm.Cli
 
                     Program.Trace.WriteLine($"clean '{target}'.");
 
-                    Program.FileSystem.FileDelete(target);
+                    Program.Storage.FileDelete(target);
 
                     cleanedFiles.Add(file);
                 }
@@ -809,13 +809,13 @@ namespace Microsoft.Alm.Cli
         {
             copiedFiles = new List<string>();
 
-            if (!Program.FileSystem.DirectoryExists(srcPath))
+            if (!Program.Storage.DirectoryExists(srcPath))
             {
                 Program.Trace.WriteLine($"source '{srcPath}' does not exist.");
                 return false;
             }
 
-            if (Program.FileSystem.DirectoryExists(dstPath))
+            if (Program.Storage.DirectoryExists(dstPath))
             {
                 try
                 {
@@ -826,7 +826,7 @@ namespace Microsoft.Alm.Cli
                         string src = Path.Combine(srcPath, file);
                         string dst = Path.Combine(dstPath, file);
 
-                        Program.FileSystem.FileCopy(src, dst, true);
+                        Program.Storage.FileCopy(src, dst, true);
 
                         copiedFiles.Add(file);
                     }
@@ -918,7 +918,7 @@ namespace Microsoft.Alm.Cli
             if (string.IsNullOrEmpty(gitCmdPath) || string.IsNullOrEmpty(command))
                 return false;
 
-            if (!Program.FileSystem.FileExists(gitCmdPath))
+            if (!Program.Storage.FileExists(gitCmdPath))
                 return false;
 
             var options = new ProcessStartInfo()

--- a/Cli-CredentialHelper/Program.cs
+++ b/Cli-CredentialHelper/Program.cs
@@ -368,12 +368,12 @@ namespace Microsoft.Alm.Cli
             {
                 foreach (var installation in installations)
                 {
-                    if (FileSystem.DirectoryExists(installation.Doc))
+                    if (Storage.DirectoryExists(installation.Doc))
                     {
                         string doc = Path.Combine(installation.Doc, HelpFileName);
 
                         // if the help file exists, send it to the operating system to display to the user
-                        if (FileSystem.FileExists(doc))
+                        if (Storage.FileExists(doc))
                         {
                             Trace.WriteLine($"opening help documentation '{doc}'.");
 

--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Alm.Cli
 
                     string gitDirPath = Path.GetDirectoryName(gitConfigPath);
 
-                    if (program.FileSystem.DirectoryExists(gitDirPath))
+                    if (program.Storage.DirectoryExists(gitDirPath))
                     {
                         program.EnableTraceLogging(operationArguments, gitDirPath);
                     }
@@ -295,7 +295,7 @@ namespace Microsoft.Alm.Cli
 
                     string homeDirPath = Path.GetDirectoryName(gitConfigPath);
 
-                    if (program.FileSystem.DirectoryExists(homeDirPath))
+                    if (program.Storage.DirectoryExists(homeDirPath))
                     {
                         program.EnableTraceLogging(operationArguments, homeDirPath);
                     }
@@ -327,7 +327,7 @@ namespace Microsoft.Alm.Cli
                     string moveName = string.Format("{0}{1:000}.log", Program.ConfigPrefix, i);
                     string movePath = Path.Combine(logFilePath, moveName);
 
-                    if (!program.FileSystem.FileExists(movePath))
+                    if (!program.Storage.FileExists(movePath))
                     {
                         logFileInfo.MoveTo(movePath);
                         break;
@@ -337,7 +337,7 @@ namespace Microsoft.Alm.Cli
 
             program.Trace.WriteLine($"trace log destination is '{logFilePath}'.");
 
-            using (var fileStream = program.FileSystem.FileOpen(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            using (var fileStream = program.Storage.FileOpen(logFileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
             {
                 var listener = new StreamWriter(fileStream, Encoding.UTF8);
                 program.Trace.AddListener(listener);

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Alm.Cli
         }
 
         internal IStorage FileSystem
-            => _context.FileSystem;
+            => _context.Storage;
 
         internal TextReader In
         {

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -310,9 +310,6 @@ namespace Microsoft.Alm.Cli
             }
         }
 
-        internal IStorage FileSystem
-            => _context.Storage;
-
         internal TextReader In
         {
             get
@@ -380,6 +377,9 @@ namespace Microsoft.Alm.Cli
             }
         }
 
+        internal IStorage Storage
+            => _context.Storage;
+
         internal Git.ITrace Trace
             => _context.Trace;
 
@@ -427,7 +427,7 @@ namespace Microsoft.Alm.Cli
                 else if (Path.IsPathRooted(traceValue))
                 {
                     // Open or create the log file.
-                    var stream = FileSystem.FileOpen(traceValue, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+                    var stream = Storage.FileOpen(traceValue, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
 
                     // Create the writer and add it to the list.
                     var writer = new StreamWriter(stream, System.Text.Encoding.UTF8, 4096, true);

--- a/Cli-Shared/Program.cs
+++ b/Cli-Shared/Program.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Alm.Cli
             }
         }
 
-        internal IFileSystem FileSystem
+        internal IStorage FileSystem
             => _context.FileSystem;
 
         internal TextReader In

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Alm.Authentication
             get { return _context; }
         }
 
-        protected IFileSystem FileSystem
+        protected IStorage FileSystem
             => _context.FileSystem;
 
         protected INetwork Network

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Alm.Authentication
             get { return _context; }
         }
 
-        protected IStorage FileSystem
-            => _context.Storage;
-
         protected INetwork Network
             => _context.Network;
+
+        protected IStorage Storage
+            => _context.Storage;
 
         protected Git.ITrace Trace
             => _context.Trace;

--- a/Microsoft.Alm.Authentication/Base.cs
+++ b/Microsoft.Alm.Authentication/Base.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Alm.Authentication
         }
 
         protected IStorage FileSystem
-            => _context.FileSystem;
+            => _context.Storage;
 
         protected INetwork Network
             => _context.Network;

--- a/Microsoft.Alm.Authentication/Git/Configuration.cs
+++ b/Microsoft.Alm.Authentication/Git/Configuration.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Alm.Authentication.Git
                 throw new ArgumentNullException(nameof(context));
             if (directory is null)
                 throw new ArgumentNullException(nameof(directory));
-            if (!context.FileSystem.DirectoryExists(directory))
+            if (!context.Storage.DirectoryExists(directory))
             {
                 var inner = new DirectoryNotFoundException(directory);
                 throw new ArgumentException(inner.Message, nameof(directory), inner);
@@ -423,7 +423,7 @@ namespace Microsoft.Alm.Authentication.Git
 
                                 includePath = Path.GetFullPath(includePath);
 
-                                using (FileStream includeFile = context.FileSystem.FileOpen(includePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                                using (FileStream includeFile = context.Storage.FileOpen(includePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                                 using (var includeReader = new StreamReader(includeFile))
                                 {
                                     await ParseGitConfig(context, includeReader, destination);

--- a/Microsoft.Alm.Authentication/Git/Configuration.cs
+++ b/Microsoft.Alm.Authentication/Git/Configuration.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Alm.Authentication.Git
             if ((level & ~ConfigurationLevel.All) != 0)
                 throw new ArgumentOutOfRangeException(nameof(level));
 
-            if (!FileSystem.FileExists(configPath))
+            if (!Storage.FileExists(configPath))
             {
                 var inner = new FileNotFoundException(configPath);
                 throw new ArgumentException(inner.Message, nameof(configPath), inner);
@@ -469,10 +469,10 @@ namespace Microsoft.Alm.Authentication.Git
 
             if (!_values.ContainsKey(level))
                 return;
-            if (!FileSystem.FileExists(configPath))
+            if (!Storage.FileExists(configPath))
                 return;
 
-            using (FileStream stream = FileSystem.FileOpen(configPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (FileStream stream = Storage.FileOpen(configPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             using (var reader = new StreamReader(stream))
             {
                 await ParseGitConfig(Context, reader, _values[level]);

--- a/Microsoft.Alm.Authentication/Git/Installation.cs
+++ b/Microsoft.Alm.Authentication/Git/Installation.cs
@@ -275,9 +275,9 @@ namespace Microsoft.Alm.Authentication.Git
 
         internal bool IsValid()
         {
-            return FileSystem.DirectoryExists(_path)
-                && FileSystem.DirectoryExists(_libexec)
-                && FileSystem.FileExists(_git);
+            return Storage.DirectoryExists(_path)
+                && Storage.DirectoryExists(_libexec)
+                && Storage.FileExists(_git);
         }
 
         public static bool operator ==(Installation lhs, Installation rhs)

--- a/Microsoft.Alm.Authentication/Git/Where.cs
+++ b/Microsoft.Alm.Authentication/Git/Where.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Alm.Authentication.Git
                             continue;
 
                         string value = string.Format("{0}\\{1}{2}", paths[i], name, exts[j]);
-                        if (FileSystem.FileExists(value))
+                        if (Storage.FileExists(value))
                         {
                             value = value.Replace("\\\\", "\\");
                             path = value;
@@ -356,7 +356,7 @@ namespace Microsoft.Alm.Authentication.Git
                 path = Environment.ExpandEnvironmentVariables(path);
 
                 // If the path is good, return it.
-                if (FileSystem.DirectoryExists(path))
+                if (Storage.DirectoryExists(path))
                     return path;
             }
 
@@ -369,7 +369,7 @@ namespace Microsoft.Alm.Authentication.Git
             {
                 path = homeDrive + homePath;
 
-                if (FileSystem.DirectoryExists(path))
+                if (Storage.DirectoryExists(path))
                     return path;
             }
 
@@ -387,7 +387,7 @@ namespace Microsoft.Alm.Authentication.Git
             var globalPath = Path.Combine(home, GlobalConfigFileName);
 
             // If the path is valid, return it to the user.
-            if (FileSystem.FileExists(globalPath))
+            if (Storage.FileExists(globalPath))
             {
                 path = globalPath;
                 return true;
@@ -441,7 +441,7 @@ namespace Microsoft.Alm.Authentication.Git
                         if (result is DirectoryInfo)
                         {
                             var localPath = Path.Combine(result.FullName, LocalConfigFileName);
-                            if (FileSystem.FileExists(localPath))
+                            if (Storage.FileExists(localPath))
                             {
                                 path = localPath;
                                 return true;
@@ -482,10 +482,10 @@ namespace Microsoft.Alm.Authentication.Git
                                     localPath = Path.Combine(localPath, content);
                                 }
 
-                                if (FileSystem.DirectoryExists(localPath))
+                                if (Storage.DirectoryExists(localPath))
                                 {
                                     localPath = Path.Combine(localPath, LocalConfigFileName);
-                                    if (FileSystem.FileExists(localPath))
+                                    if (Storage.FileExists(localPath))
                                     {
                                         path = localPath;
                                         return true;
@@ -515,7 +515,7 @@ namespace Microsoft.Alm.Authentication.Git
 
             var portableConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), PortableConfigFolder, PortableConfigFileName);
 
-            if (FileSystem.FileExists(portableConfigPath))
+            if (Storage.FileExists(portableConfigPath))
             {
                 path = portableConfigPath;
             }
@@ -525,7 +525,7 @@ namespace Microsoft.Alm.Authentication.Git
 
         public bool GitSystemConfig(Installation installation, out string path)
         {
-            if (installation != null && FileSystem.FileExists(installation.Config))
+            if (installation != null && Storage.FileExists(installation.Config))
             {
                 path = installation.Path;
                 return true;
@@ -536,7 +536,7 @@ namespace Microsoft.Alm.Authentication.Git
                 List<Installation> installations;
 
                 if (FindGitInstallations(out installations)
-                    && FileSystem.FileExists(installations[0].Config))
+                    && Storage.FileExists(installations[0].Config))
                 {
                     path = installations[0].Config;
                     return true;
@@ -558,11 +558,11 @@ namespace Microsoft.Alm.Authentication.Git
             // The XDG config home is defined by an environment variable.
             xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
 
-            if (FileSystem.DirectoryExists(xdgConfigHome))
+            if (Storage.DirectoryExists(xdgConfigHome))
             {
                 xdgConfigPath = Path.Combine(xdgConfigHome, XdgConfigFolder, XdgConfigFileName);
 
-                if (FileSystem.FileExists(xdgConfigPath))
+                if (Storage.FileExists(xdgConfigPath))
                 {
                     path = xdgConfigPath;
                     return true;
@@ -574,7 +574,7 @@ namespace Microsoft.Alm.Authentication.Git
 
             xdgConfigPath = Path.Combine(xdgConfigHome, XdgConfigFolder, XdgConfigFileName);
 
-            if (FileSystem.FileExists(xdgConfigPath))
+            if (Storage.FileExists(xdgConfigPath))
             {
                 path = xdgConfigPath;
                 return true;

--- a/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Microsoft.Alm.Authentication.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Base.cs" />
-    <Compile Include="FileSystem.cs" />
+    <Compile Include="Storage.cs" />
     <Compile Include="Git\Configuration.cs" />
     <Compile Include="Git\ConfigurationLevel.cs" />
     <Compile Include="Git\Installation.cs" />

--- a/Microsoft.Alm.Authentication/RuntimeContext.cs
+++ b/Microsoft.Alm.Authentication/RuntimeContext.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Alm.Authentication
         public static readonly RuntimeContext Default;
 
         public RuntimeContext(
-            IFileSystem fileSystem,
+            IStorage fileSystem,
             INetwork network,
             Git.ITrace trace,
             Git.IWhere where)
@@ -65,21 +65,21 @@ namespace Microsoft.Alm.Authentication
             Volatile.Write(ref _count, 0);
 
             Default = new RuntimeContext();
-            Default._fileSystem = new FileSystem(Default);
+            Default._fileSystem = new Storage(Default);
             Default._network = new Network(Default);
             Default._trace = new Git.Trace(Default);
             Default._where = new Git.Where(Default);
         }
 
         private static int _count;
-        private IFileSystem _fileSystem;
+        private IStorage _fileSystem;
         private readonly int _id;
         private INetwork _network;
         private readonly object _syncpoint;
         private Git.ITrace _trace;
         private Git.IWhere _where;
 
-        public IFileSystem FileSystem
+        public IStorage FileSystem
         {
             get { return _fileSystem; }
         }

--- a/Microsoft.Alm.Authentication/RuntimeContext.cs
+++ b/Microsoft.Alm.Authentication/RuntimeContext.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Alm.Authentication
         public static readonly RuntimeContext Default;
 
         public RuntimeContext(
-            IStorage fileSystem,
+            IStorage storage,
             INetwork network,
             Git.ITrace trace,
             Git.IWhere where)
             : this()
         {
-            if (fileSystem is null)
-                throw new ArgumentNullException(nameof(fileSystem));
+            if (storage is null)
+                throw new ArgumentNullException(nameof(storage));
             if (network is null)
                 throw new ArgumentNullException(nameof(network));
             if (trace is null)
@@ -48,8 +48,8 @@ namespace Microsoft.Alm.Authentication
             if (where is null)
                 throw new ArgumentNullException(nameof(where));
 
-            _fileSystem = fileSystem;
             _network = network;
+            _storage = storage;
             _trace = trace;
             _where = where;
         }
@@ -65,24 +65,19 @@ namespace Microsoft.Alm.Authentication
             Volatile.Write(ref _count, 0);
 
             Default = new RuntimeContext();
-            Default._fileSystem = new Storage(Default);
             Default._network = new Network(Default);
+            Default._storage = new Storage(Default);
             Default._trace = new Git.Trace(Default);
             Default._where = new Git.Where(Default);
         }
 
         private static int _count;
-        private IStorage _fileSystem;
         private readonly int _id;
         private INetwork _network;
+        private IStorage _storage;
         private readonly object _syncpoint;
         private Git.ITrace _trace;
         private Git.IWhere _where;
-
-        public IStorage FileSystem
-        {
-            get { return _fileSystem; }
-        }
 
         public int Id
         {
@@ -92,6 +87,11 @@ namespace Microsoft.Alm.Authentication
         public INetwork Network
         {
             get { return _network; }
+        }
+
+        public IStorage Storage
+        {
+            get { return _storage; }
         }
 
         public Git.ITrace Trace

--- a/Microsoft.Alm.Authentication/Storage.cs
+++ b/Microsoft.Alm.Authentication/Storage.cs
@@ -28,7 +28,7 @@ using System.IO;
 
 namespace Microsoft.Alm.Authentication
 {
-    public interface IFileSystem
+    public interface IStorage
     {
         /// <summary>
         /// Creates all directories and subdirectories in the specified path.
@@ -180,9 +180,9 @@ namespace Microsoft.Alm.Authentication
         string GetParent(string path);
     }
 
-    internal class FileSystem : Base, IFileSystem
+    internal class Storage : Base, IStorage
     {
-        public FileSystem(RuntimeContext context)
+        public Storage(RuntimeContext context)
             : base(context)
         { }
 

--- a/Microsoft.Vsts.Authentication/BaseVstsAuthentication.cs
+++ b/Microsoft.Vsts.Authentication/BaseVstsAuthentication.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Alm.Authentication
                 {
                     // Just open the file from disk, the tenant identities are not secret and
                     // therefore safely left as unencrypted plain text.
-                    using (var stream = context.FileSystem.FileOpen(path, FileMode.OpenOrCreate, FileAccess.Read, FileShare.Read))
+                    using (var stream = context.Storage.FileOpen(path, FileMode.OpenOrCreate, FileAccess.Read, FileShare.Read))
                     using (var inflate = new GZipStream(stream, CompressionMode.Decompress))
                     using (var reader = new StreamReader(inflate, encoding))
                     {
@@ -505,9 +505,9 @@ namespace Microsoft.Alm.Authentication
             path = Path.Combine(path, CachePathDirectory);
 
             // Create the directory if necessary
-            if (!context.FileSystem.DirectoryExists(path))
+            if (!context.Storage.DirectoryExists(path))
             {
-                context.FileSystem.CreateDirectory(path);
+                context.Storage.CreateDirectory(path);
             }
 
             // Append the file name to the path
@@ -547,7 +547,7 @@ namespace Microsoft.Alm.Authentication
                 {
                     // Just open the file from disk, the tenant identities are not secret and
                     // therefore safely left as unencrypted plain text.
-                    using (var stream = context.FileSystem.FileOpen(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+                    using (var stream = context.Storage.FileOpen(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
                     using (var deflate = new GZipStream(stream, CompressionMode.Compress))
                     using (var writer = new StreamWriter(deflate, encoding))
                     {

--- a/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
+++ b/Microsoft.Vsts.Authentication/VstsAdalTokenCache.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Alm.Authentication
                 string directoryPath = Path.Combine(localAppDataPath, AdalCachePaths[i][0]);
                 string filePath = Path.Combine(directoryPath, AdalCachePaths[i][1]);
 
-                if (context.FileSystem.FileExists(filePath))
+                if (context.Storage.FileExists(filePath))
                 {
                     _cacheFilePath = filePath;
                     break;
@@ -78,7 +78,7 @@ namespace Microsoft.Alm.Authentication
         {
             lock (_syncpoint)
             {
-                if (_context.FileSystem.FileExists(_cacheFilePath) && HasStateChanged)
+                if (_context.Storage.FileExists(_cacheFilePath) && HasStateChanged)
                 {
                     try
                     {
@@ -86,7 +86,7 @@ namespace Microsoft.Alm.Authentication
 
                         byte[] data = ProtectedData.Protect(state, null, DataProtectionScope.CurrentUser);
 
-                        _context.FileSystem.FileWriteAllBytes(_cacheFilePath, data);
+                        _context.Storage.FileWriteAllBytes(_cacheFilePath, data);
 
                         HasStateChanged = false;
                     }
@@ -102,11 +102,11 @@ namespace Microsoft.Alm.Authentication
         {
             lock (_syncpoint)
             {
-                if (_context.FileSystem.FileExists(_cacheFilePath))
+                if (_context.Storage.FileExists(_cacheFilePath))
                 {
                     try
                     {
-                        byte[] data = _context.FileSystem.FileReadAllBytes(_cacheFilePath);
+                        byte[] data = _context.Storage.FileReadAllBytes(_cacheFilePath);
 
                         byte[] state = ProtectedData.Unprotect(data, null, DataProtectionScope.CurrentUser);
 


### PR DESCRIPTION
Since a file system is a very specific kind of storage, and there's no reason any of 'Microsoft.Alm.Authentication' API should care about the kind of storage, using "file system" could be a misnomer. Instead using "storage" as the type name makes more sense.

- [x] Rename `FileSystem` to `Storage`.
- [x] Rename `IFileSystem` to `IStorage`, and update consumers.
- [x] Update `RuntimeContext` and consumers.
- [x] Update `Base` and consumers.
- [x] Update `Program` and consumers.