### PR TITLE
Changed request uri to authority url

### DIFF
--- a/GitHub.Authentication/Authority.cs
+++ b/GitHub.Authentication/Authority.cs
@@ -88,8 +88,11 @@ namespace GitHub.Authentication
             options.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(GitHubApiAcceptsHeaderValue));
             options.Headers.Add(GitHubOptHeader, authenticationCode);
 
+            // Create the authority Uri.
+            var requestUri = new TargetUri(_authorityUrl, targetUri.ProxyUri?.ToString());
+
             using (HttpContent content = GetTokenJsonContent(targetUri, scope))
-            using (var response = await Network.HttpPostAsync(targetUri, content, options))
+            using (var response = await Network.HttpPostAsync(requestUri, content, options))
             {
                 Trace.WriteLine($"server responded with {response.StatusCode}.");
 


### PR DESCRIPTION
During refactoring the endpoint called by the authorization request for Github was set to url of github.com while is should have been the authority url
This was discussed in a series of [comments](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/issues/435#issuecomment-373555383) on #435 
Not sure it's the best way to fix this issue, but it's how validation of credentials is done