### PR TITLE
Escaping @ in username when creating resposity uri

### DIFF
--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -86,6 +86,43 @@ namespace Microsoft.Alm.Cli.Test
         }
 
         [Fact]
+        public void EmailAsUserName()
+        {
+            var input = new InputArg
+            {
+                Host = "example.visualstudio.com",
+                Password = "ḭncorrect",
+                Path = "path",
+                Protocol = Uri.UriSchemeHttps,
+                Username = "userName@domain.com"
+            };
+
+            OperationArguments cut;
+            using (var memory = new MemoryStream())
+            using (var writer = new StreamWriter(memory))
+            {
+                writer.Write(input.ToString());
+                writer.Flush();
+
+                memory.Seek(0, SeekOrigin.Begin);
+
+                cut = new OperationArguments(RuntimeContext.Default, memory);
+            }
+
+            Assert.Equal(input.Protocol, cut.QueryProtocol, StringComparer.Ordinal);
+            Assert.Equal(input.Host, cut.QueryHost, StringComparer.Ordinal);
+            Assert.Equal(input.Path, cut.QueryPath, StringComparer.Ordinal);
+            Assert.Equal(input.Username, cut.Username, StringComparer.Ordinal);
+            Assert.Equal(input.Password, cut.Password, StringComparer.Ordinal);
+
+            Assert.Equal("https://userName@domain.com@example.visualstudio.com/path", cut.TargetUri.ToString(), StringComparer.Ordinal);
+
+            var expected = input.ToString();
+            var actual = cut.ToString();
+            Assert.Equal(expected, actual, StringComparer.Ordinal);
+        }
+
+        [Fact]
         public void CreateTargetUriGitHubSimple()
         {
             var input = new InputArg()

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -513,7 +513,10 @@ namespace Microsoft.Alm.Cli
             // Username.
             if (!string.IsNullOrWhiteSpace(_username))
             {
-                buffer.Append(_username)
+                // Only URI reserved character that can appear in a git username is the @ sign
+                // when the username is an email address, so just manually escaping it
+                var escapedUsername = _username.Replace("@", "%40"); 
+                buffer.Append(escapedUsername)
                       .Append('@');
             }
 


### PR DESCRIPTION
Username in git can also be an email address, but the `@` sign is a reserved character in URI, so it needs to be escaped to `%40` before creating a URI (or the Uri constructur will fail).
Since all other reserved characters cannot appear in git usernames, I just escaped the `@` sign
Fixes #587 