### PR TITLE
Escaping reserved characters in username when creating resposity uri (alternative implementation)

### DIFF
--- a/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
+++ b/Cli-CredentialHelper.Test/OperationArgumentsTests.cs
@@ -86,6 +86,43 @@ namespace Microsoft.Alm.Cli.Test
         }
 
         [Fact]
+        public void EmailAsUserName()
+        {
+            var input = new InputArg
+            {
+                Host = "example.visualstudio.com",
+                Password = "ḭncorrect",
+                Path = "path",
+                Protocol = Uri.UriSchemeHttps,
+                Username = "userName@domain.com"
+            };
+
+            OperationArguments cut;
+            using (var memory = new MemoryStream())
+            using (var writer = new StreamWriter(memory))
+            {
+                writer.Write(input.ToString());
+                writer.Flush();
+
+                memory.Seek(0, SeekOrigin.Begin);
+
+                cut = new OperationArguments(RuntimeContext.Default, memory);
+            }
+
+            Assert.Equal(input.Protocol, cut.QueryProtocol, StringComparer.Ordinal);
+            Assert.Equal(input.Host, cut.QueryHost, StringComparer.Ordinal);
+            Assert.Equal(input.Path, cut.QueryPath, StringComparer.Ordinal);
+            Assert.Equal(input.Username, cut.Username, StringComparer.Ordinal);
+            Assert.Equal(input.Password, cut.Password, StringComparer.Ordinal);
+
+            Assert.Equal("https://userName@domain.com@example.visualstudio.com/path", cut.TargetUri.ToString(), StringComparer.Ordinal);
+
+            var expected = input.ToString();
+            var actual = cut.ToString();
+            Assert.Equal(expected, actual, StringComparer.Ordinal);
+        }
+
+        [Fact]
         public void CreateTargetUriGitHubSimple()
         {
             var input = new InputArg()

--- a/Cli-Shared/OperationArguments.cs
+++ b/Cli-Shared/OperationArguments.cs
@@ -513,7 +513,11 @@ namespace Microsoft.Alm.Cli
             // Username.
             if (!string.IsNullOrWhiteSpace(_username))
             {
-                buffer.Append(_username)
+                var username = NeedsToBeEscaped(_username)
+                    ? Uri.EscapeDataString(_username)
+                    : _username;
+
+                buffer.Append(username)
                       .Append('@');
             }
 
@@ -531,6 +535,36 @@ namespace Microsoft.Alm.Cli
 
             // Create the target URI object.
             _targetUri = new TargetUri(queryUrl, proxyUrl);
+        }
+
+        private static bool NeedsToBeEscaped(string value)
+        {
+            for (int i = 0; i < value.Length; i += 1)
+            {
+                switch (value[i])
+                {
+                    case ':':
+                    case '/':
+                    case '?':
+                    case '#':
+                    case '[':
+                    case ']':
+                    case '@':
+                    case '!':
+                    case '$':
+                    case '&':
+                    case '\'':
+                    case '(':
+                    case ')':
+                    case '*':
+                    case '+':
+                    case ',':
+                    case ';':
+                    case '=':
+                        return true;
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Since username needs to be part of URIs, they cannot contain reserved characters, so they need to be escaped.
This an alternative implementation to #593 which takes care about all reserved characters, not just the `@` sign
Fixes #587 