### PR TITLE
authentication: check 64-bit path before use

### DIFF
--- a/Microsoft.Alm.Authentication/Git/Where.cs
+++ b/Microsoft.Alm.Authentication/Git/Where.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Alm.Authentication.Git
             {
                 candidates.Add(new Installation(Context, reg64HklmPath, KnownDistribution.GitForWindows64v2));
             }
-            if (!string.IsNullOrEmpty(programFiles32Path))
+            if (!string.IsNullOrEmpty(programFiles64Path))
             {
                 candidates.Add(new Installation(Context, programFiles64Path, KnownDistribution.GitForWindows64v2));
             }


### PR DESCRIPTION
Code incorrectly checked 32-bit path before using 64-bit path.

Fixes https://github.com/git-for-windows/git/issues/1601