### PR TITLE
Allow account selection from connected windows accounts

### DIFF
--- a/Installer/Installer.proj
+++ b/Installer/Installer.proj
@@ -92,9 +92,6 @@
     <ZipContents Include="$(IntermediateOutputPath)\Microsoft.IdentityModel.Clients.ActiveDirectory.dll">
       <InProject>false</InProject>
     </ZipContents>
-    <ZipContents Include="$(IntermediateOutputPath)\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll">
-      <InProject>false</InProject>
-    </ZipContents>
     <ZipContents Include="$(IntermediateOutputPath)\Microsoft.Vsts.Authentication.dll">
       <InProject>false</InProject>
     </ZipContents>

--- a/Installer/Setup.iss
+++ b/Installer/Setup.iss
@@ -90,7 +90,6 @@ Name: "Git4Win"; Description: {#Git4WinName}; ExtraDiskSpaceRequired: {#Git4WinS
 Source: "{#binDir}\git-credential-manager.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#binDir}\Microsoft.Alm.Authentication.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#binDir}\Microsoft.IdentityModel.Clients.ActiveDirectory.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#binDir}\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#binDir}\Microsoft.Vsts.Authentication.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#binDir}\GitHub.Authentication.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#binDir}\Bitbucket.Authentication.dll"; DestDir: "{app}"; Flags: ignoreversion

--- a/Microsoft.Vsts.Authentication/AzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/AzureAuthority.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Alm.Authentication
                 AuthenticationResult authResult = await authCtx.AcquireTokenAsync(resource,
                                                                                   clientId,
                                                                                   redirectUri,
-                                                                                  new PlatformParameters(PromptBehavior.Always),
+                                                                                  new PlatformParameters(PromptBehavior.SelectAccount),
                                                                                   UserIdentifier.AnyUser,
                                                                                   queryParameters);
                 Guid tenantId;

--- a/Microsoft.Vsts.Authentication/Microsoft.Vsts.Authentication.csproj
+++ b/Microsoft.Vsts.Authentication/Microsoft.Vsts.Authentication.csproj
@@ -19,11 +19,11 @@
     <SigningTarget>$(OutputPath)\$(AssemblyName).dll</SigningTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.9.1126, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.3.10102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.3\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.13.9.1126, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.19.3.10102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.3\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Microsoft.Vsts.Authentication/packages.config
+++ b/Microsoft.Vsts.Authentication/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net451" developmentDependency="true" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.3" targetFramework="net451" />
   <package id="Microsoft.Net.Compilers" version="2.4.0" targetFramework="net451" developmentDependency="true" />
   <package id="NuGet.CommandLine" version="4.4.1" targetFramework="net451" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This fixes #611 by using the latest ADAL library and its "SelectAccount" option.

Starting with ADAL 3.17, that is the recommended approach instead of using `PromptBehavior.Always` so that a user can choose an existing account connected to windows:
https://azure.microsoft.com/en-us/blog/adal-net-3-17-0-released-2/

