### PR TITLE
installer: update Git for Windows

### DIFF
--- a/Installer/Setup.iss
+++ b/Installer/Setup.iss
@@ -31,7 +31,7 @@
 #define MyAppPublisherURL "https://www.microsoft.com"
 #define MyAppURL "https://github.com/Microsoft/Git-Credential-Manager-for-Windows"
 #define MyAppExeName "git-credential-manager.exe"
-#define Git4WinVer "2.150"
+#define Git4WinVer "2.17.0"
 #define Git4WinVerLong = "v" + str(Git4WinVer) + ".windows.1"
 #define Git4WinName "Git for Windows " + str(Git4WinVer)
 #define Git4WinFile "Git-" + str(Git4WinVer) + "-64-bit.exe"


### PR DESCRIPTION
Update the automatically downloaded Git for Windows version.

  - 2.15.0 -> 2.17.0

Resolves #614