### PR TITLE
Copy symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 [Oo]utput/
 [Pp]ackages/
 [Rr]elease/
+[Ss]ymbols/
 [Tt]est[Rr]esult/
 
 *.suo

--- a/Microsoft.Vsts.Authentication/Microsoft.Vsts.Authentication.csproj
+++ b/Microsoft.Vsts.Authentication/Microsoft.Vsts.Authentication.csproj
@@ -93,8 +93,7 @@
     <!-- Only download a new copy of nuget.exe if we don't have a copy available -->
     <PropertyGroup>
       <NugetPath>nuget.exe</NugetPath>
-      <IsSigned>
-      </IsSigned>
+      <IsSigned></IsSigned>
       <IsSigned Condition=" '$(SignType)' == '' Or '$(SignType)' == '*Undefined*' ">-unsigned</IsSigned>
       <NugetWorkDir>$(OutputPath.TrimEnd('\'))</NugetWorkDir>
     </PropertyGroup>

--- a/build.targets
+++ b/build.targets
@@ -15,4 +15,16 @@
     <Delete Files="$(OutputPath)\*.*;$(IntermediateOutputPath)\*.*" />
     <RemoveDir Directories="$(IntermediateOutputPath);$(OutputPath)"/>
   </Target>
+  <Target Name="CopySymbols" Condition=" '$(TestProjectType)' == '' Or '$(TestProjectType)' == '*Undefined*' " AfterTargets="CopyFilesToOutputDirectory">
+    <PropertyGroup>
+      <SymbolDir>$(SolutionDir)\Symbols</SymbolDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <SymbolFiles Include="$(OutputPath)\*.pdb">
+        <InProject>false</InProject>
+      </SymbolFiles>
+    </ItemGroup>
+    <MakeDir Condition="!Exists('$(SymbolDir)')" Directories="$(SymbolDir)" /> 
+    <Copy SourceFiles="@(SymbolFiles)" DestinationFolder="$(SymbolDir)" />
+  </Target>
 </Project>

--- a/test.targets
+++ b/test.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)build.targets" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
 </Project>


### PR DESCRIPTION
Copy symbols into the .\Symbols folder for all non-Test projects. This will make symbol indexing and publishing easier.

Resolves #628