### PR TITLE
Support azure

### DIFF
--- a/Bitbucket.Authentication/Authentication.cs
+++ b/Bitbucket.Authentication/Authentication.cs
@@ -115,11 +115,11 @@ namespace Atlassian.Bitbucket.Authentication
 
             // if we deleted per user then we should try and delete the host level credentials too if
             // they match the username
-            if (targetUri.TargetUriContainsUsername)
+            if (targetUri.ContainsUserInfo)
             {
                 var hostTargetUri = new TargetUri(targetUri.ToString(false, true, true));
                 var hostCredentials = await GetCredentials(hostTargetUri);
-                var encodedUsername = Uri.EscapeDataString(targetUri.TargetUriUsername);
+                var encodedUsername = Uri.EscapeDataString(targetUri.UserInfo);
                 if (encodedUsername != username)
                 {
                     Trace.WriteLine($"username {username} != targetUri userInfo {encodedUsername}");
@@ -152,7 +152,7 @@ namespace Atlassian.Bitbucket.Authentication
             if (targetUri is null)
                 throw new ArgumentNullException(nameof(targetUri));
 
-            if (string.IsNullOrWhiteSpace(username) || targetUri.TargetUriContainsUsername)
+            if (string.IsNullOrWhiteSpace(username) || targetUri.ContainsUserInfo)
             {
                 return await GetCredentials(targetUri);
             }
@@ -223,7 +223,7 @@ namespace Atlassian.Bitbucket.Authentication
             await SetCredentials(targetUri, credentials, null);
 
             // `Store()` will not call with a username Url.
-            if (targetUri.TargetUriContainsUsername)
+            if (targetUri.ContainsUserInfo)
                 return false;
 
             // See if there is a matching personal refresh token.
@@ -256,7 +256,7 @@ namespace Atlassian.Bitbucket.Authentication
             Trace.WriteLine($"{credentials.Username} at {targetUri.QueryUri.AbsoluteUri}");
 
             // If the Url doesn't contain a username then save with an explicit username.
-            if (!targetUri.TargetUriContainsUsername && (!string.IsNullOrWhiteSpace(username)
+            if (!targetUri.ContainsUserInfo && (!string.IsNullOrWhiteSpace(username)
                 || !string.IsNullOrWhiteSpace(credentials.Username)))
             {
 
@@ -332,7 +332,7 @@ namespace Atlassian.Bitbucket.Authentication
         /// <returns>a valid instance of <see cref="Credential"/> or null</returns>
         public async Task<Credential> InteractiveLogon(TargetUri targetUri, string username)
         {
-            if (string.IsNullOrWhiteSpace(username) || targetUri.TargetUriContainsUsername)
+            if (string.IsNullOrWhiteSpace(username) || targetUri.ContainsUserInfo)
             {
                 return await InteractiveLogon(targetUri);
             }
@@ -411,7 +411,7 @@ namespace Atlassian.Bitbucket.Authentication
 
             var realUsername = GetRealUsername(result.RemoteUsername, username);
 
-            if (!targetUri.TargetUriContainsUsername)
+            if (!targetUri.ContainsUserInfo)
             {
                 // No user info in Uri so personalize the credentials.
                 credentials = new Credential(realUsername, credentials.Password);
@@ -439,7 +439,7 @@ namespace Atlassian.Bitbucket.Authentication
         {
             Credential credentials = (Credential)result.Token;
 
-            if (!targetUri.TargetUriContainsUsername)
+            if (!targetUri.ContainsUserInfo)
             {
                 // no user info in uri so personalize the credentials
                 credentials = new Credential(username, result.RefreshToken.Value);
@@ -461,7 +461,7 @@ namespace Atlassian.Bitbucket.Authentication
                 throw new ArgumentNullException(nameof(credentials));
 
             TargetUri userSpecificTargetUri;
-            if (targetUri.TargetUriContainsUsername)
+            if (targetUri.ContainsUserInfo)
             {
                 userSpecificTargetUri = targetUri;
             }

--- a/Microsoft.Alm.Authentication.Test/Git/WhereTests.cs
+++ b/Microsoft.Alm.Authentication.Test/Git/WhereTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Alm.Authentication.Git.Test
                 var data = new List<object[]>()
                 {
                     new object[] { "cmd" },
-                    new object[] { "notepad" },
                     new object[] { "calc" },
                     new object[] { "powershell" },
                     new object[] { "git" },

--- a/Microsoft.Alm.Authentication.Test/TargetUriTests.cs
+++ b/Microsoft.Alm.Authentication.Test/TargetUriTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Alm.Authentication.Test
             Assert.Equal(queryUri.IsDefaultPort, targetUri.IsDefaultPort);
             Assert.Equal(queryUri.Port, targetUri.Port);
             Assert.Equal(queryUri.Scheme, targetUri.Scheme);
-            Assert.Equal(queryUri.UserInfo, targetUri.TargetUriUsername);
+            Assert.Equal(queryUri.UserInfo, targetUri.UserInfo);
 
             queryUri = queryUrl is null ? null : new Uri(queryUrl);
             proxyUri = proxyUrl is null ? null : new Uri(proxyUrl);
@@ -63,7 +63,7 @@ namespace Microsoft.Alm.Authentication.Test
             Assert.Equal(uri.Port, targetUri.Port);
             Assert.Equal(uri.Scheme, targetUri.Scheme);
 
-            Assert.Equal(uri.UserInfo, targetUri.TargetUriUsername);
+            Assert.Equal(uri.UserInfo, targetUri.UserInfo);
 
             Assert.Equal(uri, targetUri.QueryUri);
             Assert.Equal(proxyUri, targetUri.ProxyUri);
@@ -78,7 +78,7 @@ namespace Microsoft.Alm.Authentication.Test
             Assert.Equal(uri.Port, targetUri.Port);
             Assert.Equal(uri.Scheme, targetUri.Scheme);
 
-            Assert.Equal(uri.UserInfo, targetUri.TargetUriUsername);
+            Assert.Equal(uri.UserInfo, targetUri.UserInfo);
 
             Assert.Equal(queryUri, targetUri.QueryUri);
             Assert.Equal(uri, targetUri.QueryUri);

--- a/Microsoft.Alm.Authentication/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/TargetUri.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Alm.Authentication
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1057:StringUriOverloadsCallSystemUriOverloads")]
         public TargetUri(string targetUrl)
-            : this(targetUrl,  null)
+            : this(targetUrl, null)
         { }
 
         private readonly Uri _proxyUri;
@@ -90,6 +90,15 @@ namespace Microsoft.Alm.Authentication
         public string AbsolutePath
         {
             get { return QueryUri.AbsolutePath; }
+        }
+
+
+        /// <summary>
+        /// Returns `<see langword="true"/>` if `<see cref="ActualUri"/>` contains `<see cref="Uri.UserInfo"/>`; otherwise `<see langword="false"/>`.
+        /// </summary>
+        public bool ContainsUserInfo
+        {
+            get { return QueryUri.AbsoluteUri.IndexOf('@') >= 0; }
         }
 
         /// <summary>
@@ -155,7 +164,7 @@ namespace Microsoft.Alm.Authentication
         /// Gets the `<see cref="Uri.UserInfo"/>` from `<see cref="ActualUri"/>`.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
-        public string TargetUriUsername { get { return QueryUri.UserInfo; } }
+        public string UserInfo { get { return QueryUri.UserInfo; } }
 
         /// <summary>
         /// Returns a version of this `<see cref="TargetUri"/>` that contains the specified username.
@@ -167,7 +176,7 @@ namespace Microsoft.Alm.Authentication
         public TargetUri GetPerUserTargetUri(string username)
         {
             // belt and braces, don't add a username if the URI already contains one.
-            if (string.IsNullOrWhiteSpace(username) || TargetUriContainsUsername)
+            if (string.IsNullOrWhiteSpace(username) || ContainsUserInfo)
             {
                 return this;
             }
@@ -200,11 +209,6 @@ namespace Microsoft.Alm.Authentication
 
             return QueryUri.IsBaseOf(targetUri);
         }
-
-        /// <summary>
-        /// Returns `<see langword="true"/>` if `<see cref="ActualUri"/>` contains `<see cref="Uri.UserInfo"/>`; otherwise `<see langword="false"/>`.
-        /// </summary>
-        public bool TargetUriContainsUsername { get { return QueryUri.AbsoluteUri.IndexOf('@') >= 0; } }
 
         /// <summary>
         /// Gets a canonical string representation for the `<see cref="QueryUri"/>`.

--- a/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Alm.Authentication
 {
     internal class VstsAzureAuthority : AzureAuthority, IVstsAuthority
     {
+        public const string AzureBaseUrlHost = "azure.com";
         public const string VstsBaseUrlHost = "visualstudio.com";
 
         public VstsAzureAuthority(RuntimeContext context, string authorityHostUrl)
@@ -256,7 +257,9 @@ namespace Microsoft.Alm.Authentication
 
             string requestUrl = targetUri.ToString(false, true, false);
 
-            if (targetUri.TargetUriContainsUsername)
+            // Handle the Azure userinfo -> path conversion.AzureBaseUrlHost
+            if (targetUri.Host.EndsWith(AzureBaseUrlHost, StringComparison.OrdinalIgnoreCase)
+                && targetUri.TargetUriContainsUsername)
             {
                 string escapedUserInfo = Uri.EscapeUriString(targetUri.TargetUriUsername);
 
@@ -280,7 +283,9 @@ namespace Microsoft.Alm.Authentication
 
             string tenantUrl = targetUri.ToString(false, true, false);
 
-            if (targetUri.TargetUriContainsUsername)
+            // Handle Azure userinfo -> path conversion.
+            if (targetUri.Host.EndsWith(AzureBaseUrlHost)
+                && targetUri.TargetUriContainsUsername)
             {
                 string escapedUserInfo = Uri.EscapeUriString(targetUri.TargetUriUsername);
                 tenantUrl = tenantUrl + escapedUserInfo + "/";

--- a/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
+++ b/Microsoft.Vsts.Authentication/VstsAzureAuthority.cs
@@ -259,9 +259,9 @@ namespace Microsoft.Alm.Authentication
 
             // Handle the Azure userinfo -> path conversion.AzureBaseUrlHost
             if (targetUri.Host.EndsWith(AzureBaseUrlHost, StringComparison.OrdinalIgnoreCase)
-                && targetUri.TargetUriContainsUsername)
+                && targetUri.ContainsUserInfo)
             {
-                string escapedUserInfo = Uri.EscapeUriString(targetUri.TargetUriUsername);
+                string escapedUserInfo = Uri.EscapeUriString(targetUri.UserInfo);
 
                 requestUrl = requestUrl + escapedUserInfo + "/";
             }
@@ -285,9 +285,9 @@ namespace Microsoft.Alm.Authentication
 
             // Handle Azure userinfo -> path conversion.
             if (targetUri.Host.EndsWith(AzureBaseUrlHost)
-                && targetUri.TargetUriContainsUsername)
+                && targetUri.ContainsUserInfo)
             {
-                string escapedUserInfo = Uri.EscapeUriString(targetUri.TargetUriUsername);
+                string escapedUserInfo = Uri.EscapeUriString(targetUri.UserInfo);
                 tenantUrl = tenantUrl + escapedUserInfo + "/";
             }
 
@@ -346,9 +346,9 @@ namespace Microsoft.Alm.Authentication
                                                  port: true,
                                                  path: false);
 
-            if (targetUri.TargetUriContainsUsername)
+            if (targetUri.ContainsUserInfo)
             {
-                string escapedUserInfo = Uri.EscapeUriString(targetUri.TargetUriUsername);
+                string escapedUserInfo = Uri.EscapeUriString(targetUri.UserInfo);
                 tokenUrl = tokenUrl + escapedUserInfo + "/";
             }
 


### PR DESCRIPTION
Azure supports a URL format whereas the user-information (when only a username is present) is identical to the first path segment, This enables the GCM to have better handling of validation, PAT acquisition, etc so use it.