### PR TITLE
Fix VSTS Authority Detection

### DIFF
--- a/Cli-Shared/Functions/Common.cs
+++ b/Cli-Shared/Functions/Common.cs
@@ -130,21 +130,27 @@ namespace Microsoft.Alm.Cli
                 case AuthorityType.AzureDirectory:
                     program.Trace.WriteLine($"authority for '{operationArguments.TargetUri}' is Azure Directory.");
 
-                    Guid tenantId = Guid.Empty;
-
-                    // Get the identity of the tenant.
-                    var result = await BaseVstsAuthentication.DetectAuthority(program.Context, operationArguments.TargetUri);
-
-                    if (result.HasValue)
+                    if (authority is null)
                     {
-                        tenantId = result.Value;
+                        Guid tenantId = Guid.Empty;
+
+                        // Get the identity of the tenant.
+                        var result = await BaseVstsAuthentication.DetectAuthority(program.Context, operationArguments.TargetUri);
+
+                        if (result.HasValue)
+                        {
+                            tenantId = result.Value;
+                        }
+
+                        // Create the authority object.
+                        authority = new VstsAadAuthentication(program.Context,
+                                                              tenantId,
+                                                              operationArguments.VstsTokenScope,
+                                                              new SecretStore(program.Context, secretsNamespace, VstsAadAuthentication.UriNameConversion));
                     }
 
                     // Return the allocated authority or a generic AAD backed VSTS authentication object.
-                    return authority ?? new VstsAadAuthentication(program.Context,
-                                                                  tenantId,
-                                                                  operationArguments.VstsTokenScope,
-                                                                  new SecretStore(program.Context, secretsNamespace, VstsAadAuthentication.UriNameConversion));
+                    return authority;
 
                 case AuthorityType.Basic:
                     // Enforce basic authentication only.

--- a/Microsoft.Alm.Authentication/Network.cs
+++ b/Microsoft.Alm.Authentication/Network.cs
@@ -273,7 +273,6 @@ namespace Microsoft.Alm.Authentication
 
     internal class Network : Base, INetwork
     {
-        private const string BearerPrefix = "Bearer ";
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")]
         private static readonly AuthenticationHeaderValue[] NullResult = new AuthenticationHeaderValue[0];
 
@@ -455,7 +454,7 @@ namespace Microsoft.Alm.Authentication
                                         break;
 
                                     default:
-                                        Trace.WriteLine("! unsupported token type, not appeding an authentication header to the request.");
+                                        Trace.WriteLine("! unsupported token type, not appending an authentication header to the request.");
                                         break;
                                 }
                             }


### PR DESCRIPTION
When code is repeated often, it's likely because it should have been in a common, utility method.

  - Create `GetTargetUrl` method to transform `TargetUri` values into Azure happy `string` values.
  - Create `IsVstsUrl` method to test for "visualstudio.com" and "azure.com" matches.

Correctly detect the VSTS authority type.

  - Use "HEAD" HTTP/S requests, not "GET".
  - Expect a "HTTP401" response, not "HTTP200".
  - Handle lists of resource-tenant-identities.
    - Find the first non-common tentant-identity, but fallback to common if non-common aren't found.

In the case when the VSTS authroity is already known and allocated, skip running the detection logic a second time.