### PR TITLE
github: conditionally append OTP header

### DIFF
--- a/GitHub.Authentication/Authority.cs
+++ b/GitHub.Authentication/Authority.cs
@@ -86,7 +86,11 @@ namespace GitHub.Authentication
             };
 
             options.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(GitHubApiAcceptsHeaderValue));
-            options.Headers.Add(GitHubOptHeader, authenticationCode);
+
+            if (!string.IsNullOrWhiteSpace(authenticationCode))
+            {
+                options.Headers.Add(GitHubOptHeader, authenticationCode);
+            }
 
             // Create the authority Uri.
             var requestUri = new TargetUri(_authorityUrl, targetUri.ProxyUri?.ToString());


### PR DESCRIPTION
Only append the "X-GitHub-OTP" header if there's a value to append with it. Including the header without a value appears cause github.com to emit 2FA SMS messages.

Related to [comment by @shiftkey](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/issues/642#issuecomment-392033052). Still need validation.

Resolves #642 

/CC @shiftkey 