### PR TITLE
github: conditionally append OTP header

### DIFF
--- a/GitHub.Authentication/Src/Authority.cs
+++ b/GitHub.Authentication/Src/Authority.cs
@@ -86,7 +86,11 @@ namespace GitHub.Authentication
             };
 
             options.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(GitHubApiAcceptsHeaderValue));
-            options.Headers.Add(GitHubOptHeader, authenticationCode);
+
+            if (!string.IsNullOrWhiteSpace(authenticationCode))
+            {
+                options.Headers.Add(GitHubOptHeader, authenticationCode);
+            }
 
             // Create the authority Uri.
             var requestUri = targetUri.CreateWith(_authorityUrl);


### PR DESCRIPTION
Only append the "X-GitHub-OTP" header if there's a value to append with it. Including the header without a value appears cause github.com to emit 2FA SMS messages.

Pick of #643 to master.