### PR TITLE
bitbucket: do not reject valid requests

### DIFF
--- a/Bitbucket.Authentication/Src/AuthenticationResult.cs
+++ b/Bitbucket.Authentication/Src/AuthenticationResult.cs
@@ -93,9 +93,12 @@ namespace Atlassian.Bitbucket.Authentication
         /// <summary>
         /// Flag indicating if the results is a success
         /// </summary>
-        public bool IsSuccess { get { return Type.Equals(AuthenticationResultType.Success); } }
+        public bool IsSuccess
+        {
+            get { return Type.Equals(AuthenticationResultType.Success); }
+        }
 
-        public static implicit operator Boolean(AuthenticationResult result)
+        public static implicit operator bool(AuthenticationResult result)
         {
             return result.Type == AuthenticationResultType.Success;
         }
@@ -116,9 +119,9 @@ namespace Atlassian.Bitbucket.Authentication
     /// </summary>
     public enum AuthenticationResultType
     {
+        None,
         Success,
         Failure,
         TwoFactor,
-        None,
     }
 }

--- a/Bitbucket.Authentication/Src/Authority.cs
+++ b/Bitbucket.Authentication/Src/Authority.cs
@@ -69,7 +69,7 @@ namespace Atlassian.Bitbucket.Authentication
                 throw new ArgumentNullException(nameof(targetUri));
             if (credentials is null)
                 throw new ArgumentNullException(nameof(credentials));
-            if (resultType != AuthenticationResultType.Failure && resultType != AuthenticationResultType.Success && resultType != AuthenticationResultType.TwoFactor)
+            if (resultType < AuthenticationResultType.None || resultType > AuthenticationResultType.TwoFactor)
                 throw new ArgumentOutOfRangeException(nameof(resultType));
             if (scope is null)
                 throw new ArgumentNullException(nameof(scope));
@@ -78,7 +78,7 @@ namespace Atlassian.Bitbucket.Authentication
             {
                 // A previous attempt to acquire a token failed in a way that suggests the user has
                 // Bitbucket 2FA turned on. so attempt to run the OAuth dance...
-                OAuth.OAuthAuthenticator oauth = new OAuth.OAuthAuthenticator(Context);
+                var oauth = new OAuth.OAuthAuthenticator(Context);
                 try
                 {
                     var result = await oauth.GetAuthAsync(targetUri, scope, CancellationToken.None);


### PR DESCRIPTION
`AuthenticationResultType.None` is a valid result type, do not reject requests which contain a result of none.

  - Minor code clean up.

Resolves #651

/CC @mminns for review