### PR TITLE
bitbucket: Fix interactive login

### DIFF
--- a/Bitbucket.Authentication.Test/AuthorityTest.cs
+++ b/Bitbucket.Authentication.Test/AuthorityTest.cs
@@ -1,0 +1,35 @@
+﻿using Atlassian.Bitbucket.Authentication;
+using GitHub.Authentication;
+using Microsoft.Alm.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Bitbucket.Authentication.Test
+{
+    public class AuthorityTest
+    {
+        [Fact]
+        public async void VerifyAcquireTokenAcceptsValidAuthenticationResultTypes()
+        {
+            var context = RuntimeContext.Default;
+            var authority = new Authority(context);
+            var targetUri = new TargetUri("https://bitbucket.org");
+            var credentials = new Credential("a", "b");
+            var resultType = AuthenticationResultType.None;
+            var tokenScope = Atlassian.Bitbucket.Authentication.TokenScope.None;
+
+            var values = Enum.GetValues(typeof(AuthenticationResultType)).Cast<AuthenticationResultType>();
+            values.ToList().ForEach(async _ =>
+            {
+                var token = await authority.AcquireToken(targetUri, credentials, resultType, tokenScope);
+
+                Assert.NotNull(token);
+
+            });
+        }
+    }
+}

--- a/Bitbucket.Authentication.Test/Bitbucket.Authentication.Test.csproj
+++ b/Bitbucket.Authentication.Test/Bitbucket.Authentication.Test.csproj
@@ -14,15 +14,27 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <NuGetPackageImportStamp />
   </PropertyGroup>
   <Import Project="..\test.props" />
   <PropertyGroup>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
@@ -37,11 +49,16 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuthorityTest.cs" />
     <Compile Include="BitbucketAuthTests.cs" />
     <Compile Include="AuthenticationTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GitHub.Authentication\GitHub.Authentication.csproj">
+      <Project>{CF306116-BBF0-4CC7-AFCE-A506AC4752CB}</Project>
+      <Name>GitHub.Authentication</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Bitbucket.Authentication\Bitbucket.Authentication.csproj">
       <Project>{ee663736-5bad-4ca6-a4f8-99978925ad8a}</Project>
       <Name>Bitbucket.Authentication</Name>

--- a/Bitbucket.Authentication.Test/packages.config
+++ b/Bitbucket.Authentication.Test/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.2.1" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.8.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Moq" version="4.8.2" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net462" />
   <package id="xunit" version="2.3.1" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.analyzers" version="0.8.0" targetFramework="net462" />

--- a/Bitbucket.Authentication/Authentication.cs
+++ b/Bitbucket.Authentication/Authentication.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Atlassian.Bitbucket.Authentication.BasicAuth;
 using Microsoft.Alm.Authentication;
 
 namespace Atlassian.Bitbucket.Authentication
@@ -53,7 +54,8 @@ namespace Atlassian.Bitbucket.Authentication
             RuntimeContext context,
             ICredentialStore personalAccessTokenStore,
             AcquireCredentialsDelegate acquireCredentialsCallback,
-            AcquireAuthenticationOAuthDelegate acquireAuthenticationOAuthCallback)
+            AcquireAuthenticationOAuthDelegate acquireAuthenticationOAuthCallback,
+            IAuthority authority = null)
             : base(context)
         {
             if (personalAccessTokenStore == null)
@@ -61,7 +63,7 @@ namespace Atlassian.Bitbucket.Authentication
 
             PersonalAccessTokenStore = personalAccessTokenStore;
 
-            BitbucketAuthority = new Authority(context);
+            BitbucketAuthority = authority ??  new Authority(context);
             TokenScope = TokenScope.SnippetWrite | TokenScope.RepositoryWrite;
 
             AcquireCredentialsCallback = acquireCredentialsCallback;

--- a/Bitbucket.Authentication/AuthenticationResult.cs
+++ b/Bitbucket.Authentication/AuthenticationResult.cs
@@ -93,9 +93,12 @@ namespace Atlassian.Bitbucket.Authentication
         /// <summary>
         /// Flag indicating if the results is a success
         /// </summary>
-        public bool IsSuccess { get { return Type.Equals(AuthenticationResultType.Success); } }
+        public bool IsSuccess
+        {
+            get { return Type.Equals(AuthenticationResultType.Success); }
+        }
 
-        public static implicit operator Boolean(AuthenticationResult result)
+        public static implicit operator bool(AuthenticationResult result)
         {
             return result.Type == AuthenticationResultType.Success;
         }
@@ -116,9 +119,9 @@ namespace Atlassian.Bitbucket.Authentication
     /// </summary>
     public enum AuthenticationResultType
     {
+        None,
         Success,
         Failure,
         TwoFactor,
-        None,
     }
 }

--- a/Bitbucket.Authentication/Authority.cs
+++ b/Bitbucket.Authentication/Authority.cs
@@ -69,7 +69,7 @@ namespace Atlassian.Bitbucket.Authentication
                 throw new ArgumentNullException(nameof(targetUri));
             if (credentials is null)
                 throw new ArgumentNullException(nameof(credentials));
-            if (resultType != AuthenticationResultType.Failure && resultType != AuthenticationResultType.Success && resultType != AuthenticationResultType.TwoFactor)
+            if (resultType < AuthenticationResultType.None || resultType > AuthenticationResultType.TwoFactor)
                 throw new ArgumentOutOfRangeException(nameof(resultType));
             if (scope is null)
                 throw new ArgumentNullException(nameof(scope));
@@ -78,7 +78,7 @@ namespace Atlassian.Bitbucket.Authentication
             {
                 // A previous attempt to acquire a token failed in a way that suggests the user has
                 // Bitbucket 2FA turned on. so attempt to run the OAuth dance...
-                OAuth.OAuthAuthenticator oauth = new OAuth.OAuthAuthenticator(Context);
+                var oauth = new OAuth.OAuthAuthenticator(Context);
                 try
                 {
                     var result = await oauth.GetAuthAsync(targetUri, scope, CancellationToken.None);

--- a/Bitbucket.Authentication/BasicAuth/BasicAuthAuthenticator.cs
+++ b/Bitbucket.Authentication/BasicAuth/BasicAuthAuthenticator.cs
@@ -7,7 +7,10 @@ using Microsoft.Alm.Authentication.Git;
 
 namespace Atlassian.Bitbucket.Authentication.BasicAuth
 {
-    internal class BasicAuthAuthenticator : Base
+    /// <summary>
+    ///     Provides the functionality for validating basic auth credentials with Bitbucket.org
+    /// </summary>
+    public class BasicAuthAuthenticator : Base
     {
         public BasicAuthAuthenticator(RuntimeContext context)
             : base(context)

--- a/Bitbucket.Authentication/Bitbucket.Authentication.csproj
+++ b/Bitbucket.Authentication/Bitbucket.Authentication.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>Bitbucket.Authentication</AssemblyName>
-    <NuGetPackageImportStamp/>
+    <NuGetPackageImportStamp />
     <OutputType>Library</OutputType>
     <ProjectGuid>{EE663736-5BAD-4CA6-A4F8-99978925AD8A}</ProjectGuid>
     <ProjectName>Bitbucket.Authentication</ProjectName>

--- a/Bitbucket.Authentication/IAuthority.cs
+++ b/Bitbucket.Authentication/IAuthority.cs
@@ -31,7 +31,7 @@ namespace Atlassian.Bitbucket.Authentication
     /// <summary>
     /// Defines the interactions with the Authority capable of providing and validating Bitbucket credentials.
     /// </summary>
-    internal interface IAuthority
+    public interface IAuthority
     {
         /// <summary>
         /// Use the provided credentials, username and password, to request an access token from the Authority.

--- a/Bitbucket.Authentication/Properties/AssemblyInfo.cs
+++ b/Bitbucket.Authentication/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers by using the '*'
 // as shown below: [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
 
 [assembly: InternalsVisibleTo("Bitbucket.Authentication.Test")]

--- a/Bitbucket.Authentication/Properties/AssemblyInfo.cs
+++ b/Bitbucket.Authentication/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following set of attributes.
@@ -27,3 +28,5 @@ using System.Runtime.InteropServices;
 // as shown below: [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
+
+[assembly: InternalsVisibleTo("Bitbucket.Authentication.Test")]


### PR DESCRIPTION
  - `AuthenticationResultType.None` is a valid result type, do not reject requests which contain a result of none.
  - Add tests ensuring this doesn't break again.
  - Minor code clean up.

Resolves #651

Pick of #652 and #653

/CC @mminns for review.