### PR TITLE
Better NTLM Detection

### DIFF
--- a/Microsoft.Alm.Authentication/Src/WwwAuthenticateHelper.cs
+++ b/Microsoft.Alm.Authentication/Src/WwwAuthenticateHelper.cs
@@ -57,9 +57,19 @@ namespace Microsoft.Alm.Authentication
                         Flags = NetworkRequestOptionFlags.UseProxy,
                         Timeout = TimeSpan.FromMilliseconds(Global.RequestTimeout),
                     };
+                    var requestUri = targetUri;
+
+                    // Since we're more likely to get an accurate response from the actual-URL,
+                    // use it if available, otherwise use `targetUri` as supplied; but only if
+                    // the actual-URL differs from the query-URL.
+                    if (targetUri.ActualUri != null
+                        && targetUri.ActualUri != targetUri.QueryUri)
+                    {
+                        requestUri = targetUri.CreateWith(queryUri: targetUri.ActualUri);
+                    }
 
                     // Make the request and return the response.
-                    using (var result = await context.Network.HttpHeadAsync(targetUri, options))
+                    using (var result = await context.Network.HttpHeadAsync(requestUri, options))
                     {
                         return result.Headers?.WwwAuthenticate?.ToArray()
                             ?? NullResult;

--- a/Shared/Cli/OperationArguments.cs
+++ b/Shared/Cli/OperationArguments.cs
@@ -532,6 +532,13 @@ namespace Microsoft.Alm.Cli
                         {
                             password = pair[1];
                         }
+                        // This is a GCM only addition to the Git-Credential specification. The intent is to
+                        // facilitate debugging without the need for running git.exe to debug git-remote-http(s)
+                        // command line values.
+                        else if ("_url".Equals(pair[0], StringComparison.Ordinal))
+                        {
+                            _gitRemoteHttpCommandLine = pair[1];
+                        }
                     }
                 }
             }
@@ -725,10 +732,26 @@ namespace Microsoft.Alm.Cli
             {
                 string[] parts = _gitRemoteHttpCommandLine.Split(' ');
 
-                if (parts.Length == 3 && Uri.TryCreate(parts[2], UriKind.Absolute, out Uri uri))
+                switch(parts.Length)
                 {
-                    actualUrl = uri.ToString();
-                }
+                    case 1:
+                        {
+                            if (Uri.TryCreate(parts[0], UriKind.Absolute, out Uri uri))
+                            {
+                                actualUrl = uri.ToString();
+                            }
+                        }
+                        break;
+
+                    case 3:
+                        {
+                            if (Uri.TryCreate(parts[2], UriKind.Absolute, out Uri uri))
+                            {
+                                actualUrl = uri.ToString();
+                            }
+                        }
+                        break;
+                }                
             }
 
             // Create the target URI object.


### PR DESCRIPTION
With the ability to probe the `git-remote-http(s)` process for its command options, the GCM gained the ability to know the full and complete URL of the remote repository. This additional information is useful when probing a basic Git provider (like TFS) as well.

  - [x] Add ability to provide the Actual URL when debugging to avoid having to always initiate the `git-credential-manager.exe` process via `git.exe`.
  - [x] Use `TargetUri.ActualUri`, when available, to query hosts for their `www-authenticate` header list.