### PR TITLE
Clean warnings

### DIFF
--- a/Bitbucket.Authentication/Test/AuthorityTest.cs
+++ b/Bitbucket.Authentication/Test/AuthorityTest.cs
@@ -13,7 +13,7 @@ namespace Bitbucket.Authentication.Test
     public class AuthorityTest
     {
         [Fact]
-        public async void VerifyAcquireTokenAcceptsValidAuthenticationResultTypes()
+        public void VerifyAcquireTokenAcceptsValidAuthenticationResultTypes()
         {
             var context = RuntimeContext.Default;
             var authority = new Authority(context);

--- a/Microsoft.Alm.Authentication/Src/Git/Utilities.cs
+++ b/Microsoft.Alm.Authentication/Src/Git/Utilities.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Alm.Authentication.Git
             return false;
         }
 
-        internal IEnumerable<Win32.ProcessEntry32> EnumerateParentProcesses()
+        internal static IEnumerable<Win32.ProcessEntry32> EnumerateParentProcesses()
         {
             var processTable = new Dictionary<uint, uint>();
             var processEntries = new Dictionary<uint, Win32.ProcessEntry32>();

--- a/Microsoft.Alm.Authentication/Src/TargetUri.cs
+++ b/Microsoft.Alm.Authentication/Src/TargetUri.cs
@@ -230,6 +230,7 @@ namespace Microsoft.Alm.Authentication
         /// The new URL used for all queries if not `<see langword="null"/>`; otherwise is unchanged from `<seealso cref="ActualUri"/>`.
         /// </param>
         /// <exception cref="ArgumentException">When all arguments are `<see langword="null"/>`.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public TargetUri CreateWith(string queryUrl = null, string proxyUrl = null, string actualUrl = null)
         {
             if (queryUrl is null && proxyUrl is null && actualUrl is null)
@@ -255,6 +256,7 @@ namespace Microsoft.Alm.Authentication
         /// The new `<seealso cref="Uri"/>` used for all queries if not `<see langword="null"/>`; otherwise is unchanged from `<seealso cref="ActualUri"/>`.
         /// </param>
         /// <exception cref="ArgumentException">When all arguments are `<see langword="null"/>`.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public TargetUri CreateWith(Uri queryUri = null, Uri proxyUri = null, Uri actualUri = null)
         {
             if (queryUri is null && proxyUri is null && actualUri is null)

--- a/VisualStudioTeamServices.Authentication/Src/Authority.cs
+++ b/VisualStudioTeamServices.Authentication/Src/Authority.cs
@@ -90,7 +90,7 @@ namespace VisualStudioTeamServices.Authentication
         /// </summary>
         public string AuthorityHostUrl { get; protected set; }
 
-        public async Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token authorization, TokenScope tokenScope, bool requireCompactToken, TimeSpan? tokenDuration = null)
+        public async Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token authorization, TokenScope tokenScope, bool requireCompactToken, TimeSpan? tokenDuration)
         {
             if (targetUri is null)
                 throw new ArgumentNullException(nameof(targetUri));
@@ -142,6 +142,9 @@ namespace VisualStudioTeamServices.Authentication
 
             return null;
         }
+
+        public Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token authorization, TokenScope tokenScope, bool requireCompactToken)
+            => GeneratePersonalAccessToken(targetUri, authorization, tokenScope, requireCompactToken, null);
 
         /// <summary>
         /// Returns the properly formatted URL for the Azure authority given a tenant identity.

--- a/VisualStudioTeamServices.Authentication/Src/IAuthority.cs
+++ b/VisualStudioTeamServices.Authentication/Src/IAuthority.cs
@@ -45,7 +45,18 @@ namespace VisualStudioTeamServices.Authentication
         /// <para/>
         /// The authority granting the token decides the actual lifetime of any token granted, regardless of the duration requested.
         /// </param>
-        Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token accessToken, TokenScope tokenScope, bool requireCompactToken, TimeSpan? tokenDuration = null);
+        Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token accessToken, TokenScope tokenScope, bool requireCompactToken, TimeSpan? tokenDuration);
+
+        /// <summary>
+        /// Generates a personal access token for use with Visual Studio Team Services.
+        /// <para/>
+        /// Returns the acquired `<seealso cref="Token"/>` if successful; otherwise `<see langword="null"/>`;
+        /// </summary>
+        /// <param name="targetUri">The uniform resource indicator of the resource access tokens are being requested for.</param>
+        /// <param name="accessToken">Access token granted by the identity authority (Azure).</param>
+        /// <param name="tokenScope">The requested access scopes to be granted to the token.</param>
+        /// <param name="requireCompactToken">`<see langword="true"/>` if requesting a compact format token; otherwise `<see langword="false"/>`.</param>
+        Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token accessToken, TokenScope tokenScope, bool requireCompactToken);
 
         /// <summary>
         /// Acquires a `<seealso cref="Token"/>` from the authority via an interactive user logon prompt.
@@ -57,7 +68,7 @@ namespace VisualStudioTeamServices.Authentication
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="queryParameters">optional value, appended as-is to the query string in the HTTP authentication request to the authority.</param>
-        Task<Token> InteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri, string queryParameters = null);
+        Task<Token> InteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri, string queryParameters);
 
         /// <summary>
         /// Acquires a `<see cref="Token"/>` from the authority via an non-interactive user logon.

--- a/VisualStudioTeamServices.Authentication/Test/AuthorityFake.cs
+++ b/VisualStudioTeamServices.Authentication/Test/AuthorityFake.cs
@@ -63,6 +63,18 @@ namespace VisualStudioTeamServices.Authentication.Test
         }
 
         /// <summary>
+        /// Generates a personal access token for use with Visual Studio Team Services.
+        /// <para/>
+        /// Returns the acquired token if successful; otherwise <see langword="null"/>;
+        /// </summary>
+        /// <param name="targetUri">The uniform resource indicator of the resource access tokens are being requested for.</param>
+        /// <param name="accessToken">Access token granted by the identity authority (Azure).</param>
+        /// <param name="tokenScope">The requested access scopes to be granted to the token.</param>
+        /// <param name="requireCompactToken">`<see langword="true"/>` if requesting a compact format token; otherwise `<see langword="false"/>`.</param>
+        public Task<Token> GeneratePersonalAccessToken(TargetUri targetUri, Token accessToken, TokenScope tokenScope, bool requireCompactToken)
+            => GeneratePersonalAccessToken(targetUri, accessToken, tokenScope, requireCompactToken, null);
+
+        /// <summary>
         /// Acquires a <see cref="Token"/> from the authority via an interactive user logon prompt.
         /// <para/>
         /// Returns a `<see cref="Token"/>` is successful; otherwise <see langword="null"/>.
@@ -72,7 +84,7 @@ namespace VisualStudioTeamServices.Authentication.Test
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="queryParameters">optional value, appended as-is to the query string in the HTTP authentication request to the authority.</param>
-        public async Task<Token> InteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri, string queryParameters = null)
+        public async Task<Token> InteractiveAcquireToken(TargetUri targetUri, string clientId, string resource, Uri redirectUri, string queryParameters)
         {
             Assert.Equal(ExpectedQueryParameters, queryParameters);
 

--- a/analysisRules.ruleset
+++ b/analysisRules.ruleset
@@ -32,6 +32,7 @@
     <Rule Id="CA2201" Action="None" />
     <Rule Id="CA2202" Action="None" />
     <Rule Id="CA2204" Action="None" />
+    <Rule Id="CA2205" Action="None" />
     <Rule Id="CA2208" Action="None" />
     <Rule Id="CA2210" Action="None" />
     <Rule Id="CA2225" Action="None" />


### PR DESCRIPTION
Refactor the `Where.FindApp()` method to reduce complexity.
  - [x] Break the method logic into five seperate parts.
  - [x] Use local functions to avoid polluting the `Where` type with single use functions.

Clean analyzer warnings.
  - [x] Make `Git.Utilities.EnumerateParentProcesses` static.
  - [x] Supress "DefaultParametersShouldNotBeUsed" warnings on `TargetUri`.
  - [x] Remove unnecissary `async` keyword on Bitbucket test method.
  - [x] Avoid having a public signature with a default value parameter by add ing a `GeneratePersonalAccessToken` overload without `tokenDuration` parameter, and removing default value on origin method signature.
  - [x] Disable CA2205 warning about duplicating NetFx methods via P/Invoke.
