### PR TITLE
docs: replace references to deprecated Setup.exe

### DIFF
--- a/Docs/Development.md
+++ b/Docs/Development.md
@@ -50,9 +50,9 @@ This is when standard input will be consumed by the GCM.
 * `Program.QueryCredentials` method is where the "action" happens.
 * `OperationArguments` class is where the GCM consumes standard input and keeps internal state.
 
-## Installer (setup.exe)
+## Installer
 
-Changes to the installer (setup.exe) requires [Inno Setup Compiler 5.5.9](http://www.jrsoftware.org/isinfo.php) or later to compile.
+Changes to the installer (`GCMW-{version}.exe`) requires [Inno Setup Compiler 5.5.9](http://www.jrsoftware.org/isinfo.php) or later to compile.
 Additionally, the [IDP plugin for Inno Setup](https://mitrichsoftware.wordpress.com/inno-setup-tools/inno-download-plugin/) is also required.
 
 The setup compiler pulls content from the "Deploy/" folder, therefore a completed Debug or Release build needs to have been completed prior to running the setup compiler.

--- a/Docs/Faq.md
+++ b/Docs/Faq.md
@@ -50,7 +50,7 @@ Support for Mac OS and Linux are handled by [Microsoft Git Credential Manager fo
 
 ## Q: Why is my distribution/version of Git not supported? Why is Git for Windows favored?
 
-The Credential Manager deployment helpers (`install.cmd` and `Setup.exe`) are focused on support for [Git for Windows](https://github.com/git-for-windows) because Git for Windows conforms to the expected/normal behavior of software on Windows.
+The Credential Manager deployment helpers (`install.cmd` and `GCMW-{version}.exe`) are focused on support for [Git for Windows](https://github.com/git-for-windows) because Git for Windows conforms to the expected/normal behavior of software on Windows.
 It is easy to detect, has predictable installation location, etc. This makes supporting it easier and more reliable.
 
 That said, so long as your favorite version of Git supports Git’s git-credential flow, it is supported by the Git Credential Manager for Windows.

--- a/Docs/Index.md
+++ b/Docs/Index.md
@@ -19,7 +19,7 @@ For detailed information on how the GCM works go to the [wiki](https://github.co
 ## Download and Install
 
 To use the GCM, you can download the [latest installer](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/releases/latest).
-To install, double-click Setup.exe and follow the instructions presented.
+To install, double-click `GCMW-{version}.exe` and follow the instructions presented.
 
 When prompted to select your terminal emulator for Git Bash you should choose the Windows' default console window, or make sure GCM is [configured to use modal dialogs](Configuration.md#modalprompt).
 GCM cannot prompt you for credentials, at the console, in a MinTTY setup.

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ This is a community project so feel free to contribute ideas, submit bugs, fix b
 
 ## Download and Install
 
-To use the GCM, you can download the [latest installer](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/releases/latest). To install, double-click `Setup.exe` and follow the instructions presented.
+To use the GCM, you can download the [latest installer](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/releases/latest). To install, double-click `GCMW-{version}.exe` and follow the instructions presented.
 
 When prompted to select your terminal emulator for Git Bash you should choose the Windows' default console window, or make sure GCM is [configured to use modal dialogs](Docs/Configuration.md#modalprompt). GCM cannot prompt you for credentials, at the console, in a MinTTY setup.
 
 ### Manual Installation
 
-Note for users with special installation needs, you can still extract the `gcm-<version>.zip` file and run install.cmd from an administrator command prompt. This allows specification of the installation options explained below.
+Note for users with special installation needs, you can still extract the `gcm-{version}.zip` file and run install.cmd from an administrator command prompt. This allows specification of the installation options explained below.
 
 ### Installation in an MSYS2 Environment
 


### PR DESCRIPTION
Replace all references to "Setup.exe" with "`GCMW-{version}.exe`" which is the current naming scheme for the installer executable.

Resolves #674