### PR TITLE
alm: avoid cycles by limiting return size

### DIFF
--- a/Microsoft.Alm.Authentication/Src/Git/Utilities.cs
+++ b/Microsoft.Alm.Authentication/Src/Git/Utilities.cs
@@ -122,12 +122,15 @@ namespace Microsoft.Alm.Authentication.Git
                 }
             }
 
+            var cycleGuard = new HashSet<uint>();
             var processList = new LinkedList<Win32.ProcessEntry32>();
             uint processId = Win32.Kernel32.GetCurrentProcessId();
 
             // Starting with the current process, build a parentage chain back to the initial system process.
             // The resulting list will be a list of processes in invocation order starting with system, and ending with the current process.
-            while (processTable.ContainsKey(processId))
+            // Since cycles are possible, use `cycleGuard` as a guard - if a process has already been seen, stop building the list.
+            while (cycleGuard.Add(processId)
+                && processTable.ContainsKey(processId))
             {
                 processEntry = processEntries[processId];
 


### PR DESCRIPTION
When building a hierarchical list after enumerating process, it is possible to encounter a cycle in the process hierarchy reported by Windows. This will cause the previous solution (linked list) to allocate the repeating sequence until the system runs out of memory.

This change limits the number of process entries returned in the list to 32, which is an abitrary number but should be large enough to allow discovery of a sought parent process for most situations