### PR TITLE
cli: add GCM_OVERRIDE_URL support.

### DIFF
--- a/Cli/Manager/Program.cs
+++ b/Cli/Manager/Program.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Alm.Cli
             {
                 _context.Trace.WriteLine($"converted '{url}' to '{uri.AbsoluteUri}'.");
 
-                OperationArguments operationArguments = new OperationArguments(_context);
+                var operationArguments = new OperationArguments(_context);
 
                 operationArguments.SetTargetUri(uri);
 
@@ -355,8 +355,12 @@ namespace Microsoft.Alm.Cli
                     await LoadOperationArguments(operationArguments);
                     EnableTraceLogging(operationArguments);
 
-                    // Read the details of any git-remote-http(s).exe parent process.
-                    ReadGitRemoteDetails(operationArguments);
+                    // Read the details of any git-remote-http(s).exe parent process, but only if
+                    // an override hasn't been set which would override the git-remote details.
+                    if (string.IsNullOrEmpty(operationArguments.UrlOverride))
+                    {
+                        ReadGitRemoteDetails(operationArguments);
+                    }
 
                     // Set the parent window handle.
                     ParentHwnd = operationArguments.ParentHwnd;
@@ -379,7 +383,7 @@ namespace Microsoft.Alm.Cli
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
             using (var stdin = InStream)
             {
-                OperationArguments operationArguments = new OperationArguments(_context);
+                var operationArguments = new OperationArguments(_context);
 
                 Task.Run(async () =>
                 {
@@ -395,8 +399,12 @@ namespace Microsoft.Alm.Cli
                     await LoadOperationArguments(operationArguments);
                     EnableTraceLogging(operationArguments);
 
-                    // Read the details of any git-remote-http(s).exe parent process.
-                    ReadGitRemoteDetails(operationArguments);
+                    // Read the details of any git-remote-http(s).exe parent process, but only if
+                    // an override hasn't been set which would override the git-remote details.
+                    if (string.IsNullOrEmpty(operationArguments.UrlOverride))
+                    {
+                        ReadGitRemoteDetails(operationArguments);
+                    }
 
                     // Set the parent window handle.
                     ParentHwnd = operationArguments.ParentHwnd;
@@ -431,7 +439,7 @@ namespace Microsoft.Alm.Cli
                     {
                         string doc = Path.Combine(installation.Doc, HelpFileName);
 
-                        // if the help file exists, send it to the operating system to display to the user
+                        // If the help file exists, send it to the operating system to display to the user.
                         if (Storage.FileExists(doc))
                         {
                             Trace.WriteLine($"opening help documentation '{doc}'.");
@@ -465,7 +473,7 @@ namespace Microsoft.Alm.Cli
             // see: https://www.kernel.org/pub/software/scm/git/docs/git-credential.html
             using (var stdin = InStream)
             {
-                OperationArguments operationArguments = new OperationArguments(_context);
+                var operationArguments = new OperationArguments(_context);
 
                 Task.Run(async () =>
                 {
@@ -486,8 +494,12 @@ namespace Microsoft.Alm.Cli
                     await LoadOperationArguments(operationArguments);
                     EnableTraceLogging(operationArguments);
 
-                    // Read the details of any git-remote-http(s).exe parent process.
-                    ReadGitRemoteDetails(operationArguments);
+                    // Read the details of any git-remote-http(s).exe parent process, but only if
+                    // an override hasn't been set which would override the git-remote details.
+                    if (string.IsNullOrEmpty(operationArguments.UrlOverride))
+                    {
+                        ReadGitRemoteDetails(operationArguments);
+                    }
 
                     // Set the parent window handle.
                     ParentHwnd = operationArguments.ParentHwnd;

--- a/Cli/Test/Cli-Test.csproj
+++ b/Cli/Test/Cli-Test.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Microsoft.Alm.Cli.Test</RootNamespace>
     <AssemblyName>Microsoft.Alm.Cli.Test</AssemblyName>
     <IsCodedUITest>False</IsCodedUITest>
-    <NuGetPackageImportStamp/>
+    <NuGetPackageImportStamp />
   </PropertyGroup>
   <Import Project="..\..\test.props" />
   <ItemGroup>

--- a/Shared/Cli/Program.cs
+++ b/Shared/Cli/Program.cs
@@ -51,12 +51,13 @@ namespace Microsoft.Alm.Cli
         Interactive,
         ModalPrompt,
         Namespace,
+        ParentHwnd,
         PreserveCredentials,
         TokenDuration,
+        UrlOverride,
         Username,
         Validate,
         VstsScope,
-        ParentHwnd,
         Writelog,
     }
 
@@ -119,19 +120,19 @@ namespace Microsoft.Alm.Cli
 
         internal readonly Dictionary<KeyType, string> _configurationKeys = new Dictionary<KeyType, string>()
         {
-            { KeyType.Authority,  "authority" },
-            { KeyType.HttpProxy,  "httpProxy" },
-            { KeyType.HttpsProxy,  "httpsProxy" },
-            { KeyType.Interactive,  "interactive" },
-            { KeyType.ModalPrompt,  "modalPrompt" },
-            { KeyType.Namespace,  "namespace" },
-            { KeyType.PreserveCredentials,  "preserve" },
-            { KeyType.TokenDuration,  "tokenDuration" },
-            { KeyType.HttpPath,  "useHttpPath" },
-            { KeyType.Username,  "username" },
-            { KeyType.Validate,  "validate" },
-            { KeyType.VstsScope, "vstsScope" },
-            { KeyType.Writelog,  "writeLog" },
+            { KeyType.Authority, "authority" },
+            { KeyType.HttpProxy, "httpProxy" },
+            { KeyType.HttpsProxy, "httpsProxy" },
+            { KeyType.Interactive, "interactive" },
+            { KeyType.ModalPrompt, "modalPrompt" },
+            { KeyType.Namespace, "namespace" },
+            { KeyType.PreserveCredentials, "preserve" },
+            { KeyType.TokenDuration, "tokenDuration" },
+            { KeyType.HttpPath, "useHttpPath" },
+            { KeyType.Username, "username" },
+            { KeyType.Validate, "validate" },
+            { KeyType.VstsScope,"vstsScope" },
+            { KeyType.Writelog, "writeLog" },
         };
         internal readonly Dictionary<KeyType, string> _environmentKeys = new Dictionary<KeyType, string>()
         {
@@ -144,11 +145,12 @@ namespace Microsoft.Alm.Cli
             { KeyType.Interactive, "GCM_INTERACTIVE" },
             { KeyType.ModalPrompt, "GCM_MODAL_PROMPT" },
             { KeyType.Namespace, "GCM_NAMESPACE" },
+            { KeyType.ParentHwnd, "GCM_MODAL_PARENTHWND" },
             { KeyType.PreserveCredentials, "GCM_PRESERVE" },
             { KeyType.TokenDuration, "GCM_TOKEN_DURATION" },
             { KeyType.Validate, "GCM_VALIDATE" },
             { KeyType.VstsScope, "GCM_VSTS_SCOPE" },
-            { KeyType.ParentHwnd, "GCM_MODAL_PARENTHWND" },
+            { KeyType.UrlOverride, "GCM_URL_OVERRIDE" },
             { KeyType.Writelog, "GCM_WRITELOG" },
         };
 
@@ -457,7 +459,7 @@ namespace Microsoft.Alm.Cli
                 // If the value is true or a number greater than zero, then trace to standard error.
                 if (Git.Configuration.PaserBoolean(traceValue))
                 {
-                    Trace.AddListener(Console.Error);
+                    Trace.AddListener(Error);
                 }
                 // If the value is a rooted path, then trace to that file and not to the console.
                 else if (Path.IsPathRooted(traceValue))


### PR DESCRIPTION
Provide a mechanism for setting `TargetUri.ActualUri` via environment variables.

 - [x] Add `UrlOverride` property to `OperationArguments`.
 - [x] Add `UrlOverride` to the `KeyType` enumeration.
 - [x] Modify `OperationArguments` to use `UrlOverride` in its calculation of `TargetUri`.
 - [x] Add feature validation test.

Resolves issues #683 

/CC @jrbriggs 