### PR TITLE
vsts: null credentials are invalid.

### DIFF
--- a/VisualStudioTeamServices.Authentication/Src/Authentication.cs
+++ b/VisualStudioTeamServices.Authentication/Src/Authentication.cs
@@ -409,7 +409,11 @@ namespace VisualStudioTeamServices.Authentication
         /// <param name="credentials">The credentials to validate.</param>
         public async Task<bool> ValidateCredentials(TargetUri targetUri, Credential credentials)
         {
-            return await Authority.ValidateCredentials(targetUri, credentials);
+            if (targetUri is null)
+                throw new ArgumentNullException(nameof(targetUri));
+
+            return credentials != null
+                && await Authority.ValidateCredentials(targetUri, credentials);
         }
 
         /// <summary>

--- a/VisualStudioTeamServices.Authentication/Src/Authority.cs
+++ b/VisualStudioTeamServices.Authentication/Src/Authority.cs
@@ -304,8 +304,9 @@ namespace VisualStudioTeamServices.Authentication
         {
             if (targetUri is null)
                 throw new ArgumentNullException(nameof(targetUri));
+
             if (credentials is null)
-                throw new ArgumentNullException(nameof(credentials));
+                return false;
 
             try
             {


### PR DESCRIPTION
Treat null credentials as invlid and not an exceptional error case when checking credential validity.