### PR TITLE
 vsts: null credentials are invalid.

### DIFF
--- a/Cli/Manager/Cli-Manager.csproj
+++ b/Cli/Manager/Cli-Manager.csproj
@@ -20,6 +20,9 @@
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <OutputPath>$(ProjectDir)$(OutputPath)</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <StartArguments Condition=" '$(StartArguments)' == '' OR '$(StartArguments)' == '*Undefined*' ">get</StartArguments>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Treat `null` credentials and tokens as invalid; not as exception errors.