### PR TITLE
alm: complete partial cherry-pick

### DIFF
--- a/Microsoft.Alm.Authentication/Src/Network.cs
+++ b/Microsoft.Alm.Authentication/Src/Network.cs
@@ -441,6 +441,7 @@ namespace Microsoft.Alm.Authentication
                                 {
                                     case TokenType.AzureAccess:
                                     case TokenType.BitbucketAccess:
+                                    case TokenType.Personal:
                                         {
                                             // ADAL access tokens are packed into the Authorization header.
                                             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);


### PR DESCRIPTION
When `f8b3707a` was cherry-picked from `master`, a line was missed. The missing line causes Bitbucket authentication to be unable to perform two-factor authentication.

This commit restores the missing line.

Resolves #704 

/CC @Foda