### PR TITLE
alm: correct pass args within `Trace` methods.

### DIFF
--- a/Microsoft.Alm.Authentication/Src/Git/Trace.cs
+++ b/Microsoft.Alm.Authentication/Src/Git/Trace.cs
@@ -138,11 +138,11 @@ namespace Microsoft.Alm.Authentication.Git
             if (exception is null)
                 return;
 
-            WriteLine($"! error: '{exception.Message}'.");
+            WriteLine($"! error: '{exception.Message}'.", filePath, lineNumber, memberName);
 
             while ((exception = exception.InnerException) != null)
             {
-                WriteLine($"       > '{exception.Message}'.");
+                WriteLine($"       > '{exception.Message}'.", filePath, lineNumber, memberName);
             }
         }
 


### PR DESCRIPTION
When `WriteException` calls `WriteLine` it must pass the `filePath`, `lineNumber`, and `methodName` arguments to `WriteLine` otherwise data loss occurs.