### PR TITLE
bitbucket: fix data loss from token misuse

### DIFF
--- a/Bitbucket.Authentication/Src/OAuth/OAuthAuthenticator.cs
+++ b/Bitbucket.Authentication/Src/OAuth/OAuthAuthenticator.cs
@@ -323,7 +323,7 @@ namespace Atlassian.Bitbucket.Authentication.OAuth
                 && tokenMatch.Groups.Count > 1)
             {
                 string tokenText = tokenMatch.Groups[1].Value;
-                return new Token(tokenText, TokenType.Personal);
+                return new Token(tokenText, TokenType.BitbucketAccess);
             }
 
             return null;

--- a/Microsoft.Alm.Authentication/Src/Network.cs
+++ b/Microsoft.Alm.Authentication/Src/Network.cs
@@ -566,6 +566,17 @@ namespace Microsoft.Alm.Authentication
                                 }
                                 break;
 
+                                case TokenType.Personal:
+                                {
+                                    // Personal access tokens are designed to treated like credentials,
+                                    // so treat them like credentials.
+                                    var credentials = (Credential)token;
+
+                                    // Credentials are packed into the 'Authorization' header as a base64 encoded pair.
+                                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials.ToBase64String());
+                                }
+                                break;
+
                                 default:
                                 Trace.WriteLine("! unsupported token type, not appending an authentication header to the request.");
                                 break;
@@ -602,7 +613,7 @@ namespace Microsoft.Alm.Authentication
 
             if (proxyUri != null)
             {
-                WebProxy proxy = new WebProxy(proxyUri) { UseDefaultCredentials = true };
+                var proxy = new WebProxy(proxyUri) { UseDefaultCredentials = true };
 
                 // check if the user has specified authentications (comes as UserInfo)
                 if (!string.IsNullOrWhiteSpace(proxyUri.UserInfo) && proxyUri.UserInfo.Length > 1)
@@ -615,7 +626,7 @@ namespace Microsoft.Alm.Authentication
                         string userName = proxyUri.UserInfo.Substring(0, tokenIndex);
                         string password = proxyUri.UserInfo.Substring(tokenIndex + 1);
 
-                        NetworkCredential proxyCreds = new NetworkCredential(userName, password);
+                        var proxyCreds = new NetworkCredential(userName, password);
 
                         proxy.UseDefaultCredentials = false;
                         proxy.Credentials = proxyCreds;

--- a/Microsoft.Alm.Authentication/Src/Token.cs
+++ b/Microsoft.Alm.Authentication/Src/Token.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Alm.Authentication
             if (token is null)
                 return null;
 
-            if (token.Type != TokenType.Personal)
+            if (token.Type != TokenType.Personal && token.Type != TokenType.BitbucketAccess)
                 throw new InvalidCastException($"Cannot cast `{nameof(Token)}` of type '{token.Type}' to `{nameof(Credential)}`");
 
             return new Credential("PersonalAccessToken", token._value);


### PR DESCRIPTION
Allow Bitbucket access tokens to be cast as credentials, and properly handle personal access tokens used as authentication in network requests. Now that Bitbucket access tokens are allowed to be case to credentials, start returning them from `OAuthAuthenticator`.

/CC @Foda