### PR TITLE
bitbucket: fix data loss from token misuse

### DIFF
--- a/Bitbucket.Authentication/Src/OAuth/OAuthAuthenticator.cs
+++ b/Bitbucket.Authentication/Src/OAuth/OAuthAuthenticator.cs
@@ -323,7 +323,7 @@ namespace Atlassian.Bitbucket.Authentication.OAuth
                 && tokenMatch.Groups.Count > 1)
             {
                 string tokenText = tokenMatch.Groups[1].Value;
-                return new Token(tokenText, TokenType.Personal);
+                return new Token(tokenText, TokenType.BitbucketAccess);
             }
 
             return null;

--- a/Microsoft.Alm.Authentication/Src/Token.cs
+++ b/Microsoft.Alm.Authentication/Src/Token.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Alm.Authentication
             if (token is null)
                 return null;
 
-            if (token.Type != TokenType.Personal)
+            if (token.Type != TokenType.Personal && token.Type != TokenType.BitbucketAccess)
                 throw new InvalidCastException($"Cannot cast `{nameof(Token)}` of type '{token.Type}' to `{nameof(Credential)}`");
 
             return new Credential(token.ToString(), token._value);


### PR DESCRIPTION
Allow Bitbucket access tokens to be cast as credentials, and properly handle personal access tokens used as authentication in network requests. Now that Bitbucket access tokens are allowed to be case to credentials, start returning them from `OAuthAuthenticator`.

/CC @Foda