### PR TITLE
bitbucket: fix authentication

### DIFF
--- a/Bitbucket.Authentication/OAuth/OAuthAuthenticator.cs
+++ b/Bitbucket.Authentication/OAuth/OAuthAuthenticator.cs
@@ -323,7 +323,7 @@ namespace Atlassian.Bitbucket.Authentication.OAuth
                 && tokenMatch.Groups.Count > 1)
             {
                 string tokenText = tokenMatch.Groups[1].Value;
-                return new Token(tokenText, TokenType.Personal);
+                return new Token(tokenText, TokenType.BitbucketAccess);
             }
 
             return null;

--- a/Microsoft.Alm.Authentication/Token.cs
+++ b/Microsoft.Alm.Authentication/Token.cs
@@ -305,7 +305,9 @@ namespace Microsoft.Alm.Authentication
             if (token is null)
                 return null;
 
-            if (token.Type != TokenType.Personal)
+            if (token.Type == TokenType.AzureAccess
+                || token.Type == TokenType.AzureFederated
+                || token.Type == TokenType.Unknown)
                 throw new InvalidCastException($"Cannot cast `{nameof(Token)}` of type '{token.Type}' to `{nameof(Credential)}`");
 
             return new Credential(token.ToString(), token._value);


### PR DESCRIPTION
Loosen token cast requirements, and only throw when known invalid to cast types are encountered. Now that Bitbucket access tokens can be cast to credentials, return them instead of personal access tokens.

/CC @Foda