### PR TITLE
bitbucket: Fixed basic auth with new username

### DIFF
--- a/Bitbucket.Authentication/Src/Authentication.cs
+++ b/Bitbucket.Authentication/Src/Authentication.cs
@@ -411,11 +411,12 @@ namespace Atlassian.Bitbucket.Authentication
         {
             Credential credentials = (Credential)result.Token;
 
-            var realUsername = GetRealUsername(result.RemoteUsername, username);
 
-            if (!targetUri.ContainsUserInfo)
+            // No user info in Uri, or it's a basic login so we need to personalize the credentials.
+            if (!targetUri.ContainsUserInfo || result.Token.Type == TokenType.Personal)
             {
                 // No user info in Uri so personalize the credentials.
+                var realUsername = GetRealUsername(result.RemoteUsername, username);
                 credentials = new Credential(realUsername, credentials.Password);
             }
 

--- a/Bitbucket.Authentication/Src/OAuth/SimpleServer.cs
+++ b/Bitbucket.Authentication/Src/OAuth/SimpleServer.cs
@@ -56,14 +56,19 @@ namespace Atlassian.Bitbucket.Authentication.OAuth
                 var context = await listener.GetContextAsync().RunWithCancellation(cancellationToken);
                 rawUrl = context.Request.RawUrl;
 
-                //Serve back a simple auth message.
+                Thread.Sleep(100); // Wait 100ms without this the server closes before the complete response has been written
+                
+                // Serve back a simple authentication message.
                 var html = GetSuccessString();
-                context.Response.ContentType = "text/html";
-                context.Response.OutputStream.WriteStringUtf8(html);
+                var buffer = System.Text.Encoding.UTF8.GetBytes(html);
+                context.Response.ContentLength64 = buffer.Length;
+                Task responseTask = context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length).ContinueWith((task) =>
+                {
+                    context.Response.OutputStream.Close();
+                    listener.Stop();
+                });
 
-                await Task.Delay(100); //Wait 100ms without this the server closes before the complete response has been written
-
-                context.Response.Close();
+                Thread.Sleep(100);
             }
             catch (TimeoutException ex)
             {

--- a/Bitbucket.Authentication/Test/AuthenticationTest.cs
+++ b/Bitbucket.Authentication/Test/AuthenticationTest.cs
@@ -474,6 +474,46 @@ namespace Atlassian.Bitbucket.Authentication.Test
         }
 
         [Fact]
+        public async void VerifyInteractiveLoginDoesNotAquireInvalidBasicAuthCredentialsWithUsername()
+        {
+            var bitbucketUrl = "https://bitbucket.org";
+            var credentialStore = new Mock<ICredentialStore>();
+
+            // mock the result that normally causes issues
+            var validAuthenticationResult = new AuthenticationResult(AuthenticationResultType.Success)
+            {
+                Token = new Token(_validPassword, TokenType.Personal),
+                RemoteUsername = _validUsername
+            };
+
+            var targetUri = new TargetUri(bitbucketUrl);
+
+            // Mock the behaviour of IAuthority.AcquireToken() to basically mimic BasicAuthAuthenticator.GetAuthAsync() validating the useername/password
+            var authority = new Mock<IAuthority>();
+            authority
+                .Setup(a => a.AcquireToken(It.IsAny<TargetUri>(), It.IsAny<Credential>(), It.IsAny<AuthenticationResultType>(), It.IsAny<TokenScope>()))
+                // return 'success' with the validated credentials
+                .Returns(Task.FromResult(validAuthenticationResult));
+
+            var bbAuth = new Authentication(RuntimeContext.Default, credentialStore.Object, 
+                MockInvalidBasicAuthCredentialsAquireCredentialsCallback, MockValidAquireAuthenticationOAuthCallback, authority.Object);
+
+            // perform login with username
+            var credentials = await bbAuth.InteractiveLogon(targetUri, _validUsername);
+
+            Assert.NotNull(credentials);
+            Assert.Equal(_validUsername, credentials.Username);
+            Assert.Equal(_validPassword, credentials.Password);
+
+            // attempted to validate credentials
+            authority.Verify(a => a.AcquireToken(It.IsAny<TargetUri>(), It.IsAny<Credential>(), It.IsAny<AuthenticationResultType>(),
+                It.IsAny<TokenScope>()), Times.Once);
+           
+            // must have a valid attempt to store the valid credentials
+            credentialStore.Verify(c => c.WriteCredentials(It.IsAny<TargetUri>(), credentials), Times.Once);
+        }
+
+        [Fact]
         public async void VerifyInteractiveLoginDoesNothingIfUserDoesNotEnterCredentials()
         {
             var bitbucketUrl = "https://bitbucket.org";


### PR DESCRIPTION
Fixed an issue where logging into Bitbucket with basic auth with a provided username would store the username as "Personal Access Token". 

Additionally, this fixes an issue where the simple server for oauth would not respond with a valid webpage

Resolves #710
Resolves #704