### PR TITLE
build: fix CI build

### DIFF
--- a/vsts-tt.yml
+++ b/vsts-tt.yml
@@ -53,18 +53,12 @@ phases:
         restoreSolution: '$(Build.Solution)'
         verbosityRestore: 'quiet'
     
-    - task: NuGetCommand@2
-      displayName: NuGet restore
-      inputs:
-        command: custom
-        arguments: restore '$(Build.SourcesDirectory)\$(Build.Target)' '-SolutionDirectory $(Build.SourcesDirectory)'
-    
     - ${{ parameters.MicrobuildSetup }}
     
     - task: MSBuild@1
       displayName: 'Core Build'
       inputs:
-        solution: '$(Build.Target)'
+        solution: '$(Build.Solution)'
         msbuildArguments: '/nologo /verbosity:$(Build.Verbosity) /binaryLogger:$(Build.SourcesDirectory)/$(build.buildNumber).binlog'
         platform: '$(Build.Platform)'
         configuration: '$(Build.Configuration)'


### PR DESCRIPTION
The CI build for rel/v1.16 because changes for master and v1.17 leaked into the branch. These fixes undo the breakage.