### PR TITLE
bitbucket: Backmerge 1.17 oauth fix to 1.16

### DIFF
--- a/Bitbucket.Authentication.Test/Bitbucket.Authentication.Test.csproj
+++ b/Bitbucket.Authentication.Test/Bitbucket.Authentication.Test.csproj
@@ -29,6 +29,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>

--- a/Bitbucket.Authentication/Authority.cs
+++ b/Bitbucket.Authentication/Authority.cs
@@ -166,7 +166,7 @@ namespace Atlassian.Bitbucket.Authentication
             }
 
             // If the basic authentication test failed then try again as OAuth
-            if (await ValidateCredentials(targetUri, new Token(credentials.Password, TokenType.BitbucketPassword)))
+            if (await ValidateCredentials(targetUri, new Token(credentials.Password, TokenType.BitbucketAccess)))
             {
                 return true;
             }

--- a/Bitbucket.Authentication/Rest/RestClient.cs
+++ b/Bitbucket.Authentication/Rest/RestClient.cs
@@ -26,7 +26,9 @@ namespace Atlassian.Bitbucket.Authentication.Rest
                 Authorization = authorization,
                 Timeout = TimeSpan.FromMilliseconds(requestTimeout),
             };
-            var requestUri = new TargetUri(restRootUrl, targetUri.ProxyUri);
+
+            var apiUrl = new Uri(restRootUrl, UserUrl);
+            var requestUri = new TargetUri(apiUrl, targetUri.ProxyUri);
 
             using (var response = await Network.HttpGetAsync(requestUri, options))
             {

--- a/Microsoft.Alm.Authentication/Network.cs
+++ b/Microsoft.Alm.Authentication/Network.cs
@@ -440,6 +440,7 @@ namespace Microsoft.Alm.Authentication
                                 switch (token.Type)
                                 {
                                     case TokenType.AzureAccess:
+                                    case TokenType.BitbucketAccess:
                                         {
                                             // ADAL access tokens are packed into the Authorization header.
                                             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);

--- a/Microsoft.Alm.Authentication/TokenType.cs
+++ b/Microsoft.Alm.Authentication/TokenType.cs
@@ -61,21 +61,15 @@ namespace Microsoft.Alm.Authentication
         Test = 5,
 
         /// <summary>
-        /// Bitbucket Password Tokens.
-        /// </summary>
-        [System.ComponentModel.Description("Bitbucket Password Token")]
-        BitbucketPassword = 6,
-
-        /// <summary>
         /// Bitbucket Access Tokens.
         /// </summary>
         [System.ComponentModel.Description("Bitbucket Access Token")]
-        BitbucketAccess = 7,
+        BitbucketAccess = 6,
 
         /// <summary>
         /// Used to auto-refresh Bitbucket Access Tokens.
         /// </summary>
         [System.ComponentModel.Description("Bitbucket Refresh Token")]
-        BitbucketRefresh = 8,
+        BitbucketRefresh = 7,
     }
 }


### PR DESCRIPTION
This PR backmerges the issues found in https://github.com/Microsoft/Git-Credential-Manager-for-Windows/pull/697 to the 1.16 branch. I also added a regression test.