### PR TITLE
alm: allow tokens as basic authorization

### DIFF
--- a/Microsoft.Alm.Authentication/Network.cs
+++ b/Microsoft.Alm.Authentication/Network.cs
@@ -454,6 +454,15 @@ namespace Microsoft.Alm.Authentication
                                         }
                                         break;
 
+                                    case TokenType.Personal:
+                                        {
+                                            var credentials = (Credential)token;
+
+                                            // Credentials are packed into the 'Authorization' header as a base64 encoded pair.
+                                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials.ToBase64String());
+                                        }
+                                        break;
+
                                     default:
                                         Trace.WriteLine("! unsupported token type, not appending an authentication header to the request.");
                                         break;


### PR DESCRIPTION
Enable tokens to be used as basic authoriztion for http-requests.