### PR TITLE
bitbucket: Remove calls to Thread.Sleep

### DIFF
--- a/Bitbucket.Authentication/Src/OAuth/SimpleServer.cs
+++ b/Bitbucket.Authentication/Src/OAuth/SimpleServer.cs
@@ -56,19 +56,12 @@ namespace Atlassian.Bitbucket.Authentication.OAuth
                 var context = await listener.GetContextAsync().RunWithCancellation(cancellationToken);
                 rawUrl = context.Request.RawUrl;
 
-                Thread.Sleep(100); // Wait 100ms without this the server closes before the complete response has been written
-                
                 // Serve back a simple authentication message.
                 var html = GetSuccessString();
                 var buffer = System.Text.Encoding.UTF8.GetBytes(html);
                 context.Response.ContentLength64 = buffer.Length;
-                Task responseTask = context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length).ContinueWith((task) =>
-                {
-                    context.Response.OutputStream.Close();
-                    listener.Stop();
-                });
-
-                Thread.Sleep(100);
+                await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+                context.Response.Close();
             }
             catch (TimeoutException ex)
             {


### PR DESCRIPTION
I've tested this change and was able to successfully authenticate to Bitbucket with 2FA enabled.

- First call to `Thread.Sleep` looks like a mistake
- We should await the call to `WriteAsync`
- Use the overload of `WriteAsync` that takes a `CancellationToken`
- `listener.Stop` is called in the `finally` clause anyway
- Second call to `Thread.Sleep` should not be relied upon for correctness
- `context.Response.OutputStream.Close()` was intentionally changed to `context.Response.Close()`: the latter ["closes the response stream and the `HttpListenerRequest` associated with the response"](https://docs.microsoft.com/en-us/dotnet/api/system.net.httplistenerresponse.close?view=netframework-4.7#System_Net_HttpListenerResponse_Close_System_Byte___System_Boolean_)