### PR TITLE
issue-742 Grab keyboard focus when the Bitbucket dialog opens. 

### DIFF
--- a/Bitbucket.Authentication/Src/Controls/CredentialsControl.xaml.cs
+++ b/Bitbucket.Authentication/Src/Controls/CredentialsControl.xaml.cs
@@ -24,6 +24,7 @@
 **/
 
 using System;
+using System.Windows.Input;
 using GitHub.Shared.Controls;
 using GitHub.Shared.Helpers;
 
@@ -44,10 +45,12 @@ namespace Atlassian.Bitbucket.Authentication.Controls
             if (string.IsNullOrWhiteSpace(loginTextBox.Text))
             {
                 loginTextBox.TryFocus().Wait(TimeSpan.FromSeconds(1));
+                Keyboard.Focus(loginTextBox);
             }
             else
             {
                 passwordTextBox.TryFocus().Wait(TimeSpan.FromSeconds(1));
+                Keyboard.Focus(passwordTextBox);
             }
         }
     }

--- a/Bitbucket.Authentication/Src/Views/CredentialsWindow.xaml
+++ b/Bitbucket.Authentication/Src/Views/CredentialsWindow.xaml
@@ -42,6 +42,7 @@
     MinHeight="380"
     Height="420"
     Width="420"
+    Topmost="True"
     Icon="pack://application:,,,/Bitbucket.Authentication;component/Assets/ADG3/Images/Bitbucket-16x16.ico">
     <Window.DataContext>
         <viewmodels:CredentialsViewModel />

--- a/Bitbucket.Authentication/Src/Views/OAuthWindow.xaml
+++ b/Bitbucket.Authentication/Src/Views/OAuthWindow.xaml
@@ -41,6 +41,7 @@
     Title="Bitbucket OAuth Authentication"
     Height="420"
     Width="420"
+    Topmost="True"
     Icon="pack://application:,,,/Bitbucket.Authentication;component/Assets/ADG3/Images/Bitbucket-16x16.ico">
     <Window.DataContext>
         <viewmodels:OAuthViewModel />


### PR DESCRIPTION
Try to ensure the dialogs are not missed by users by attempting to place them topmost.