### PR TITLE
devops: update requestUri for easier debugging 

### DIFF
--- a/AzureDevOps.Authentication/Src/Authentication.cs
+++ b/AzureDevOps.Authentication/Src/Authentication.cs
@@ -207,6 +207,9 @@ namespace AzureDevOps.Authentication
                     return tenantId;
                 }
 
+                // Use the properly formatted URL
+                requestUri = requestUri.CreateWith(queryUrl: requestUrl);
+
                 var options = new NetworkRequestOptions(false)
                 {
                     Flags = NetworkRequestOptionFlags.UseProxy,


### PR DESCRIPTION
- Use the reformated url for the head request to get the tenant.  This doesn't fix a runtime problem (we should have the correct url already from parsing the command line), but allows easier debugging based on parameters passed in.