### PR TITLE
devops: Purge tenant cache when credentials are deleted

### DIFF
--- a/AzureDevOps.Authentication/Src/Authentication.cs
+++ b/AzureDevOps.Authentication/Src/Authentication.cs
@@ -131,31 +131,11 @@ namespace AzureDevOps.Authentication
             if (targetUri is null)
                 throw new ArgumentNullException(nameof(targetUri));
 
-            Credential credentials = await PersonalAccessTokenStore.ReadCredentials(targetUri);
+            await PersonalAccessTokenStore.DeleteCredentials(targetUri);
 
-            // Attempt to validate the credentials, if they're truly invalid delete them.
-            if (!await ValidateCredentials(targetUri, credentials))
-            {
-                await PersonalAccessTokenStore.DeleteCredentials(targetUri);
-
-                // Remove any related entries from the tenant cache because tenant change
-                // could the be source of the invalidation, and not purging the cache will
-                // trap the user in a limbo state of invalid credentials.
-
-                // Deserialize the cache and remove any matching entry.
-                string tenantUrl = targetUri.ToString();
-                var cache = await DeserializeTenantCache(Context);
-
-                // Attempt to remove the URL entry, if successful serialize the cache.
-                if (cache.Remove(tenantUrl))
-                {
-                    await SerializeTenantCache(Context, cache);
-                }
-
-                return true;
-            }
-
-            return false;
+            // Purge the entire tenant cache when credentials are deleted
+            // This prevents stale values and tenant information can be easily looked up
+            return DeleteTenantCache(Context);
         }
 
         /// <summary>
@@ -531,6 +511,29 @@ namespace AzureDevOps.Authentication
             targetUrl = targetUrl.TrimEnd('/', '\\');
 
             return $"{prefix}:{targetUrl}";
+        }
+
+        private static bool DeleteTenantCache(RuntimeContext context)
+        {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+
+            var path = GetCachePath(context);
+
+            try
+            {
+                File.Delete(path);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(ex);
+
+                context.Trace.WriteLine($"failed to delete tenant cache file.");
+                context.Trace.WriteException(ex);
+            }
+
+            return false;
         }
 
         private static async Task<Dictionary<string, Guid>> DeserializeTenantCache(RuntimeContext context)


### PR DESCRIPTION
The tenant cache is not correctly being purged when credentials are deleted.  Delete the file to ensure the cache is erased. Tenants can be easily looked up again if necessary.

resolves #650