### PR TITLE
Update Delete Handling

### DIFF
--- a/AzureDevOps.Authentication/Src/Authentication.cs
+++ b/AzureDevOps.Authentication/Src/Authentication.cs
@@ -143,7 +143,7 @@ namespace AzureDevOps.Authentication
                 // trap the user in a limbo state of invalid credentials.
 
                 // Deserialize the cache and remove any matching entry.
-                string tenantUrl = targetUri.ToString();
+                string tenantUrl = GetTargetUrl(targetUri, keepUsername: false);
                 var cache = await DeserializeTenantCache(Context);
 
                 // Attempt to remove the URL entry, if successful serialize the cache.

--- a/Docs/CredentialManager.md
+++ b/Docs/CredentialManager.md
@@ -16,10 +16,12 @@ git credential-manager [<command> [<args>]]
 
 ## Commands
 
-### delete
+### delete (deprecated)
 
 Removes stored credentials for a given URL.
 Any future attempts to authenticate with the remote will require authentication steps to be completed again.
+
+This method is being deprecated and users should use "git credential reject" instead
 
 ### deploy _\[--path \<installation_path\>\] \[--passive\] \[--force\]_
 

--- a/Microsoft.Alm.Authentication/Src/BaseAuthentication.cs
+++ b/Microsoft.Alm.Authentication/Src/BaseAuthentication.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Alm.Authentication
         public abstract Task<bool> DeleteCredentials(TargetUri targetUri);
 
         public virtual Task<bool> DeleteCredentials(TargetUri targetUri, string username)
-            => DeleteCredentials(targetUri, null);
+            // Use default handling if not overwritten
+            // username should be on the Uri
+            => DeleteCredentials(targetUri);
 
         public abstract Task<Credential> GetCredentials(TargetUri targetUri);
 


### PR DESCRIPTION
 **Mark Delete as deprecated**
It's very hard to construct what git would have sent across the wire for a given url, so instead of trying to support delete directly in GCM, alternatively users can 
1. Delete credentials using 'git credential reject'
2. Open "Credential Manager" in windows and delete

**Remove Infinite recursion DeleteCredentials call**
VSTS will use the url that was sent in as the key

**DevOps: Always Delete credentials when asked to do so**
Git calls reject in the scenarios [here](https://github.com/git/git/blob/2d3b1c576c85b7f5db1f418907af00ab88e0c303/http.c) and for these we should be removing credentials

**DevOps: Fix TenantUrl Look in Cache**

resolves #792