### PR TITLE
Issue-799 De-dupe Environment Variables when loading.

### DIFF
--- a/Microsoft.Alm.Authentication/Src/Settings.cs
+++ b/Microsoft.Alm.Authentication/Src/Settings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using static System.StringComparer;
 
@@ -79,13 +80,19 @@ namespace Microsoft.Alm.Authentication
         public IDictionary<string, string> GetEnvironmentVariables(EnvironmentVariableTarget target)
         {
             var variables = Environment.GetEnvironmentVariables(target);
+            return DeduplicateStringDictionary(variables);
+        }
+
+        internal IDictionary<string, string> DeduplicateStringDictionary(IDictionary variables)
+        {
             var result = new Dictionary<string, string>(variables.Count, OrdinalIgnoreCase);
 
-            foreach(var key in variables.Keys)
+            foreach (var key in variables.Keys)
             {
                 if (key is string name && variables[key] is string value)
                 {
-                    result.Add(name, value);
+                    // avoid trying to add duplicates, e.g. different case names, last entry wins
+                    result[name] = value;
                 }
             }
 

--- a/Microsoft.Alm.Authentication/Test/Microsoft.Alm.Authentication.Test.csproj
+++ b/Microsoft.Alm.Authentication/Test/Microsoft.Alm.Authentication.Test.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Git\GlobalSuppressions.cs" />
     <Compile Include="Git\WhereTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SettingsTest.cs" />
     <Compile Include="TargetUriTests.cs" />
     <Compile Include="TokenTests.cs" />
     <Compile Include="WwwAuthenticateHelperTests.cs" />

--- a/Microsoft.Alm.Authentication/Test/SettingsTest.cs
+++ b/Microsoft.Alm.Authentication/Test/SettingsTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Alm.Authentication.Test
+{
+    public class SettingsTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public SettingsTest(ITestOutputHelper testOutputHelper)
+        {
+            _output = testOutputHelper;
+        }
+
+        [Fact]
+        public void VerifyDeduplicateStringDictionaryStripsEntriesWithDuplicatedByCaseKeys()
+        {
+            var vars = new Dictionary<string,string>()
+            {
+                { "home", "value-1" },
+                { "Home", "value-2" },
+                { "HOme", "value-3" },
+                { "HOMe", "value-4" },
+                { "HOME", "value-5" },
+                { "homE", "value-6" },
+                { "away", "value-7" },
+            };
+
+            var settings = new Settings(RuntimeContext.Default);
+            var result = settings.DeduplicateStringDictionary(vars);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal("home", result.First().Key);
+            Assert.Equal("value-6", result.First().Value);
+            Assert.Equal("value-6", result["HOME"]);
+            Assert.Equal("away", result.Last().Key);
+            Assert.Equal("value-7", result.Last().Value);
+            Assert.Equal("value-7", result["AwAy"]);
+
+        }
+    }
+}


### PR DESCRIPTION
This is a fix and test to show it is possible to create environment variables with duplicated names that vary only in their case, how that can crash the GCM and a possible solution. 

The test requires a hack as the ServicePointManager.SecurityProtocol setting in Program.cs crashes when running the GCM inside xunit as a child process

see https://github.com/Microsoft/Git-Credential-Manager-for-Windows/issues/799