### PR TITLE
Implemented custom installation directory

### DIFF
--- a/AzureDevOps.Authentication/Src/AzureDevOps.Authentication.csproj
+++ b/AzureDevOps.Authentication/Src/AzureDevOps.Authentication.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{19770407-D7D8-4A37-914C-F552FF4B90D4}</ProjectGuid>
     <ProjectName>AzureDevOps.Authentication</ProjectName>
     <RootNamespace>AzureDevOps.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>

--- a/Bitbucket.Authentication/Src/Bitbucket.Authentication.csproj
+++ b/Bitbucket.Authentication/Src/Bitbucket.Authentication.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{EE663736-5BAD-4CA6-A4F8-99978925AD8A}</ProjectGuid>
     <ProjectName>Bitbucket.Authentication</ProjectName>
     <RootNamespace>Atlassian.Bitbucket.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>

--- a/GitHub.Authentication/Src/App.config
+++ b/GitHub.Authentication/Src/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
 </configuration>

--- a/GitHub.Authentication/Src/GitHub.Authentication.csproj
+++ b/GitHub.Authentication/Src/GitHub.Authentication.csproj
@@ -12,7 +12,7 @@
     <ProjectName>GitHub.Authentication</ProjectName>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>GitHub.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>

--- a/Microsoft.Alm.Authentication/Src/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Src/Microsoft.Alm.Authentication.csproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{19770407-B493-459D-BB4F-04FBEFB1BA13}</ProjectGuid>
     <ProjectName>Microsoft.Alm.Authentication</ProjectName>
     <RootNamespace>Microsoft.Alm.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>


### PR DESCRIPTION
This PR contains supports for a custom installation directory for the GIT credential manager and the possibility to **not** integrate the manager into detected GIT installations. Both options utilize the fact that according to the [GIT credentials documentation](https://git-scm.com/docs/gitcredentials) the configuration setting `credential.helper` is

> The name of an external credential helper, and any associated options. If the helper name is not an absolute path, then the string 'git-credential-' is prepended. The resulting string is executed by the shell

and thus the path to an credential manager can be set not only by using an arbitrary word like `manager` but the absolute path to an executable that acts as an credential helper for git.

The PR instroduces two new program options to the `install` command of `git-credential-manager.exe`

* `--destination` specifies a custom installation directory diverging from `$Home\bin` (`~/bin`)
* `--dontintegrate` prevents the installation of teh Windows Credential Manager into all detected GIT installations

Using one of the above mentioned options will insert the absolute path of `git-credential-manager.exe` to all detected GIT installations. If none is used the installation routine behaves as before.

The above mentioned command line options allows the implementation of diverse installation scenarios that weren't able to be performed before:

1.  Installing `git-credential-manager.exe` into a custom installation directory and not to `$Home\bin`. This is important if the normal path is protected by Window AppLocker and thus prevents the execution of `git-credential-manager.exe`.
2. Using `--dontintegrate` will prevent the integration (copy local) of  `git-credential-manager.exe` and it's required files to the detected Git installations. This is important if the detected Git installations aren't writeable for current user. Currently this won't happen because the installation always runs elevated but at in later version the installer can check if it's really required to run elevated or not so that a user without administration privileges is able to install `git-credential-manager.exe`.
3. When Git is installed via a portable package and an automated process it might be desired that the `git-credential-manager.exe` isn't copied to the installation directory of Git because it won't survive an update or reinstall of Git via the portable package. When  `--dontintegrate` is used to install `git-credential-manager.exe` the absolute path of the executable is added to the global configuration and thus it's irrelevant if it's present in the Git installation.

In addition to the above mentioned extensions the used .NET 4.5 versions has been streamlined to v4.5.2 so it's no more required to install both v4.5.1 and v4.5.2 to build Git Credential Manager for Windows.