### PR TITLE
Workaround ADAL 3.x bug by catching all exceptions

### DIFF
--- a/AzureDevOps.Authentication/Src/Adal.cs
+++ b/AzureDevOps.Authentication/Src/Adal.cs
@@ -134,7 +134,10 @@ namespace AzureDevOps.Authentication
 
                 return new Result(result);
             }
-            catch (ActiveDirectory.AdalException exception)
+            // We should just be able to catch AdalException here but due to an ADAL bug an HttpRequestException can be leaked:
+            // https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1285
+            // Until we update to ADAL 4.x or MSAL, we should just workaround this problem.
+            catch (Exception exception)
             {
                 throw new AuthenticationException(exception);
             }
@@ -164,7 +167,10 @@ namespace AzureDevOps.Authentication
 
                 return new Result(result);
             }
-            catch (ActiveDirectory.AdalException exception)
+            // We should just be able to catch AdalException here but due to an ADAL bug an HttpRequestException can be leaked:
+            // https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1285
+            // Until we update to ADAL 4.x or MSAL, we should just workaround this problem.
+            catch (Exception exception)
             {
                 throw new AuthenticationException(exception);
             }


### PR DESCRIPTION
Due to a bug in ADAL 3.x an `HttpRequestException` can leak instead of being a `AdalException`.

https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1285

ADAL 3.x is not going to patched for this as ADAL 4.x and MSAL do not have this problem. We can revisit this if we upgrade ADAL->4 or ->MSAL.

Fixes #827 