### PR TITLE
Add description about using GCM with WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ To use the GCM along with git installed with `pacman` in an MSYS2 environment, s
 git config --global credential.helper manager
 ```
 
+### Installation in a WSL Environment
+
+To use the GCM along with git inside the Windows Subsytem for Linux (WSL), install GCM using the [installer](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/releases).
+Assuming that GCM has been installed, for instance, in `C:\Program Files\gcmw-v1.16.2`, you can now configure git to use the GCM by invoking git as follows in WSL: 
+
+```shell
+git config --global credential.helper "/mnt/c/Program\ Files/gcmw-v1.16.2/git-credential-manager.exe"
+```
+
 ## How to use
 
 You don't. It [magically](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/issues/31) works when credentials are needed. For example, when pushing to [Azure DevOps](https://dev.azure.com), it automatically opens a window and initializes an oauth2 flow to get your token.


### PR DESCRIPTION
Using the same approach as for MSYS does not seem to work,
but git can be pointed to a installation of GCM in the Windows
directory tree.