### PR TITLE
Added support for storing PAT tokens to Azure KeyVault

### DIFF
--- a/AzureDevOps.Authentication/Proxy/AzureDevOps.Authentication.Proxy.csproj
+++ b/AzureDevOps.Authentication/Proxy/AzureDevOps.Authentication.Proxy.csproj
@@ -7,7 +7,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AzureDevOps.Authentication.Test</RootNamespace>
     <AssemblyName>AzureDevOps.Authentication.Proxy</AssemblyName>
-    <NuGetPackageImportStamp />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="..\..\Proxy.props" />
   <ItemGroup>
@@ -31,8 +34,8 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -56,7 +59,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/AzureDevOps.Authentication/Proxy/packages.config
+++ b/AzureDevOps.Authentication/Proxy/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net472" />
   <package id="Microsoft.Net.Compilers" version="2.8.0" targetFramework="net472" developmentDependency="true" />
   <package id="Moq" version="4.8.2" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net472" />
 </packages>

--- a/AzureDevOps.Authentication/Src/AzureDevOps.Authentication.csproj
+++ b/AzureDevOps.Authentication/Src/AzureDevOps.Authentication.csproj
@@ -10,7 +10,8 @@
     <ProjectGuid>{19770407-D7D8-4A37-914C-F552FF4B90D4}</ProjectGuid>
     <ProjectName>AzureDevOps.Authentication</ProjectName>
     <RootNamespace>AzureDevOps.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>
@@ -18,8 +19,8 @@
     <OutputPath>$(ProjectDir)$(OutputPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.4.11002, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.4\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.5.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.19.4.11002, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.4\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>

--- a/Bitbucket.Authentication/Proxy/Bitbucket.Authentication.Proxy.csproj
+++ b/Bitbucket.Authentication/Proxy/Bitbucket.Authentication.Proxy.csproj
@@ -7,7 +7,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Bitbucket.Authentication.Test</RootNamespace>
     <AssemblyName>Bitbucket.Authentication.Proxy</AssemblyName>
-    <NuGetPackageImportStamp />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="..\..\Proxy.props" />
   <ItemGroup>
@@ -31,8 +34,8 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Bitbucket.Authentication/Src/Bitbucket.Authentication.csproj
+++ b/Bitbucket.Authentication/Src/Bitbucket.Authentication.csproj
@@ -10,7 +10,8 @@
     <ProjectGuid>{EE663736-5BAD-4CA6-A4F8-99978925AD8A}</ProjectGuid>
     <ProjectName>Bitbucket.Authentication</ProjectName>
     <RootNamespace>Atlassian.Bitbucket.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>

--- a/Bitbucket.Authentication/Test/Bitbucket.Authentication.Test.csproj
+++ b/Bitbucket.Authentication/Test/Bitbucket.Authentication.Test.csproj
@@ -14,7 +14,10 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="..\..\test.props" />
   <PropertyGroup>

--- a/Cli/Manager/Cli-Manager.csproj
+++ b/Cli/Manager/Cli-Manager.csproj
@@ -6,7 +6,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>git-credential-manager</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <NuGetPackageImportStamp />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <OutputType>Exe</OutputType>
     <ProjectGuid>{19770407-63D4-40A8-A9DF-F1C4B473308A}</ProjectGuid>
     <ProjectName>Cli-Manager</ProjectName>
@@ -24,10 +25,25 @@
     <StartArguments Condition=" '$(StartArguments)' == '' OR '$(StartArguments)' == '*Undefined*' ">get</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Azure.Services.AppAuthentication, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\lib\net452\Microsoft.Azure.Services.AppAuthentication.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.5.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Bitbucket.Authentication\Src\Bitbucket.Authentication.csproj">
@@ -57,6 +73,9 @@
     <None Include="app.config">
       <InProject>false</InProject>
     </None>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -67,5 +86,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Net.Compilers.2.8.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Net.Compilers.2.8.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets" Condition="Exists('..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" />
 </Project>

--- a/Cli/Manager/app.config
+++ b/Cli/Manager/app.config
@@ -1,3 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.19.4.11002" newVersion="3.19.4.11002" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Cli/Manager/packages.config
+++ b/Cli/Manager/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Azure.Services.AppAuthentication" version="1.0.3" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.5.0" targetFramework="net452" />
   <package id="Microsoft.Net.Compilers" version="2.8.0" targetFramework="net452" developmentDependency="true" />
   <package id="Pandoc.Windows" version="2.1.0" developmentDependency="true" />
   <package id="Tools.InnoSetup" version="5.5.9" targetFramework="net452" />

--- a/Cli/Test/ProgramTests.cs
+++ b/Cli/Test/ProgramTests.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
 using Moq;
 using Xunit;
-using Azure = AzureDevOps.Authentication;
+using AzureDev = AzureDevOps.Authentication;
 using Git = Microsoft.Alm.Authentication.Git;
 
 namespace Microsoft.Alm.Cli.Test
@@ -108,7 +108,7 @@ namespace Microsoft.Alm.Cli.Test
 
             Assert.NotNull(opargs.DevOpsTokenScope);
 
-            var expectedScope = Azure.TokenScope.BuildAccess | Azure.TokenScope.CodeWrite;
+            var expectedScope = AzureDev.TokenScope.BuildAccess | AzureDev.TokenScope.CodeWrite;
             Assert.Equal(expectedScope, opargs.DevOpsTokenScope);
         }
 

--- a/Cli/Test/app.config
+++ b/Cli/Test/app.config
@@ -10,6 +10,18 @@
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.19.4.11002" newVersion="3.19.4.11002" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/GitHub.Authentication/Proxy/GitHub.Authentication.Proxy.csproj
+++ b/GitHub.Authentication/Proxy/GitHub.Authentication.Proxy.csproj
@@ -31,8 +31,8 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/GitHub.Authentication/Src/GitHub.Authentication.csproj
+++ b/GitHub.Authentication/Src/GitHub.Authentication.csproj
@@ -12,7 +12,7 @@
     <ProjectName>GitHub.Authentication</ProjectName>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>GitHub.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>

--- a/GitHub.Authentication/Test/AuthenticationTests.cs
+++ b/GitHub.Authentication/Test/AuthenticationTests.cs
@@ -27,7 +27,7 @@ namespace GitHub.Authentication.Test
                 new Authentication.AcquireAuthenticationCodeDelegate(prompts.AuthenticationCodeModalPrompt),
                 null);
 
-            await authentication.SetCredentials(new Uri(writeUriString), new Credential("haacked"));
+            await authentication.SetCredentials(new Uri(writeUriString), new Credential("haacked", string.Empty));
             var credentials = await authentication.GetCredentials(retrieveUri);
             Assert.Equal("haacked", credentials.Username);
         }
@@ -48,7 +48,7 @@ namespace GitHub.Authentication.Test
                 new Authentication.AcquireAuthenticationCodeDelegate(prompts.AuthenticationCodeModalPrompt),
                 null);
 
-            await authentication.SetCredentials(new Uri("https://github.com/"), new Credential("haacked"));
+            await authentication.SetCredentials(new Uri("https://github.com/"), new Credential("haacked", string.Empty));
 
             Assert.Null(await authentication.GetCredentials(retrieveUri));
         }

--- a/Microsoft.Alm.Authentication/Proxy/Microsoft.Alm.Authentication.Proxy.csproj
+++ b/Microsoft.Alm.Authentication/Proxy/Microsoft.Alm.Authentication.Proxy.csproj
@@ -23,8 +23,8 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Microsoft.Alm.Authentication/Src/Credential.cs
+++ b/Microsoft.Alm.Authentication/Src/Credential.cs
@@ -42,24 +42,16 @@ namespace Microsoft.Alm.Authentication
         /// <summary>
         /// Creates a credential object with a username and password pair.
         /// </summary>
-        /// <param name="username">The username value of the `<see cref="Credential"/>`.</param>
-        /// <param name="password">The password value of the `<see cref="Credential"/>`.</param>
-        public Credential(string username, string password)
+        /// <param name="Username">The username value of the `<see cref="Credential"/>`.</param>
+        /// <param name="Password">The password value of the `<see cref="Credential"/>`.</param>
+        public Credential(string Username, string Password)
         {
-            if (username is null)
-                throw new ArgumentNullException(nameof(username));
+            if (Username is null)
+                throw new ArgumentNullException(nameof(Username));
 
-            _password = password ?? string.Empty;
-            _username = username;
+            _password = Password ?? string.Empty;
+            _username = Username;
         }
-
-        /// <summary>
-        /// Creates a credential object with only a username.
-        /// </summary>
-        /// <param name="username">The username value of the `<see cref="Credential"/>`.</param>
-        public Credential(string username)
-            : this(username, string.Empty)
-        { }
 
         private readonly string _password;
         private readonly string _username;

--- a/Microsoft.Alm.Authentication/Src/KeyVaultHelper.cs
+++ b/Microsoft.Alm.Authentication/Src/KeyVaultHelper.cs
@@ -1,0 +1,256 @@
+﻿//------------------------------------------------------------------------------
+// <copyright company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Microsoft.Azure.KeyVault.Helper
+{
+    /// <summary>
+    /// This class provides access to secrets stored in the KeyVault
+    /// </summary>
+    public sealed class KeyVaultHelper : IDisposable
+    {
+        public struct Config
+        {
+            public string CertificateThumbprint { get; set; }
+            public string CertificateStoreType { get; set; }
+            public string KeyVaultUrl { get; set; }
+            public string ClientId { get; set; }
+            public bool? UseMsi { get; set; }
+        }
+
+        private static KeyVaultHelper _instance = null;
+        private static KeyVaultHelper.Config _config;
+
+        private readonly string _keyVaultUrl;
+        private readonly string _clientId;
+        private readonly string _certificateThumbprint;
+        private readonly StoreLocation _storeLocation;
+        private readonly bool? _useMsi;
+        private readonly KeyVaultClient _keyVaultClient;
+        private string _accessToken;
+        private DateTimeOffset _expiration;
+
+        private KeyVaultHelper()
+        {
+            _keyVaultUrl = _config.KeyVaultUrl;
+            if (string.IsNullOrWhiteSpace(_keyVaultUrl))
+            {
+                throw new KeyVaultHelperConfigurationException("KeyVault URL is not set in the git config file");
+            }
+
+            _useMsi = _config.UseMsi;
+            if (!_useMsi.HasValue)
+            {
+                 _useMsi = false;
+            }
+
+            // using MSI (Managed Service Identity) method of authentication means we dont need any service principal arguments - appId, certificate or cert store
+            if (_useMsi == true)
+            {
+                var azureServiceTokenProvider = new AzureServiceTokenProvider();
+                _keyVaultClient = new KeyVaultClient(
+                    new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
+            }
+            else
+            {
+                _certificateThumbprint = _config.CertificateThumbprint;
+                if (string.IsNullOrWhiteSpace(_certificateThumbprint))
+                {
+                    throw new KeyVaultHelperConfigurationException("Certificate thumbprint is required for Azure AD application authentication. Please set KeyVaultAuthCertificateThumbprint setting in the git config file");
+                }
+                _certificateThumbprint = _certificateThumbprint.Replace(" ", "").Trim();
+
+                string certificateStoreType = _config.CertificateStoreType;
+                if (string.IsNullOrWhiteSpace(certificateStoreType))
+                {
+                    throw new KeyVaultHelperConfigurationException("Certificate store type (CurrentUser or LocalMachine) is required for KeyVault access. Please set KeyVaultAuthCertificateStoreType setting in the git config file");
+                }
+
+                if (!Enum.TryParse(certificateStoreType, true, out _storeLocation))
+                    throw new KeyVaultHelperConfigurationException("Invalid certificate store type in git config file:" + certificateStoreType);
+
+                _clientId = _config.ClientId;
+                if (string.IsNullOrWhiteSpace(_clientId))
+                {
+                    throw new KeyVaultHelperConfigurationException("Client Id (applicationID) for KeyVault App is not set in the git config file");
+                }
+
+                _keyVaultClient = new KeyVaultClient(GetAccessToken);
+            }
+        }
+
+        public static void Configure(KeyVaultHelper.Config config)
+        {
+            // validate and clean up config
+            if (string.IsNullOrWhiteSpace(config.KeyVaultUrl))
+            {
+                throw new KeyVaultHelperConfigurationException("KeyVault URL is not set in the git config file");
+            }
+
+            config.KeyVaultUrl = config.KeyVaultUrl.Trim();
+
+            // if msi is not specified or value is false retrieve the cert details
+            if (config.UseMsi != true)
+            {
+                if (string.IsNullOrWhiteSpace(config.CertificateThumbprint))
+                {
+                    throw new KeyVaultHelperConfigurationException("Certificate thumbprint is required for Azure AD application authentication. Please set KeyVaultAuthCertificateThumbprint setting in the git config file");
+                }
+
+                config.CertificateThumbprint = config.CertificateThumbprint.Replace(" ", "").Trim();
+
+                if (string.IsNullOrWhiteSpace(config.CertificateStoreType))
+                {
+                    throw new KeyVaultHelperConfigurationException("Certificate store type (CurrentUser or LocalMachine) is required for KeyVault access. Please set KeyVaultAuthCertificateStoreType setting in the git config file");
+                }
+
+                config.CertificateStoreType = config.CertificateStoreType.Trim();
+                StoreLocation storeLocation;
+                if (!Enum.TryParse(config.CertificateStoreType, true, out storeLocation))
+                    throw new KeyVaultHelperConfigurationException("Invalid certificate store type in the git config file:" + config.CertificateStoreType);
+
+                if (string.IsNullOrWhiteSpace(config.ClientId))
+                {
+                    throw new KeyVaultHelperConfigurationException("Client Id (applicationID) for KeyVault App is not set in the git config file");
+                }
+                config.ClientId = config.ClientId.Trim();
+            }
+            _config = config;
+        }
+
+        public static KeyVaultHelper KeyVault
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = new KeyVaultHelper();
+                return _instance;
+            }
+        }
+
+        public async Task<string> GetSecretAsync(string secretName)
+        {
+            if (string.IsNullOrEmpty(secretName))
+            {
+                throw new ArgumentNullException("secretName");
+            }
+
+            string fixedSecretName = FixSecretName(secretName);
+
+            var secret = await _keyVaultClient.GetSecretAsync(_keyVaultUrl, fixedSecretName).ConfigureAwait(false);
+
+            return secret.Value;
+        }
+
+        public async Task<string> SetSecretAsync(string secretName, string secretValue)
+        {
+            if (string.IsNullOrEmpty(secretName))
+            {
+                throw new ArgumentNullException("secretName");
+            }
+            // KeyVault doesn't allow dots in key name, allows only alphanumeric and dashes. Replace dots with dash
+            string fixedSecretName = FixSecretName(secretName);
+
+            var secret = await _keyVaultClient.SetSecretAsync(_keyVaultUrl, fixedSecretName, secretValue);
+            return secret.Value;
+        }
+
+        public async Task<string> DeleteSecretAsync(string secretName)
+        {
+            if (string.IsNullOrEmpty(secretName))
+            {
+                throw new ArgumentNullException("secretName");
+            }
+            // KeyVault doesn't allow dots in key name, allows only alphanumeric and dashes. Replace dots with dash
+            string fixedSecretName = FixSecretName (secretName);
+
+            var deletedSecretResult = await _keyVaultClient.DeleteSecretAsync(_keyVaultUrl, fixedSecretName);
+            return deletedSecretResult.Value;
+        }
+
+        private static string FixSecretName (string secretName)
+        {
+            // KeyVault doesn't allow dots or slashes in key name, allows only alphanumeric and dashes. Replace dots and slashes with dash
+            return secretName.Replace('.', '-').Replace('/', '-').Replace(' ', '-'); ;
+        }
+        private async Task<string> GetAccessToken(string authority, string resource, string scope)
+        {
+            // get new token if needed or current token expires soon
+            if (_accessToken == null || 
+                _expiration == null || 
+                _expiration.UtcDateTime > DateTime.Now.AddMinutes(1).ToUniversalTime())
+            {
+                var context = new AuthenticationContext(authority);
+                var cert = RetrieveCertificate();
+                var clientAssertionCertificate = new ClientAssertionCertificate(_clientId, cert);
+
+                var result = await context.AcquireTokenAsync(resource, clientAssertionCertificate);
+                _expiration = result.ExpiresOn;
+                _accessToken = result.AccessToken;
+            }
+            return _accessToken;
+        }
+
+        private X509Certificate2 RetrieveCertificate()
+        {
+            X509Store certStore = null;
+            try
+            {
+                certStore = new X509Store(_storeLocation);
+                certStore.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
+                var userCertCollection = certStore.Certificates.Find(X509FindType.FindByThumbprint, _certificateThumbprint, false);
+
+                if (userCertCollection?.Count == 0)
+                {
+                    throw new KeyVaultHelperConfigurationException(
+                        $"Certificate with thumbprint '{_certificateThumbprint}' not found in store '{certStore.Location}/{certStore.Name}'");
+                }
+                return userCertCollection[0];
+            }
+            catch (KeyVaultHelperConfigurationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new KeyVaultHelperConfigurationException(
+                    $"An error occurred accessing the '{_storeLocation}' certificate store.", ex);
+            }
+            finally
+            {
+                certStore?.Close();
+            }
+        }
+
+        // Implement IDisposable.
+        public void Dispose()
+        {
+            Dispose(true);
+            // This object will be cleaned up by the Dispose method.
+            GC.SuppressFinalize(this);
+        }
+
+        public void Dispose(bool disposing)
+        {
+            // Check to see if Dispose has already been called.
+            if (_keyVaultClient != null && _instance != null)
+            {
+                // If disposing equals true, dispose all managed
+                // and unmanaged resources.
+                if (disposing)
+                {
+                    _keyVaultClient.Dispose();
+                }
+            }
+            _instance = null;
+        }
+    }
+}

--- a/Microsoft.Alm.Authentication/Src/KeyVaultHelperConfigurationException.cs
+++ b/Microsoft.Alm.Authentication/Src/KeyVaultHelperConfigurationException.cs
@@ -1,0 +1,29 @@
+﻿// ------------------------------------------------------------------------------
+//  <copyright company="Microsoft Corporation">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+//  </copyright>
+// ------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Azure.KeyVault.Helper
+{
+    /// <summary>
+    /// This exception is thrown when KeyVaultHelper class can't read configuration from 
+    /// config file or can't access cerificate store and retrieve certificate for KeyVault access.
+    /// </summary>
+    [Serializable]
+    public class KeyVaultHelperConfigurationException : Exception
+    {
+        public KeyVaultHelperConfigurationException(string message)
+            : base(message)
+        {
+        }
+
+        public KeyVaultHelperConfigurationException(string message, Exception ex)
+            : base(message + "  See inner exception for details.", ex)
+        {
+        }
+    }
+
+}

--- a/Microsoft.Alm.Authentication/Src/KeyVaultSecretStore.cs
+++ b/Microsoft.Alm.Authentication/Src/KeyVaultSecretStore.cs
@@ -1,0 +1,220 @@
+﻿/**** Git Credential Manager for Windows ****
+ *
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the """"Software""""), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+**/
+
+using Newtonsoft.Json;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault.Helper;
+
+namespace Microsoft.Alm.Authentication
+{
+    public class KeyVaultSecretStore : ICredentialStore
+    {
+        private readonly RuntimeContext _context;
+        private Secret.UriNameConversionDelegate _getTargetName;
+        private readonly string _namespace;
+        private readonly ICredentialStore _credentialCache;
+
+        protected Git.ITrace Trace
+            => _context.Trace;
+
+        public KeyVaultSecretStore(RuntimeContext context,
+            string @namespace,
+            string keyVaultUrl,
+            bool? useMsi,
+            string certAuthStoreType,
+            string certAuthThumbprint,
+            string certAuthClientId) :
+                this (context, @namespace, null, keyVaultUrl, useMsi, certAuthStoreType, certAuthThumbprint, certAuthClientId, null)
+        { }
+
+        public KeyVaultSecretStore(RuntimeContext context, 
+            string @namespace,
+            ICredentialStore credentialCache,
+            string keyVaultUrl, 
+            bool? useMsi,
+            string certAuthStoreType, 
+            string certAuthThumbprint, 
+            string certAuthClientId, 
+            Secret.UriNameConversionDelegate getTargetName)
+        {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+            _context = context;
+
+            if (@namespace is null)
+                throw new ArgumentNullException(nameof(@namespace));
+
+            if (@namespace.IndexOfAny(BaseSecureStore.IllegalCharacters) != -1)
+            {
+                var inner = new FormatException("Namespace contains illegal characters.");
+                throw new ArgumentException(inner.Message, nameof(@namespace), inner);
+            }
+
+            _getTargetName = getTargetName ?? Secret.UriToName;
+
+            _namespace = @namespace;
+            _credentialCache = credentialCache ?? new SecretCache(context, @namespace, _getTargetName);
+            this._getTargetName = getTargetName;
+
+            KeyVaultHelper.Config config = new KeyVaultHelper.Config()
+            {
+                KeyVaultUrl = keyVaultUrl,
+                UseMsi = useMsi,
+                CertificateThumbprint = certAuthThumbprint,
+                CertificateStoreType = certAuthStoreType,
+                ClientId = certAuthClientId
+            };
+
+            KeyVaultHelper.Configure(config);
+        }
+        public string Namespace
+        {
+            get { return _namespace; }
+        }
+
+        public Secret.UriNameConversionDelegate UriNameConversion
+        {
+            get { return _getTargetName; }
+            set
+            {
+                if (value is null)
+                    throw new ArgumentNullException(nameof(UriNameConversion));
+
+                _getTargetName = value;
+            }
+        }
+
+        public async Task<bool> DeleteCredentials(TargetUri targetUri)
+        {
+#if DEBUG
+            Trace.WriteLine($"targetUri: '{targetUri}': Key: '{GetKeyVaultKey(targetUri)}'");
+#endif
+
+            if (targetUri is null || string.IsNullOrEmpty(targetUri.Host))
+                throw new ArgumentNullException(nameof(targetUri));
+
+            string secret = null;
+            try
+            {
+                secret = await KeyVaultHelper.KeyVault.DeleteSecretAsync(GetKeyVaultKey(targetUri));
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine("Exception deleting the secret from KeyVault:" + ex.Message);
+            }
+
+            return string.IsNullOrEmpty(secret) 
+                && await _credentialCache.DeleteCredentials(targetUri);
+        }
+
+        public async Task<Credential> ReadCredentials(TargetUri targetUri)
+        {
+#if DEBUG
+            Trace.WriteLine($"targetUri: '{targetUri}': Key: '{GetKeyVaultKey(targetUri)}'");
+#endif
+            if (targetUri is null || string.IsNullOrEmpty(targetUri.Host))
+                throw new ArgumentNullException(nameof(targetUri));
+
+            return await _credentialCache.ReadCredentials(targetUri)
+            ?? await this.ReadKeyVaultCredentials(targetUri);
+        }
+
+        public async Task<bool> WriteCredentials(TargetUri targetUri, Credential credentials)
+        {
+#if DEBUG
+            Trace.WriteLine($"targetUri: '{targetUri}', userName: '{credentials?.Username}' PAT: '{credentials?.Password}',  : Key: '{GetKeyVaultKey(targetUri)}'");
+#endif
+            if (targetUri is null || string.IsNullOrEmpty (targetUri.Host))
+                throw new ArgumentNullException(nameof(targetUri));
+
+            if (credentials is null)
+                throw new ArgumentNullException(nameof(credentials));
+            return await WriteKeyVaultCredentials(targetUri, credentials)
+                && await _credentialCache.WriteCredentials(targetUri, credentials);
+        }
+
+        private async Task<Credential> ReadKeyVaultCredentials(TargetUri targetUri)
+        {
+            string secret = null;
+            try
+            {
+                secret = await KeyVaultHelper.KeyVault.GetSecretAsync(GetKeyVaultKey(targetUri));
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine("Exception getting the secret from KeyVault:" + ex.Message);
+            }
+
+            if (string.IsNullOrEmpty(secret))
+            {
+                return null;
+            }
+
+            // parse secret from JSon
+            try
+            {
+                Credential credential = JsonConvert.DeserializeObject<Credential>(secret);
+                return credential;
+            }
+            catch (JsonException)
+            {
+                Trace.WriteLine("Keyvault secret doesn't contain Json value, returning as is");
+                return new Credential("PersonalAccessToken", secret);
+            }
+        }
+
+        private async Task<bool> WriteKeyVaultCredentials(TargetUri targetUri, Credential credentials)
+        {
+            string secret = "{ \"Username\" : \"" + credentials.Username + "\", \"Password\" : \"" + credentials.Password + "\", \"Message\" : \"\" }";
+            try
+            {
+                await KeyVaultHelper.KeyVault.SetSecretAsync(GetKeyVaultKey(targetUri), secret);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine("Exception writing a secret to KeyVault:" + ex.Message);
+            }
+            return false;
+        }
+
+        private static string GetKeyVaultKey (TargetUri targetUri)
+        {
+            string path = null;
+
+            if (targetUri.HasPath && !string.IsNullOrEmpty(targetUri.AbsolutePath))
+                path = targetUri.Host + targetUri.AbsolutePath;
+            else if (targetUri.ContainsUserInfo && !string.IsNullOrEmpty(targetUri.UserInfo))
+                path = targetUri.UserInfo + "-" + targetUri.Host;
+            else
+                path = targetUri.Host;
+
+            string key = path.Replace('.', '-').Replace('/', '-').Replace(' ', '-');
+            return key;
+        }
+
+    }
+}

--- a/Microsoft.Alm.Authentication/Src/Microsoft.Alm.Authentication.csproj
+++ b/Microsoft.Alm.Authentication/Src/Microsoft.Alm.Authentication.csproj
@@ -5,12 +5,14 @@
   <PropertyGroup>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>Microsoft.Alm.Authentication</AssemblyName>
-    <NuGetPackageImportStamp />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <OutputType>Library</OutputType>
     <ProjectGuid>{19770407-B493-459D-BB4F-04FBEFB1BA13}</ProjectGuid>
     <ProjectName>Microsoft.Alm.Authentication</ProjectName>
     <RootNamespace>Microsoft.Alm.Authentication</RootNamespace>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="..\..\build.props" />
   <PropertyGroup>
@@ -18,16 +20,56 @@
     <OutputPath>$(ProjectDir)$(OutputPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hyak.Common.1.2.2\lib\net452\Hyak.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Common, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Common.2.2.1\lib\net452\Microsoft.Azure.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.3.0.3\lib\net452\Microsoft.Azure.KeyVault.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.WebKey, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.WebKey.3.0.3\lib\net452\Microsoft.Azure.KeyVault.WebKey.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Services.AppAuthentication, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\lib\net452\Microsoft.Azure.Services.AppAuthentication.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.4.5.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.18\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.18\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Base.cs" />
     <Compile Include="IRuntimeService.cs" />
+    <Compile Include="KeyVaultHelper.cs" />
+    <Compile Include="KeyVaultHelperConfigurationException.cs" />
+    <Compile Include="KeyVaultSecretStore.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="ISecretStore.cs" />
     <Compile Include="Storage.cs" />
@@ -63,8 +105,10 @@
     <Compile Include="WwwAuthenticateHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config"/>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\..\Shared\Win32\Microsoft.Alm.Win32.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -74,5 +118,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Net.Compilers.2.8.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Net.Compilers.2.8.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets" Condition="Exists('..\..\packages\Microsoft.Azure.Services.AppAuthentication.1.0.3\build\Microsoft.Azure.Services.AppAuthentication.targets')" />
 </Project>

--- a/Microsoft.Alm.Authentication/Src/app.config
+++ b/Microsoft.Alm.Authentication/Src/app.config
@@ -4,8 +4,12 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/Microsoft.Alm.Authentication/Src/packages.config
+++ b/Microsoft.Alm.Authentication/Src/packages.config
@@ -1,4 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Hyak.Common" version="1.2.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Common" version="2.2.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault" version="3.0.3" targetFramework="net472" />
+  <package id="Microsoft.Azure.KeyVault.WebKey" version="3.0.3" targetFramework="net472" />
+  <package id="Microsoft.Azure.Services.AppAuthentication" version="1.0.3" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.5.0" targetFramework="net452" />
   <package id="Microsoft.Net.Compilers" version="2.8.0" targetFramework="net451" developmentDependency="true" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.18" targetFramework="net472" />
+  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.18" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
 </packages>

--- a/Microsoft.Alm.Authentication/Test/app.config
+++ b/Microsoft.Alm.Authentication/Test/app.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.18.0.0" newVersion="2.18.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />

--- a/Shared/Cli/OperationArguments.cs
+++ b/Shared/Cli/OperationArguments.cs
@@ -30,7 +30,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
 using static System.Globalization.CultureInfo;
-using Azure = AzureDevOps.Authentication;
+using AzureDev = AzureDevOps.Authentication;
 using Git = Microsoft.Alm.Authentication.Git;
 
 namespace Microsoft.Alm.Cli
@@ -69,7 +69,7 @@ namespace Microsoft.Alm.Cli
         private Git.Configuration _configuration;
         private Credential _credentials;
         private string _customNamespace;
-        private Azure.TokenScope _devopsTokenScope;
+        private AzureDev.TokenScope _devopsTokenScope;
         private Dictionary<string, string> _environmentVariables;
         private string _gitRemoteHttpCommandLine;
         private Interactivity _interactivity;
@@ -128,7 +128,7 @@ namespace Microsoft.Alm.Cli
         /// <para/>
         /// Default value is `<seealso cref="Program.DevOpsCredentialScope"/>`.
         /// </summary>
-        public virtual Azure.TokenScope DevOpsTokenScope
+        public virtual AzureDev.TokenScope DevOpsTokenScope
         {
             get { return _devopsTokenScope; }
             set { _devopsTokenScope = value; }
@@ -445,6 +445,20 @@ namespace Microsoft.Alm.Cli
             set { _writeLog = value; }
         }
 
+        /// <summary>
+        /// KeyVaultUrl for storing credentials and PAT tokens in KeyVault. 
+        /// If specified, KeyVault is used as a storage mechanism for secrets.
+        /// </summary>
+        public virtual string KeyVaultUrl { get; set; }
+
+        public virtual bool? KeyVaultUseMsi { get; set; }
+
+        public virtual string KeyVaulyAuthCertificateStoreType { get; set; }
+
+        public virtual string KeyVaultAuthCertificateThumbprint { get; set; }
+
+        public virtual string KeyVaultAuthClientId { get; set; }
+
         internal string DebuggerDisplay
         {
             get { return $"{nameof(OperationArguments)}: TargetUri: {TargetUri}, Authority: {Authority}, Credentials: {Credentials}"; }
@@ -655,20 +669,29 @@ namespace Microsoft.Alm.Cli
                    .Append(_queryPath ?? string.Empty)
                    .Append('\n');
 
-            // Only write out username if we know it.
-            if (_credentials?.Username != null)
+            if (_credentials == null)
             {
                 builder.Append("username=")
-                       .Append(_credentials.Username)
-                       .Append('\n');
+                   .Append(_username ?? string.Empty)
+                   .Append('\n');
             }
-
-            // Only write out password if we know it.
-            if (_credentials?.Password != null)
+            else
             {
-                builder.Append("password=")
-                       .Append(_credentials.Password)
-                       .Append('\n');
+                // Only write out username if we know it.
+                if (_credentials.Username != null)
+                {
+                    builder.Append("username=")
+                           .Append(_credentials.Username)
+                           .Append('\n');
+                }
+
+                // Only write out password if we know it.
+                if (_credentials.Password != null)
+                {
+                    builder.Append("password=")
+                           .Append(_credentials.Password)
+                           .Append('\n');
+                }
             }
 
             builder.Append('\n');

--- a/Shared/Cli/Program.cs
+++ b/Shared/Cli/Program.cs
@@ -32,7 +32,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Alm.Authentication;
-using Azure = AzureDevOps.Authentication;
+using AzureDev = AzureDevOps.Authentication;
 using Bitbucket = Atlassian.Bitbucket.Authentication;
 using Git = Microsoft.Alm.Authentication.Git;
 using Github = GitHub.Authentication;
@@ -61,6 +61,11 @@ namespace Microsoft.Alm.Cli
         ParentHwnd,
         VstsScope,
         Writelog,
+        KeyVaultUrl,
+        KeyVaultUseMsi,
+        KeyVaultAuthCertificateThumbprint,
+        KeyVaultAuthCertificateStoreType,
+        KeyVaultAuthClientId
     }
 
     partial class Program
@@ -79,7 +84,7 @@ namespace Microsoft.Alm.Cli
         internal const string ConfigPrefix = "credential";
         internal const string SecretsNamespace = "git";
 
-        internal static readonly Azure.TokenScope DevOpsCredentialScope = Azure.TokenScope.CodeWrite | Azure.TokenScope.PackagingRead;
+        internal static readonly AzureDev.TokenScope DevOpsCredentialScope = AzureDev.TokenScope.CodeWrite | AzureDev.TokenScope.PackagingRead;
         internal static readonly Github.TokenScope GitHubCredentialScope = Github.TokenScope.Gist | Github.TokenScope.Repo;
 
         internal BasicCredentialPromptDelegate _basicCredentialPrompt = ConsoleFunctions.CredentialPrompt;
@@ -135,6 +140,11 @@ namespace Microsoft.Alm.Cli
             { KeyType.Validate, "validate" },
             { KeyType.VstsScope,"vstsScope" },
             { KeyType.Writelog, "writeLog" },
+            { KeyType.KeyVaultUrl, "keyvaultUrl" },
+            { KeyType.KeyVaultUseMsi, "keyVaultUseMsi" },
+            { KeyType.KeyVaultAuthCertificateStoreType, "keyvaultAuthCertificateStoreType" },
+            { KeyType.KeyVaultAuthCertificateThumbprint, "keyvaultAuthCertificateThumbprint" },
+            { KeyType.KeyVaultAuthClientId, "keyvaultAuthClientId" },
         };
         internal readonly Dictionary<KeyType, string> _environmentKeys = new Dictionary<KeyType, string>()
         {

--- a/azure-pipelines-1.yml
+++ b/azure-pipelines-1.yml
@@ -1,0 +1,38 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+
+pool:
+  vmImage: 'windows-latest'
+
+steps:
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Host "Build.BuildUri:" $(Build.BuildUri)
+      Write-Host "System.CollectionUri:" $(System.CollectionUri)
+      Write-Host "System.TeamFoundationCollectionUri:" $(System.TeamFoundationCollectionUri)
+      Write-Host "Build.Repository.Uri:" $(Build.Repository.Uri)
+      Write-Host "Build Source Directory:" $(Build.SourcesDirectory)
+- task: UseDotNet@2
+  inputs:
+    packageType: 'runtime'
+    version: '3.1.x'
+
+- task: NuGetCommand@2
+  displayName: NuGet restore
+  inputs:
+    restoreSolution: 'GitCredentialManager.sln'
+    verbosityRestore: 'quiet'
+
+- task: MSBuild@1
+  displayName: 'Core Build'
+  inputs:
+    solution: "GitCredentialManager.sln"
+    msbuildArguments: /nologo "/binaryLogger:$(Build.SourcesDirectory)/$(build.buildNumber).binlog"
+    platform: 'Any CPU'
+    configuration: 'Debug'
+    maximumCpuCount: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@
 
 
 pool:
-  vmImage: 'Hosted VS2017'
+  vmImage: 'windows-latest'
 
 steps:
 - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,11 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- main
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'Hosted VS2017'
 
 steps:
 - task: PowerShell@2
@@ -23,7 +21,18 @@ steps:
   inputs:
     packageType: 'runtime'
     version: '3.1.x'
+
 - task: NuGetCommand@2
+  displayName: NuGet restore
   inputs:
-    command: 'custom'
-    arguments: 'install microsoft.codeql.full.linux -prerelease -OutputDirectory $(System.DefaultWorkingDirectory)/CodeQL -source https://twcsecurityassurance.pkgs.visualstudio.com/_packaging/SemmleDistribution/nuget/v3/index.json -NonInteractive'
+    restoreSolution: 'GitCredentialManager.sln'
+    verbosityRestore: 'quiet'
+
+- task: MSBuild@1
+  displayName: 'Core Build'
+  inputs:
+    solution: "GitCredentialManager.sln"
+    msbuildArguments: /nologo /verbosity:$(Build.Verbosity) "/binaryLogger:$(Build.SourcesDirectory)/$(build.buildNumber).binlog"
+    platform: '$(Build.Platform)'
+    configuration: '$(Build.Configuration)'
+    maximumCpuCount: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,8 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'runtime'
-    version: '3.1.201'
-- task: Semmle@1
+    version: '3.1.x'
+- task: NuGetCommand@2
   inputs:
-    sourceCodeDirectory: '$(Build.SourcesDirectory)'
-    language: 'csharp'
-    querySuite: 'Recommended'
-    timeout: '1800'
-    ram: '16384'
-    addProjectDirToScanningExclusionList: true
+    command: 'custom'
+    arguments: 'install microsoft.codeql.full.win64 -source https://twcsecurityassurance.pkgs.visualstudio.com/_packaging/SemmleDistribution/nuget/v3/index.json'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,4 +20,34 @@ steps:
       Write-Host "System.CollectionUri:" $env:System_CollectionUri
       Write-Host "System.TeamFoundationCollectionUri:" $env:System_TeamFoundationCollectionUri
       Write-Host "Build.Repository.Uri:" $env:Build_Repository_Uri
-      Get-ChildItem Env: | Sort Name
+      #Validate as per https://tools.ietf.org/html/rfc7519
+      
+      $token = $env:SYSTEM_ACCESSTOKEN
+      #Access and ID tokens are fine, Refresh tokens will not work
+      if (!$token.Contains(".") -or !$token.StartsWith("eyJ")) { Write-Error "Invalid token - not JWT" -ErrorAction Stop }
+  
+      #Header
+      $tokenheader = $token.Split(".")[0].Replace('-', '+').Replace('_', '/')
+      #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
+      while ($tokenheader.Length % 4) { Write-Verbose "Invalid length for a Base-64 char array or string, adding ="; $tokenheader += "=" }
+      Write-Verbose "Base64 encoded (padded) header:"
+      Write-Verbose $tokenheader
+      #Convert from Base64 encoded string to PSObject all at once
+      Write-Verbose "Decoded header:"
+      [System.Text.Encoding]::ASCII.GetString([system.convert]::FromBase64String($tokenheader)) | ConvertFrom-Json | fl | Out-Default
+  
+      #Payload
+      $tokenPayload = $token.Split(".")[1].Replace('-', '+').Replace('_', '/')
+      #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
+      while ($tokenPayload.Length % 4) { Write-Verbose "Invalid length for a Base-64 char array or string, adding ="; $tokenPayload += "=" }
+      Write-Verbose "Base64 encoded (padded) payoad:"
+      Write-Verbose $tokenPayload
+      #Convert to Byte array
+      $tokenByteArray = [System.Convert]::FromBase64String($tokenPayload)
+      #Convert to string array
+      $tokenArray = [System.Text.Encoding]::ASCII.GetString($tokenByteArray)
+      Write-Verbose "Decoded array in JSON format:"
+      Write-Verbose $tokenArray
+      #Convert from JSON to PSObject
+      $tokobj = $tokenArray | ConvertFrom-Json
+      Write-Verbose "Decoded Payload:"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ steps:
       Write-Host "System.TeamFoundationCollectionUri:" $(System.TeamFoundationCollectionUri)
       Write-Host "Build.Repository.Uri:" $(Build.Repository.Uri)
       Write-Host "Build Source Directory:" $(Build.SourcesDirectory)
+      java --version
 - task: UseDotNet@2
   inputs:
     packageType: 'runtime'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,4 +26,4 @@ steps:
 - task: NuGetCommand@2
   inputs:
     command: 'custom'
-    arguments: 'install microsoft.codeql.full.linux -prerelease -OutputDirectory $(System.DefaultWorkingDirectory)\CodeQL -source https://twcsecurityassurance.pkgs.visualstudio.com/_packaging/SemmleDistribution/nuget/v3/index.json -NonInteractive'
+    arguments: 'install microsoft.codeql.full.linux -prerelease -OutputDirectory $(System.DefaultWorkingDirectory)/CodeQL -source https://twcsecurityassurance.pkgs.visualstudio.com/_packaging/SemmleDistribution/nuget/v3/index.json -NonInteractive'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,6 @@ steps:
   inputs:
     solution: "GitCredentialManager.sln"
     msbuildArguments: /nologo "/binaryLogger:$(Build.SourcesDirectory)/$(build.buildNumber).binlog"
-    platform: '$(Build.Platform)'
-    configuration: '$(Build.Configuration)'
+    platform: 'AnyCPU'
+    configuration: 'Debug'
     maximumCpuCount: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,37 +18,11 @@ steps:
       Write-Host "System.CollectionUri:" $env:System_CollectionUri
       Write-Host "System.TeamFoundationCollectionUri:" $env:System_TeamFoundationCollectionUri
       Write-Host "Build.Repository.Uri:" $env:Build_Repository_Uri
-      #Validate as per https://tools.ietf.org/html/rfc7519
-      
-      $token = $env:SYSTEM_ACCESSTOKEN
-      #Access and ID tokens are fine, Refresh tokens will not work
-      if (!$token.Contains(".") -or !$token.StartsWith("eyJ")) { Write-Error "Invalid token - not JWT" -ErrorAction Stop }
-  
-      #Header
-      $tokenheader = $token.Split(".")[0].Replace('-', '+').Replace('_', '/')
-      #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
-      while ($tokenheader.Length % 4) { Write-Verbose "Invalid length for a Base-64 char array or string, adding ="; $tokenheader += "=" }
-      Write-Verbose "Base64 encoded (padded) header:"
-      Write-Verbose $tokenheader
-      #Convert from Base64 encoded string to PSObject all at once
-      Write-Host "Decoded header:"
-      [System.Text.Encoding]::ASCII.GetString([system.convert]::FromBase64String($tokenheader)) | ConvertFrom-Json | fl | Out-Default
-  
-      #Payload
-      $tokenPayload = $token.Split(".")[1].Replace('-', '+').Replace('_', '/')
-      #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
-      while ($tokenPayload.Length % 4) { Write-Verbose "Invalid length for a Base-64 char array or string, adding ="; $tokenPayload += "=" }
-      Write-Host "Base64 encoded (padded) payoad:"
-      Write-Host $tokenPayload
-      #Convert to Byte array
-      $tokenByteArray = [System.Convert]::FromBase64String($tokenPayload)
-      #Convert to string array
-      $tokenArray = [System.Text.Encoding]::ASCII.GetString($tokenByteArray)
-      Write-Host "Decoded array in JSON format:"
-      Write-Host $tokenArray
-      #Convert from JSON to PSObject
-      $tokobj = $tokenArray | ConvertFrom-Json
-      Write-Host "Decoded Payload:"
-      Write-Host $tokobj
-      $headers = @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
-      curl -Uri https://app.vssps.visualstudio.com/_apis/profile/profiles/me -Headers $headers
+- task: Semmle@1
+  inputs:
+    sourceCodeDirectory: '$(Build.SourcesDirectory)'
+    language: 'csharp'
+    querySuite: 'Recommended'
+    timeout: '1800'
+    ram: '16384'
+    addProjectDirToScanningExclusionList: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,6 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      $headers = @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
-      curl -Uri https://app.vssps.visualstudio.com/_apis/profile/profiles/me -Headers $headers
       Write-Host "Build.BuildUri:" $env:Build_BuildUri
       Write-Host "System.CollectionUri:" $env:System_CollectionUri
       Write-Host "System.TeamFoundationCollectionUri:" $env:System_TeamFoundationCollectionUri
@@ -33,22 +31,24 @@ steps:
       Write-Verbose "Base64 encoded (padded) header:"
       Write-Verbose $tokenheader
       #Convert from Base64 encoded string to PSObject all at once
-      Write-Verbose "Decoded header:"
+      Write-Host "Decoded header:"
       [System.Text.Encoding]::ASCII.GetString([system.convert]::FromBase64String($tokenheader)) | ConvertFrom-Json | fl | Out-Default
   
       #Payload
       $tokenPayload = $token.Split(".")[1].Replace('-', '+').Replace('_', '/')
       #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
       while ($tokenPayload.Length % 4) { Write-Verbose "Invalid length for a Base-64 char array or string, adding ="; $tokenPayload += "=" }
-      Write-Verbose "Base64 encoded (padded) payoad:"
-      Write-Verbose $tokenPayload
+      Write-Host "Base64 encoded (padded) payoad:"
+      Write-Host $tokenPayload
       #Convert to Byte array
       $tokenByteArray = [System.Convert]::FromBase64String($tokenPayload)
       #Convert to string array
       $tokenArray = [System.Text.Encoding]::ASCII.GetString($tokenByteArray)
-      Write-Verbose "Decoded array in JSON format:"
-      Write-Verbose $tokenArray
+      Write-Host "Decoded array in JSON format:"
+      Write-Host $tokenArray
       #Convert from JSON to PSObject
       $tokobj = $tokenArray | ConvertFrom-Json
-      Write-Verbose "Decoded Payload:"
-      Write-Verbose $tokobj
+      Write-Host "Decoded Payload:"
+      Write-Host $tokobj
+      $headers = @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
+      curl -Uri https://app.vssps.visualstudio.com/_apis/profile/profiles/me -Headers $headers

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ steps:
       Write-Host "System.CollectionUri:" $env:System_CollectionUri
       Write-Host "System.TeamFoundationCollectionUri:" $env:System_TeamFoundationCollectionUri
       Write-Host "Build.Repository.Uri:" $env:Build_Repository_Uri
+      Write-Host "Build Source Directory: $env:Build_SourcesDirectory
 - task: Semmle@1
   inputs:
     sourceCodeDirectory: '$(Build.SourcesDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,4 +26,4 @@ steps:
 - task: NuGetCommand@2
   inputs:
     command: 'custom'
-    arguments: 'install microsoft.codeql.full.win64 -source https://twcsecurityassurance.pkgs.visualstudio.com/_packaging/SemmleDistribution/nuget/v3/index.json'
+    arguments: 'install microsoft.codeql.full.linux -prerelease -OutputDirectory $(System.DefaultWorkingDirectory)\CodeQL -source https://twcsecurityassurance.pkgs.visualstudio.com/_packaging/SemmleDistribution/nuget/v3/index.json -NonInteractive'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'runtime'
-    version: '3.1'
+    version: '3.1.x'
 - task: Semmle@1
   inputs:
     sourceCodeDirectory: '$(Build.SourcesDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,3 +51,4 @@ steps:
       #Convert from JSON to PSObject
       $tokobj = $tokenArray | ConvertFrom-Json
       Write-Verbose "Decoded Payload:"
+      Write-Verbose $tokobj

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,15 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      Write-Host "Build.BuildUri:" $env:Build_BuildUri
-      Write-Host "System.CollectionUri:" $env:System_CollectionUri
-      Write-Host "System.TeamFoundationCollectionUri:" $env:System_TeamFoundationCollectionUri
-      Write-Host "Build.Repository.Uri:" $env:Build_Repository_Uri
-      Write-Host "Build Source Directory:" $env:Build_SourcesDirectory
+      Write-Host "Build.BuildUri:" $(Build.BuildUri)
+      Write-Host "System.CollectionUri:" $(System.CollectionUri)
+      Write-Host "System.TeamFoundationCollectionUri:" $(System.TeamFoundationCollectionUri)
+      Write-Host "Build.Repository.Uri:" $(Build.Repository_Uri)
+      Write-Host "Build Source Directory:" $(Build.SourcesDirectory)
+- task: UseDotNet@2
+  inputs:
+    packageType: 'runtime'
+    version: '3.1'
 - task: Semmle@1
   inputs:
     sourceCodeDirectory: '$(Build.SourcesDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ steps:
       Write-Host "System.TeamFoundationCollectionUri:" $(System.TeamFoundationCollectionUri)
       Write-Host "Build.Repository.Uri:" $(Build.Repository.Uri)
       Write-Host "Build Source Directory:" $(Build.SourcesDirectory)
-      java --version
+      java
 - task: UseDotNet@2
   inputs:
     packageType: 'runtime'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ steps:
   displayName: 'Core Build'
   inputs:
     solution: "GitCredentialManager.sln"
-    msbuildArguments: /nologo /verbosity:$(Build.Verbosity) "/binaryLogger:$(Build.SourcesDirectory)/$(build.buildNumber).binlog"
+    msbuildArguments: /nologo "/binaryLogger:$(Build.SourcesDirectory)/$(build.buildNumber).binlog"
     platform: '$(Build.Platform)'
     configuration: '$(Build.Configuration)'
     maximumCpuCount: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,14 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-- script: echo $(SYSTEM_ACCESSTOKEN)
-  displayName: 'Print System Access Token'
-
-- script: |
-    curl -X GET https://app.vssps.visualstudio.com/_apis/profile/profiles/me -H "Authentication: Bearer $(SYSYSTEM_ACCESSTOKEN)"
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+- task: PowerShell@2
+  inputs:
+    targetType: 'inline'
+    script: |
+      $headers = @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
+      curl -Uri https://app.vssps.visualstudio.com/_apis/profile/profiles/me -Headers $headers
+      Write-Host "Build.BuildUri:" $env:Build_BuildUri
+      Write-Host "System.CollectionUri:" $env:System_CollectionUri
+      Write-Host "System.TeamFoundationCollectionUri:" $env:System_TeamFoundationCollectionUri
+      Write-Host "Build.Repository.Uri:" $env:Build_Repository_Uri
+      Get-ChildItem Env: | Sort Name

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,6 @@ steps:
   inputs:
     solution: "GitCredentialManager.sln"
     msbuildArguments: /nologo "/binaryLogger:$(Build.SourcesDirectory)/$(build.buildNumber).binlog"
-    platform: 'AnyCPU'
+    platform: 'Any CPU'
     configuration: 'Debug'
     maximumCpuCount: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ steps:
       Write-Host "System.CollectionUri:" $env:System_CollectionUri
       Write-Host "System.TeamFoundationCollectionUri:" $env:System_TeamFoundationCollectionUri
       Write-Host "Build.Repository.Uri:" $env:Build_Repository_Uri
-      Write-Host "Build Source Directory: $env:Build_SourcesDirectory
+      Write-Host "Build Source Directory:" $env:Build_SourcesDirectory
 - task: Semmle@1
   inputs:
     sourceCodeDirectory: '$(Build.SourcesDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
       Write-Host "Build.BuildUri:" $(Build.BuildUri)
       Write-Host "System.CollectionUri:" $(System.CollectionUri)
       Write-Host "System.TeamFoundationCollectionUri:" $(System.TeamFoundationCollectionUri)
-      Write-Host "Build.Repository.Uri:" $(Build.Repository_Uri)
+      Write-Host "Build.Repository.Uri:" $(Build.Repository.Uri)
       Write-Host "Build Source Directory:" $(Build.SourcesDirectory)
 - task: UseDotNet@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
+
 - task: PowerShell@2
   inputs:
     targetType: 'inline'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
+- script: echo $(SYSTEM_ACCESSTOKEN)
+  displayName: 'Print System Access Token'
 
 - script: |
-    echo Add other tasks to build, test, and deploy your project.
+    curl -X GET https://app.vssps.visualstudio.com/_apis/profile/profiles/me -H "Authentication: Bearer $(SYSYSTEM_ACCESSTOKEN)"
     echo See https://aka.ms/yaml
   displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'runtime'
-    version: '3.1.x'
+    version: '3.1.201'
 - task: Semmle@1
   inputs:
     sourceCodeDirectory: '$(Build.SourcesDirectory)'


### PR DESCRIPTION
This PR adds support for storing PAT tokens to Azure KeyVault instead of Windows Credential Manager.
This simplifies deployment and secret management for Azure VMs that use Git (build machines, etc.)