### PR TITLE
Add username to target name of GitHub credential

### DIFF
--- a/Shared/Cli/Functions/Common.cs
+++ b/Shared/Cli/Functions/Common.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Alm.Cli
                                                                         Program.GitHubCredentialScope,
                                                                         new SecretStore(program.Context,
                                                                                         secretsNamespace,
-                                                                                        Secret.UriToName),
+                                                                                        Secret.UriToIdentityUrl),
                                                                         githubCredentialCallback,
                                                                         githubAuthcodeCallback,
                                                                         null)
@@ -181,7 +181,7 @@ namespace Microsoft.Alm.Cli
                                                                   Program.GitHubCredentialScope,
                                                                   new SecretStore(program.Context,
                                                                                   secretsNamespace,
-                                                                                  Secret.UriToName),
+                                                                                  Secret.UriToIdentityUrl),
                                                                   githubCredentialCallback,
                                                                   githubAuthcodeCallback,
                                                                   null);


### PR DESCRIPTION
* This is related to https://github.com/microsoft/Git-Credential-Manager-for-Windows/issues/749
* Usage example:
  * We can use different GitHub accounts for `https://github.com/user/repo`, `https://account1@github.com/user/repo` and `https://account2@github.com/user/repo`